### PR TITLE
Update SA docs and command-line opts

### DIFF
--- a/docs/frontends/systolic-array.md
+++ b/docs/frontends/systolic-array.md
@@ -27,6 +27,8 @@ can be configured.
 
 - `--top-length`, `--left-length`: The length of top and left sides of the systolic array.
 - `--top-depth`, `--left-depth`: The length of the input streams from top and left sides of the array.
+- `--post-op`: Specify the post operation to be performed on the result of the matrix-multiply.
+- `--fixed-dim`: Generate systolic array that only processes matrices with the given sizes. The default strategy supports matrices with any contraction dimension.
 
 [kung-systolic]: http://www.eecs.harvard.edu/~htk/publication/1982-kung-why-systolic-architecture.pdf
 [systolic-lang]: https://github.com/calyxir/calyx/tree/master/frontends/systolic-lang

--- a/frontends/systolic-lang/systolic_arg_parser.py
+++ b/frontends/systolic-lang/systolic_arg_parser.py
@@ -37,7 +37,11 @@ class SystolicConfiguration:
         )
         parser.add_argument(
             "--fixed-dim",
-            help="systolic array that only processes fixed dimension matrices. By default, generated array can process matrices with any contraction dimension",
+            help=(
+                "systolic array that only processes fixed dimension matrices."
+                " By default, generated array can process matrices "
+                " with any contraction dimension"
+            ),
             action="store_true",
         )
 

--- a/frontends/systolic-lang/systolic_arg_parser.py
+++ b/frontends/systolic-lang/systolic_arg_parser.py
@@ -20,14 +20,26 @@ class SystolicConfiguration:
         """
 
         # Arg parsing
-        parser = argparse.ArgumentParser(description="Process some integers.")
+        parser = argparse.ArgumentParser(
+            description="Generate an output-stationary systolic array in Calyx."
+        )
         parser.add_argument("file", nargs="?", type=str)
         parser.add_argument("-tl", "--top-length", type=int)
         parser.add_argument("-td", "--top-depth", type=int)
         parser.add_argument("-ll", "--left-length", type=int)
         parser.add_argument("-ld", "--left-depth", type=int)
-        parser.add_argument("-p", "--post-op", type=str, default=None)
-        parser.add_argument("-s", "--static", action="store_true")
+        parser.add_argument(
+            "-p",
+            "--post-op",
+            help="post operation to be performed on the matrix-multiply result",
+            type=str,
+            default=None,
+        )
+        parser.add_argument(
+            "--fixed-dim",
+            help="systolic array that only processes fixed dimension matrices. By default, generated array can process matrices with any contraction dimension",
+            action="store_true",
+        )
 
         args = parser.parse_args()
 
@@ -38,7 +50,7 @@ class SystolicConfiguration:
             self.left_length = args.left_length
             self.left_depth = args.left_depth
             self.post_op = args.post_op
-            self.static = args.static
+            self.static = args.fixed_dim
         elif args.file is not None:
             with open(args.file, "r") as f:
                 spec = json.load(f)


### PR DESCRIPTION
Renames the confusingly named `--static` CLI argument to `--fixed-dim`. @calebmkim this might break some of your evaluation scripts.