### PR TITLE
Installation instructions fix: Make runt.toml expect runt version 0.4.1 instead of 0.4.0.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
   interpreter:
     name: Test Interpreter
     runs-on: ubuntu-latest
-    container: ghcr.io/cucapra/calyx:0.3.0
+    container: ghcr.io/cucapra/calyx:0.6.0
     steps:
     - name: Copy fud configuration
       run: |
@@ -62,7 +62,7 @@ jobs:
   compiler:
     name: Test Compiler
     runs-on: ubuntu-latest
-    container: ghcr.io/cucapra/calyx:0.3.0
+    container: ghcr.io/cucapra/calyx:0.6.0
     steps:
     - name: Copy fud configuration
       run: |
@@ -120,7 +120,7 @@ jobs:
   evaluation:
     name: Polybench Integration
     runs-on: ubuntu-latest
-    container: ghcr.io/cucapra/calyx:0.3.0
+    container: ghcr.io/cucapra/calyx:0.6.0
     steps:
     - name: Copy and clean up fud configuration
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
         git remote add origin https://github.com/cucapra/calyx.git
         git fetch --all
         git checkout -f $GITHUB_SHA
-
+    
     - name: Build
       uses: actions-rs/cargo@v1
       with:
@@ -84,6 +84,13 @@ jobs:
         git remote add origin https://github.com/cucapra/calyx.git
         git fetch --all
         git checkout -f $GITHUB_SHA
+
+    #Calyx docker container 0.6.0 has some quirks which requires this for now. Eventually hope to delete
+    - name: Remove stale systolic-array
+      working-directory: /home/calyx/tests/frontend/systolic
+      run: |
+        rm array-2.*
+        rm array-3.*
 
     - name: Install calyx-py & MrXL
       working-directory: /home/calyx

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,8 @@ jobs:
     - name: Checkout commit that triggered run
       working-directory: /home/calyx
       run: |
+        git init
+        git remote add origin git@github.com:cucapra/calyx.git
         git fetch --all
         git checkout $GITHUB_SHA
 
@@ -78,6 +80,8 @@ jobs:
     - name: Checkout commit that triggered run
       working-directory: /home/calyx
       run: |
+        git init
+        git remote add origin git@github.com:cucapra/calyx.git
         git fetch --all
         git checkout $GITHUB_SHA
 
@@ -136,6 +140,8 @@ jobs:
     - name: Checkout commit that triggered run
       working-directory: /home/calyx
       run: |
+        git init
+        git remote add origin git@github.com:cucapra/calyx.git
         git fetch --all
         git checkout $GITHUB_SHA
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
         git init
         git remote add origin https://github.com/cucapra/calyx.git
         git fetch --all
-        git checkout $GITHUB_SHA
+        git checkout -f $GITHUB_SHA
 
     - name: Build
       uses: actions-rs/cargo@v1
@@ -83,7 +83,7 @@ jobs:
         git init
         git remote add origin https://github.com/cucapra/calyx.git
         git fetch --all
-        git checkout $GITHUB_SHA
+        git checkout -f $GITHUB_SHA
 
     - name: Install calyx-py & MrXL
       working-directory: /home/calyx
@@ -143,7 +143,7 @@ jobs:
         git init
         git remote add origin https://github.com/cucapra/calyx.git
         git fetch --all
-        git checkout $GITHUB_SHA
+        git checkout -f $GITHUB_SHA
 
     - name: Build
       uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
       working-directory: /home/calyx
       run: |
         git init
-        git remote add origin git@github.com:cucapra/calyx.git
+        git remote add origin https://github.com/cucapra/calyx.git
         git fetch --all
         git checkout $GITHUB_SHA
 
@@ -81,7 +81,7 @@ jobs:
       working-directory: /home/calyx
       run: |
         git init
-        git remote add origin git@github.com:cucapra/calyx.git
+        git remote add origin https://github.com/cucapra/calyx.git
         git fetch --all
         git checkout $GITHUB_SHA
 
@@ -141,7 +141,7 @@ jobs:
       working-directory: /home/calyx
       run: |
         git init
-        git remote add origin git@github.com:cucapra/calyx.git
+        git remote add origin https://github.com/cucapra/calyx.git
         git fetch --all
         git checkout $GITHUB_SHA
 

--- a/frontends/mrxl/test/runt.toml
+++ b/frontends/mrxl/test/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.4.0"
+ver = "0.4.1"
 
 [[tests]]
 name = "interpret"

--- a/interp/runt.toml
+++ b/interp/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.4.0"
+ver = "0.4.1"
 
 # Check basic functionality of the interpreter
 [[tests]]

--- a/runt.toml
+++ b/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.4.0"
+ver = "0.4.1"
 
 ##### Compilation Tests ######
 ## Test each pass in isolation. Gets the pass flags from a comment on the first line of the file

--- a/tests/xilinx/runt.toml
+++ b/tests/xilinx/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.4.0"
+ver = "0.4.1"
 
 # Run Vivado/Vitis to produce an xclbin binary.
 # This command needs to output to a temporary file and delete it because fud

--- a/tools/data_gen/runt.toml
+++ b/tools/data_gen/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.4.0"
+ver = "0.4.1"
 [[tests]]
 name = "data gen tests"
 paths = [


### PR DESCRIPTION
Fixes issue when following ['Getting Started'](https://docs.calyxir.org/#running-core-tests) requiring a manual version change in runt.toml. Could also be addressed in runt itself, but this is a bandaid fix for now.