### PR TITLE
Add parentheses around `==` and `!=` in builder

### DIFF
--- a/calyx-py/calyx/py_ast.py
+++ b/calyx-py/calyx/py_ast.py
@@ -294,7 +294,7 @@ class Eq(GuardExpr):
     right: GuardExpr
 
     def doc(self) -> str:
-        return f"{self.left.doc()} == {self.right.doc()}"
+        return f"({self.left.doc()} == {self.right.doc()})"
 
 
 @dataclass
@@ -303,7 +303,7 @@ class Neq(GuardExpr):
     right: GuardExpr
 
     def doc(self) -> str:
-        return f"{self.left.doc()} != {self.right.doc()}"
+        return f"({self.left.doc()} != {self.right.doc()})"
 
 
 # Control

--- a/tests/frontend/systolic/array-1.expect
+++ b/tests/frontend/systolic/array-1.expect
@@ -148,7 +148,7 @@ component default_post_op(out_mem_0_done: 1, r0_valid: 1, r0_value: 32, r0_idx: 
     }
     static<1> group write_done_cond {
       delay_reg.in = 1'd1;
-      delay_reg.write_en = (r0_valid & r0_idx == 1'd0) ? 1'd1;
+      delay_reg.write_en = (r0_valid & (r0_idx == 1'd0)) ? 1'd1;
       computation_done = delay_reg.done ? 1'd1;
     }
   }


### PR DESCRIPTION
Same thing as #1858 for equality and inequality. I think these were missed there.

Worth noting that this is somewhat of a "brute force" solution that does not attempt to minimize parentheses. Not sure if that is something worth pursuing at the moment?

cc @rachitnigam 