### PR TITLE
Fix read channel read_data_reg write_en

### DIFF
--- a/yxi/axi-calyx/axi-combined-calyx.futil
+++ b/yxi/axi-calyx/axi-combined-calyx.futil
@@ -204,7 +204,7 @@ component m_read_channel(
   RREADY : 1,
 ) {
   cells {
-      // 16 is due to dot-product vector length assumption
+      // 8 is due to vector_add length assumption
       // For this manual implementation we are just writing into this data based
       // on the data we read from cocotb
       ref data_received = seq_mem_d1(32, 8, 64);
@@ -267,7 +267,9 @@ component m_read_channel(
 
         //store the data we want to write
         read_data_reg.in = RDATA;
-        read_data_reg.write_en = is_rdy.out;
+        //read_data_reg.write_en = is_rdy.out;
+        read_data_reg.write_en = !(RVALID & is_rdy.out) ? 1'b0;
+        read_data_reg.write_en = RVALID & is_rdy.out ? 1'b1;
 
         //update n_RLAST reg
         n_RLAST.in = RLAST ? 1'b0;


### PR DESCRIPTION
Looking over the hardcoded implementation while creating the generator, I'm not sure how this worked in the first place.

`read_data_reg` is supposed to store the value of `RDATA` for use in a group later on in the control sequence.
making `read_data_reg.write_en` high with `is_rdy.out` seems like there would be a delay of a cycle between storing the data and receiving it, so `RDATA` would in theory be garbage.

To me it makes sense that this should be high with the handshake.

`read_data_reg.write_en = RVALID & is_rdy.out ? 1'b1;`

Going to merge this and leave this here for record keeping/for those interested to look over in case I'm missing something.
cc @sampsyo 
