### PR TITLE
Add support for using python builder `invoke` with integer literals

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -836,7 +836,16 @@ def invoke(cell: CellBuilder, **kwargs) -> ast.Invoke:
     return ast.Invoke(
         cell._cell.id,
         [
-            (k[3:], ExprBuilder.unwrap(v))
+            (
+                k[3:],
+                (
+                    (
+                        const(cell.infer_width(k[3:]), v).expr
+                        if isinstance(v, int)
+                        else ExprBuilder.unwrap(v)
+                    )
+                ),
+            )
             for (k, v) in kwargs.items()
             if k.startswith("in_")
         ],

--- a/docs/builder/ref.md
+++ b/docs/builder/ref.md
@@ -309,7 +309,8 @@ See the language reference for [`invoke`][invoke].
 
 ```python
 # invoke(cell, **kwargs)
-my_invoke = invoke(my_cell, in_arg1=my_cell_arg1_reg.out, in_arg2=my_cell_arg2_reg.out)
+my_invoke = invoke(my_cell, in_arg1=my_cell_arg1_reg.out, in_arg2=1)
+
 ```
 
 ## Miscellaneous Tips + Tricks


### PR DESCRIPTION
Was messing around building AXI implementations in python and thought this could be nice. If there are downstream effects I'm not aware of please let me know and I'll try to address them or stop pursuing this if it doesn't seem worth it.

Previously we had to write things like
```
    invoke_txn_count = invoke(txn_count, in_in=const(32,0))
```

This PR lets us write write the above as
```
    invoke_txn_count = invoke(txn_count, in_in=0)
```

which is what I initially did before being surprised that it didn't work.

Not sure who has been taking charge of builder stuff so
cc @anshumanmohan @rachitnigam @sampsyo 