### PR TITLE
[Calyx-FIRRTL] Primitive cell bug fix

### DIFF
--- a/calyx-backend/src/firrtl.rs
+++ b/calyx-backend/src/firrtl.rs
@@ -193,7 +193,7 @@ fn emit_port<F: io::Write>(
         }
         calyx_frontend::Direction::Inout => todo!(),
     };
-    Ok(if port_borrowed.has_attribute(ir::BoolAttr::Clk) {
+    if port_borrowed.has_attribute(ir::BoolAttr::Clk) {
         writeln!(
             f,
             "{}{} {}: Clock",
@@ -210,7 +210,8 @@ fn emit_port<F: io::Write>(
             port_borrowed.name,
             port_borrowed.width
         )?;
-    })
+    };
+    Ok(())
 }
 
 // fn create_primitive_extmodule() {}

--- a/calyx-backend/src/firrtl.rs
+++ b/calyx-backend/src/firrtl.rs
@@ -7,7 +7,6 @@ use crate::{traits::Backend, VerilogBackend};
 use calyx_ir::{self as ir, Binding, RRC};
 use calyx_utils::{CalyxResult, Id, OutputFile};
 use ir::Port;
-use smallvec::SmallVec;
 use std::collections::HashSet;
 use std::io;
 
@@ -152,7 +151,7 @@ fn get_primitive_module_name(name: &Id, param_binding: &Binding) -> String {
 }
 
 fn emit_primitive_extmodule<F: io::Write>(
-    ports: &SmallVec<[RRC<Port>; 10]>,
+    ports: &[RRC<Port>],
     curr_module_name: &String,
     name: &Id,
     param_binding: &Binding,

--- a/calyx-backend/src/firrtl.rs
+++ b/calyx-backend/src/firrtl.rs
@@ -172,11 +172,11 @@ fn emit_primitive_extmodule<F: io::Write>(
 }
 
 fn emit_port<F: io::Write>(
-    port_borrowed: std::cell::Ref<'_, Port>,
+    port: std::cell::Ref<'_, Port>,
     reverse_direction: bool,
     f: &mut F,
 ) -> Result<(), io::Error> {
-    let direction_string = match port_borrowed.direction {
+    let direction_string = match port.direction {
         calyx_frontend::Direction::Input => {
             if reverse_direction {
                 "output"
@@ -191,15 +191,17 @@ fn emit_port<F: io::Write>(
                 "output"
             }
         }
-        calyx_frontend::Direction::Inout => todo!(),
+        calyx_frontend::Direction::Inout => {
+            panic!("Unexpected Inout port on Component: {}", port.name)
+        }
     };
-    if port_borrowed.has_attribute(ir::BoolAttr::Clk) {
+    if port.has_attribute(ir::BoolAttr::Clk) {
         writeln!(
             f,
             "{}{} {}: Clock",
             SPACING.repeat(2),
             direction_string,
-            port_borrowed.name
+            port.name
         )?;
     } else {
         writeln!(
@@ -207,8 +209,8 @@ fn emit_port<F: io::Write>(
             "{}{} {}: UInt<{}>",
             SPACING.repeat(2),
             direction_string,
-            port_borrowed.name,
-            port_borrowed.width
+            port.name,
+            port.width
         )?;
     };
     Ok(())

--- a/tests/backend/firrtl/basic-cell.expect
+++ b/tests/backend/firrtl/basic-cell.expect
@@ -1,5 +1,7 @@
 circuit main:
     extmodule std_wire_1:
+        input in: UInt<1>
+        output out: UInt<1>
         defname = std_wire
         parameter WIDTH = 1
 

--- a/tests/backend/firrtl/primitive-cells.expect
+++ b/tests/backend/firrtl/primitive-cells.expect
@@ -1,9 +1,14 @@
 circuit main:
     extmodule std_add_32:
+        input left: UInt<32>
+        input right: UInt<32>
+        output out: UInt<32>
         defname = std_add
         parameter WIDTH = 32
 
     extmodule std_wire_1:
+        input in: UInt<1>
+        output out: UInt<1>
         defname = std_wire
         parameter WIDTH = 1
 


### PR DESCRIPTION
I had a fault of omission in my previous primitive cell translation where the generated `extmodule` didn't list any of the input/output ports. I realized that the fix was pretty similar to the previous [lines 80-106](https://github.com/calyxir/calyx/compare/primitive-cell-bug-fix?expand=1#diff-f16e7b65190b7d8381dde2cf3ba8bbcfad0e1c985ef449ed647dde975b37abc0L80) so I extracted out that code into a function. I checked that the outputted FIRRTL files passed the FIRRTL to Verilog compiler, so this should be a fix!

Please let me know if there's anything I can improve here :) Thank you in advance!