### PR TITLE
[Calyx-Firrtl] Fix undefined values bug by initializing to zero

### DIFF
--- a/calyx-backend/src/firrtl.rs
+++ b/calyx-backend/src/firrtl.rs
@@ -304,7 +304,8 @@ fn write_invalid_initialization<F: io::Write>(
             SPACING.repeat(2),
             dst_string,
             default_initialization_str
-        )
+        )?;
+        writeln!(f, "{}{} <= UInt(0)", SPACING.repeat(2), dst_string)
     }
 }
 

--- a/tests/backend/firrtl/and-or-not-guard.expect
+++ b/tests/backend/firrtl/and-or-not-guard.expect
@@ -12,6 +12,7 @@ circuit main:
         ; COMPONENT START: main
         done <= UInt(1)
         out is invalid ; default initialization
+        out <= UInt(0)
         when and(or(not(cond), cond2), cond3):
             out <= in
         ; COMPONENT END: main

--- a/tests/backend/firrtl/basic-cell.expect
+++ b/tests/backend/firrtl/basic-cell.expect
@@ -27,14 +27,17 @@ circuit main:
         inst invoke0_go of std_wire_1
         inst invoke0_done of std_wire_1
         done is invalid ; default initialization
+        done <= UInt(0)
         when invoke0_done.out:
             done <= UInt(1)
         id.clk <= clk
         id.go is invalid ; default initialization
+        id.go <= UInt(0)
         when invoke0_go.out:
             id.go <= UInt(1)
         id.reset <= reset
         id.in is invalid ; default initialization
+        id.in <= UInt(0)
         when invoke0_go.out:
             id.in <= UInt(5)
         invoke0_go.in <= go

--- a/tests/backend/firrtl/basic-guard.expect
+++ b/tests/backend/firrtl/basic-guard.expect
@@ -10,6 +10,7 @@ circuit main:
         ; COMPONENT START: main
         done <= UInt(1)
         out is invalid ; default initialization
+        out <= UInt(0)
         when cond:
             out <= in
         ; COMPONENT END: main

--- a/tests/backend/firrtl/comparison-guard.expect
+++ b/tests/backend/firrtl/comparison-guard.expect
@@ -12,6 +12,7 @@ circuit main:
         ; COMPONENT START: main
         done <= UInt(1)
         out is invalid ; default initialization
+        out <= UInt(0)
         when and(leq(var, var2), cond3):
             out <= in
         ; COMPONENT END: main

--- a/tests/backend/firrtl/or-guard.expect
+++ b/tests/backend/firrtl/or-guard.expect
@@ -11,6 +11,7 @@ circuit main:
         ; COMPONENT START: main
         done <= UInt(1)
         out is invalid ; default initialization
+        out <= UInt(0)
         when or(cond, cond2):
             out <= in
         ; COMPONENT END: main

--- a/tests/backend/firrtl/primitive-cells.expect
+++ b/tests/backend/firrtl/primitive-cells.expect
@@ -37,16 +37,19 @@ circuit main:
         inst invoke0_go of std_wire_1
         inst invoke0_done of std_wire_1
         done is invalid ; default initialization
+        done <= UInt(0)
         when invoke0_done.out:
             done <= UInt(1)
         invoke0_go.in <= go
         invoke0_done.in <= po.done
         po.clk <= clk
         po.go is invalid ; default initialization
+        po.go <= UInt(0)
         when invoke0_go.out:
             po.go <= UInt(1)
         po.reset <= reset
         po.in is invalid ; default initialization
+        po.in <= UInt(0)
         when invoke0_go.out:
             po.in <= UInt(5)
         ; COMPONENT END: main

--- a/tests/backend/firrtl/two-or-guards.expect
+++ b/tests/backend/firrtl/two-or-guards.expect
@@ -13,6 +13,7 @@ circuit main:
         ; COMPONENT START: main
         done <= UInt(1)
         out is invalid ; default initialization
+        out <= UInt(0)
         when or(cond, cond2):
             out <= in
         when or(cond2, cond3):


### PR DESCRIPTION
I ran into a problem with my FIRRTL backend where both the FIRRTL compiler and ESSENT would squash (for lack of a better term) guarded assignments into a straightforward assignments. For example, the FIRRTL code:
```
        done is invalid ; default initialization
        when wrapper_early_reset_static_seq_done.out:
            done <= UInt(1)
```
was compiled to the below Verilog:
```
assign done = 1'h1;
```
since there were no other assignments to `done` in the FIRRTL program. This caused the execution to finish in 0 cycles since `done` was always `1`.

So, I fixed my backend to insert an assignment to 0, so it would produce the below FIRRTL:
```
        done is invalid ; default initialization
        done <= UInt(0)
        when wrapper_early_reset_static_seq_done.out:
            done <= UInt(1)
```
This solves the problem, as the FIRRTL compiler now produces the below Verilog:
```
assign done = wrapper_early_reset_static_seq_done_out;
```
and the intended output was produced.

Please let me know if I should fix anything/deal with things more elegantly! (I only changed 2 lines of Rust in this PR :sweat_smile: )