### PR TITLE
Compaction Accounts for Continuous Assignments 

### DIFF
--- a/calyx-opt/src/analysis/control_order.rs
+++ b/calyx-opt/src/analysis/control_order.rs
@@ -162,8 +162,10 @@ impl<const BETTER_ERR: bool> ControlOrder<BETTER_ERR> {
         latency_map: &mut HashMap<NodeIndex, u64>,
     ) -> DiGraph<Option<ir::StaticControl>, ()> {
         // The names of the cells that are read/written in continuous assignments
-        let mut cont_read_cell_names = Self::filter_out_constants(cont_reads);
-        let mut cont_write_cell_names = Self::filter_out_constants(cont_writes);
+        let cont_read_cell_names =
+            Self::filter_out_constants(cont_reads).collect_vec();
+        let cont_write_cell_names =
+            Self::filter_out_constants(cont_writes).collect_vec();
 
         // Directed graph where edges means that a control program must be run before.
         let mut gr: DiGraph<Option<ir::StaticControl>, ()> = DiGraph::new();

--- a/calyx-opt/src/analysis/control_order.rs
+++ b/calyx-opt/src/analysis/control_order.rs
@@ -200,7 +200,8 @@ impl<const BETTER_ERR: bool> ControlOrder<BETTER_ERR> {
                     }
                 }
 
-                // 5. Program reads from a cell that a continuous assignment writes to.
+                // Checking: 5. Program reads from a cell that a continuous
+                // assignment writes to.
                 if cont_write_cell_names.contains(&cell) {
                     for cur_idx in continuous_idxs.iter() {
                         if !cur_idx.eq(&idx) {
@@ -234,7 +235,7 @@ impl<const BETTER_ERR: bool> ControlOrder<BETTER_ERR> {
                     }
                 }
 
-                // 4. Program writes to cell that a continuous assignment
+                // Checking: 4. Program writes to cell that a continuous assignment
                 // writes to or reads from.
                 if cont_write_cell_names.contains(&cell)
                     || cont_read_cell_names.contains(&cell)

--- a/calyx-opt/src/analysis/reaching_defns.rs
+++ b/calyx-opt/src/analysis/reaching_defns.rs
@@ -143,8 +143,8 @@ impl DefSet {
             set: self
                 .set
                 .iter()
+                .filter(|&(name, _)| !killset.contains(name))
                 .cloned()
-                .filter(|(name, _)| !killset.contains(name))
                 .collect(),
         }
     }

--- a/calyx-opt/src/analysis/read_write_set.rs
+++ b/calyx-opt/src/analysis/read_write_set.rs
@@ -121,7 +121,7 @@ impl ReadWriteSet {
 
 impl ReadWriteSet {
     /// Returns the ports that are read and written, respectively,
-    /// by the given control program.
+    /// by the given static control program.
     pub fn control_port_read_write_set_static(
         scon: &ir::StaticControl,
     ) -> (Vec<RRC<ir::Port>>, Vec<RRC<ir::Port>>) {
@@ -194,6 +194,8 @@ impl ReadWriteSet {
         }
     }
 
+    /// Returns the cells that are read and written, respectively,
+    /// by the given static control program.
     pub fn control_read_write_set_static(
         scon: &ir::StaticControl,
     ) -> (Vec<RRC<ir::Cell>>, Vec<RRC<ir::Cell>>) {
@@ -325,6 +327,8 @@ impl ReadWriteSet {
         }
     }
 
+    /// Returns the cells that are read and written, respectively,
+    /// by the given control program.
     pub fn control_read_write_set(
         con: &ir::Control,
     ) -> (Vec<RRC<ir::Cell>>, Vec<RRC<ir::Cell>>) {

--- a/calyx-opt/src/analysis/read_write_set.rs
+++ b/calyx-opt/src/analysis/read_write_set.rs
@@ -194,6 +194,23 @@ impl ReadWriteSet {
         }
     }
 
+    pub fn control_read_write_set_static(
+        scon: &ir::StaticControl,
+    ) -> (Vec<RRC<ir::Cell>>, Vec<RRC<ir::Cell>>) {
+        let (port_reads, port_writes) =
+            Self::control_port_read_write_set_static(&scon);
+        (
+            port_reads
+                .into_iter()
+                .map(|p| p.borrow().cell_parent())
+                .collect(),
+            port_writes
+                .into_iter()
+                .map(|p| p.borrow().cell_parent())
+                .collect(),
+        )
+    }
+
     /// Returns the ports that are read and written, respectively,
     /// by the given control program.
     pub fn control_port_read_write_set(
@@ -306,6 +323,22 @@ impl ReadWriteSet {
                 Self::control_port_read_write_set_static(sc)
             }
         }
+    }
+
+    pub fn control_read_write_set(
+        con: &ir::Control,
+    ) -> (Vec<RRC<ir::Cell>>, Vec<RRC<ir::Cell>>) {
+        let (port_reads, port_writes) = Self::control_port_read_write_set(&con);
+        (
+            port_reads
+                .into_iter()
+                .map(|p| p.borrow().cell_parent())
+                .collect(),
+            port_writes
+                .into_iter()
+                .map(|p| p.borrow().cell_parent())
+                .collect(),
+        )
     }
 
     /// Returns the ports that are read and written, respectively,

--- a/calyx-opt/src/analysis/read_write_set.rs
+++ b/calyx-opt/src/analysis/read_write_set.rs
@@ -120,7 +120,8 @@ impl ReadWriteSet {
 }
 
 impl ReadWriteSet {
-    /// Returns the ports that are read by the given control program.
+    /// Returns the ports that are read and written, respectively,
+    /// by the given control program.
     pub fn control_port_read_write_set_static(
         scon: &ir::StaticControl,
     ) -> (Vec<RRC<ir::Port>>, Vec<RRC<ir::Port>>) {
@@ -193,7 +194,8 @@ impl ReadWriteSet {
         }
     }
 
-    /// Returns the ports that are read by the given control program.
+    /// Returns the ports that are read and written, respectively,
+    /// by the given control program.
     pub fn control_port_read_write_set(
         con: &ir::Control,
     ) -> (Vec<RRC<ir::Port>>, Vec<RRC<ir::Port>>) {
@@ -304,5 +306,27 @@ impl ReadWriteSet {
                 Self::control_port_read_write_set_static(sc)
             }
         }
+    }
+
+    /// Returns the ports that are read and written, respectively,
+    /// in the continuous assignments of the given component.
+    pub fn cont_ports_read_write_set(
+        comp: &mut calyx_ir::Component,
+    ) -> (Vec<RRC<ir::Port>>, Vec<RRC<ir::Port>>) {
+        (
+            Self::port_read_set(comp.continuous_assignments.iter()).collect(),
+            Self::port_write_set(comp.continuous_assignments.iter()).collect(),
+        )
+    }
+
+    /// Returns the cells that are read and written, respectively,
+    /// in the continuous assignments of the given component.
+    pub fn cont_read_write_set(
+        comp: &mut calyx_ir::Component,
+    ) -> (Vec<RRC<ir::Cell>>, Vec<RRC<ir::Cell>>) {
+        (
+            Self::read_set(comp.continuous_assignments.iter()).collect(),
+            Self::write_set(comp.continuous_assignments.iter()).collect(),
+        )
     }
 }

--- a/calyx-opt/src/analysis/read_write_set.rs
+++ b/calyx-opt/src/analysis/read_write_set.rs
@@ -200,7 +200,7 @@ impl ReadWriteSet {
         scon: &ir::StaticControl,
     ) -> (Vec<RRC<ir::Cell>>, Vec<RRC<ir::Cell>>) {
         let (port_reads, port_writes) =
-            Self::control_port_read_write_set_static(&scon);
+            Self::control_port_read_write_set_static(scon);
         (
             port_reads
                 .into_iter()
@@ -332,7 +332,7 @@ impl ReadWriteSet {
     pub fn control_read_write_set(
         con: &ir::Control,
     ) -> (Vec<RRC<ir::Cell>>, Vec<RRC<ir::Cell>>) {
-        let (port_reads, port_writes) = Self::control_port_read_write_set(&con);
+        let (port_reads, port_writes) = Self::control_port_read_write_set(con);
         (
             port_reads
                 .into_iter()

--- a/tests/passes/schedule-compaction/continuous-compaction.expect
+++ b/tests/passes/schedule-compaction/continuous-compaction.expect
@@ -1,0 +1,47 @@
+import "primitives/core.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 8, @done done: 1) {
+  cells {
+    r0 = std_reg(8);
+    r1 = std_reg(8);
+    r2 = std_reg(8);
+    r3 = std_reg(8);
+    add = std_add(8);
+  }
+  wires {
+    static<1> group write_r0 {
+      r0.in = 8'd1;
+      r0.write_en = 1'd1;
+    }
+    static<1> group write_r1 {
+      r1.in = add.out;
+      r1.write_en = 1'd1;
+    }
+    static<1> group write_r2 {
+      r2.in = 8'd3;
+      r2.write_en = 1'd1;
+    }
+    static<1> group write_r3 {
+      r3.in = 8'd3;
+      r3.write_en = 1'd1;
+    }
+    out = r1.out;
+    add.right = 8'd1;
+    add.left = r0.out;
+  }
+  control {
+    seq {
+      static<2> par {
+        static<2> seq  {
+          write_r0;
+          write_r1;
+        }
+        static<1> seq  {
+          write_r2;
+        }
+        static<1> seq  {
+          write_r3;
+        }
+      }
+    }
+  }
+}

--- a/tests/passes/schedule-compaction/continuous-compaction.futil
+++ b/tests/passes/schedule-compaction/continuous-compaction.futil
@@ -1,0 +1,45 @@
+// -p validate -p schedule-compaction
+
+import "primitives/core.futil";
+
+component main() -> (out: 8) {
+  cells {
+    r0 = std_reg(8);
+    r1 = std_reg(8);
+    r2 = std_reg(8);
+    r3 = std_reg(8);
+    add = std_add(8);
+  }
+  wires {
+    static<1> group write_r0 {
+      r0.write_en = 1'd1;
+      r0.in = 8'd1;
+    }
+    static<1> group write_r1 {
+      r1.write_en = 1'd1;
+      r1.in = add.out;
+    }
+    static<1> group write_r2 {
+      r2.write_en = 1'd1;
+      r2.in = 8'd3;
+    }
+    static<1> group write_r3 {
+      r3.write_en = 1'd1;
+      r3.in = 8'd3;
+    }
+    add.left = r0.out;
+    add.right = 8'd1;
+    out = r1.out;
+  }
+  control {
+    seq {
+      @compactable static seq {
+        write_r0;
+        // Continuous assignments to add.left and add.right prevent compation.
+        write_r1;
+        write_r2;
+        write_r3;
+      }
+    }
+  }
+}

--- a/tests/passes/schedule-compaction/continuous-no-compaction.expect
+++ b/tests/passes/schedule-compaction/continuous-no-compaction.expect
@@ -1,0 +1,40 @@
+import "primitives/core.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 8, @done done: 1) {
+  cells {
+    r0 = std_reg(8);
+    r1 = std_reg(8);
+    r2 = std_reg(8);
+    add = std_add(8);
+    add1 = std_add(8);
+  }
+  wires {
+    static<1> group write_r0 {
+      r0.in = 8'd1;
+      r0.write_en = 1'd1;
+    }
+    static<1> group write_r1 {
+      r1.in = add.out;
+      r1.write_en = 1'd1;
+    }
+    static<1> group write_add1 {
+      add1.right = 8'd4;
+      add1.left = 8'd1;
+    }
+    out = r1.out;
+    add.right = 8'd1;
+    add.left = r0.out;
+    r2.in = add1.out;
+  }
+  control {
+    seq {
+      static<2> seq  {
+        write_r0;
+        write_r1;
+      }
+      static<2> seq  {
+        write_r0;
+        write_add1;
+      }
+    }
+  }
+}

--- a/tests/passes/schedule-compaction/continuous-no-compaction.futil
+++ b/tests/passes/schedule-compaction/continuous-no-compaction.futil
@@ -1,0 +1,46 @@
+// -p validate -p schedule-compaction
+
+import "primitives/core.futil";
+
+component main() -> (out: 8) {
+  cells {
+    r0 = std_reg(8);
+    r1 = std_reg(8);
+    r2 = std_reg(8);
+    add = std_add(8);
+    add1 = std_add(8);
+  }
+  wires {
+    static<1> group write_r0 {
+      r0.write_en = 1'd1;
+      r0.in = 8'd1;
+    }
+    static<1> group write_r1 {
+      r1.write_en = 1'd1;
+      r1.in = add.out;
+    }
+    static<1> group write_add1 {
+      add1.left = 8'd1;
+      add1.right = 8'd4;
+    }
+    r2.in = add1.out;
+    add.left = r0.out;
+    add.right = 8'd1;
+    out = r1.out;
+  }
+  control {
+    seq {
+      @compactable static seq {
+        write_r0;
+        // Continuous assignments to add.left and add.right prevent compation.
+        write_r1;
+      }
+      @compactable static seq {
+        write_r0;
+        // Continuous assignment r2.in = add1.out prevents compaction.
+        // This is overly conservative.
+        write_add1;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix #1767. Adds analysis so that compaction accounts for continuous assignments.

The analysis here is conservative, since it essentially treats all the continuous assignment as one big "block". In other words, any time a group affects the continuous assignments, then it will depend on any previous groups that affect on continuous assignments too. For example say we have
```
seq {
  A; // Affects continuous assignments
  B; 
  C; // Affects continuous assignments
  D; 
  E; // Affects continuous assignments
} 
``` 
Then we detect an `A->C->E` dependence, in addition to the existing dependencies we already find by analyzing the groups/control. 

When I say a group "affects" a continuous assignment, I mean that the group reads or writes to a cell that continuous assignments read or write from (except in the case when the group and continuous assignments are just reading from the same cell; that's the only time that doesn't count). 

Also, I checked and this doesn't affect the polybench results from our paper. 