### PR TITLE
Backend for listing instantiations of primitives

### DIFF
--- a/calyx-backend/src/backend_opt.rs
+++ b/calyx-backend/src/backend_opt.rs
@@ -14,6 +14,7 @@ pub enum BackendOpt {
     Sexp,
     Yxi,
     Firrtl,
+    PrimitiveInst,
     None,
 }
 
@@ -30,6 +31,7 @@ fn backends() -> Vec<(&'static str, BackendOpt)> {
         ("sexp", BackendOpt::Sexp),
         ("yxi", BackendOpt::Yxi),
         ("firrtl", BackendOpt::Firrtl),
+        ("primitive-inst", BackendOpt::PrimitiveInst),
         ("none", BackendOpt::None),
     ]
 }
@@ -74,6 +76,7 @@ impl ToString for BackendOpt {
             Self::Yxi => "yxi",
             Self::Calyx => "calyx",
             Self::Firrtl => "firrtl",
+            Self::PrimitiveInst => "primitive-inst",
             Self::None => "none",
         }
         .to_string()

--- a/calyx-backend/src/backend_opt.rs
+++ b/calyx-backend/src/backend_opt.rs
@@ -14,7 +14,7 @@ pub enum BackendOpt {
     Sexp,
     Yxi,
     Firrtl,
-    PrimitiveInst,
+    PrimitiveUses,
     None,
 }
 
@@ -31,7 +31,7 @@ fn backends() -> Vec<(&'static str, BackendOpt)> {
         ("sexp", BackendOpt::Sexp),
         ("yxi", BackendOpt::Yxi),
         ("firrtl", BackendOpt::Firrtl),
-        ("primitive-inst", BackendOpt::PrimitiveInst),
+        ("primitive-uses", BackendOpt::PrimitiveUses),
         ("none", BackendOpt::None),
     ]
 }
@@ -76,7 +76,7 @@ impl ToString for BackendOpt {
             Self::Yxi => "yxi",
             Self::Calyx => "calyx",
             Self::Firrtl => "firrtl",
-            Self::PrimitiveInst => "primitive-inst",
+            Self::PrimitiveUses => "primitive-uses",
             Self::None => "none",
         }
         .to_string()

--- a/calyx-backend/src/lib.rs
+++ b/calyx-backend/src/lib.rs
@@ -1,12 +1,14 @@
 //! Backends for the Calyx compiler.
 mod backend_opt;
 mod firrtl;
+mod primitives;
 mod traits;
 mod verilog;
 mod yxi;
 
 pub use backend_opt::BackendOpt;
 pub use firrtl::FirrtlBackend;
+pub use primitives::PrimitiveInstBackend;
 pub use traits::Backend;
 pub use verilog::VerilogBackend;
 pub use yxi::YxiBackend;

--- a/calyx-backend/src/lib.rs
+++ b/calyx-backend/src/lib.rs
@@ -1,14 +1,14 @@
 //! Backends for the Calyx compiler.
 mod backend_opt;
 mod firrtl;
-mod primitives;
+mod primitive_uses;
 mod traits;
 mod verilog;
 mod yxi;
 
 pub use backend_opt::BackendOpt;
 pub use firrtl::FirrtlBackend;
-pub use primitives::PrimitiveInstBackend;
+pub use primitive_uses::PrimitiveUsesBackend;
 pub use traits::Backend;
 pub use verilog::VerilogBackend;
 pub use yxi::YxiBackend;

--- a/calyx-backend/src/primitive_uses.rs
+++ b/calyx-backend/src/primitive_uses.rs
@@ -34,15 +34,11 @@ impl Backend for PrimitiveUsesBackend {
     }
 
     fn emit(ctx: &ir::Context, file: &mut OutputFile) -> CalyxResult<()> {
-        let main_comp = ctx
-            .components
-            .iter()
-            .find(|comp| comp.name == ctx.entrypoint)
-            .unwrap();
+        let main_comp = ctx.entrypoint();
 
-        let primitive_set: &mut HashSet<PrimitiveUse> = &mut HashSet::new();
+        let mut primitive_set: HashSet<PrimitiveUse> = HashSet::new();
 
-        gen_primitive_set(ctx, main_comp, primitive_set);
+        gen_primitive_set(ctx, main_comp, &mut primitive_set);
 
         write_json(primitive_set.clone(), file)?;
 

--- a/calyx-backend/src/primitive_uses.rs
+++ b/calyx-backend/src/primitive_uses.rs
@@ -77,14 +77,13 @@ fn gen_primitive_set(
                 param_binding,
                 ..
             } => {
-                let mut curr_params = Vec::new();
-                for (param_name, param_size) in param_binding.iter() {
-                    let param = PrimitiveParam {
+                let curr_params = param_binding
+                    .iter()
+                    .map(|(param_name, param_size)| PrimitiveParam {
                         param_name: param_name.to_string(),
                         param_value: *param_size,
-                    };
-                    curr_params.push(param);
-                }
+                    })
+                    .collect();
                 let curr_primitive = PrimitiveUse {
                     name: name.to_string(),
                     params: curr_params,

--- a/calyx-backend/src/primitive_uses.rs
+++ b/calyx-backend/src/primitive_uses.rs
@@ -13,11 +13,11 @@ use calyx_utils::{CalyxResult, OutputFile};
 use serde::{Deserialize, Serialize};
 
 #[derive(Default)]
-pub struct PrimitiveInstBackend;
+pub struct PrimitiveUsesBackend;
 
-impl Backend for PrimitiveInstBackend {
+impl Backend for PrimitiveUsesBackend {
     fn name(&self) -> &'static str {
-        "resources"
+        "primitive_uses"
     }
 
     /// OK to run this analysis on any Calyx program
@@ -40,7 +40,7 @@ impl Backend for PrimitiveInstBackend {
             .find(|comp| comp.name == ctx.entrypoint)
             .unwrap();
 
-        let primitive_set: &mut HashSet<PrimitiveInst> = &mut HashSet::new();
+        let primitive_set: &mut HashSet<PrimitiveUse> = &mut HashSet::new();
 
         gen_primitive_set(ctx, main_comp, primitive_set);
 
@@ -51,7 +51,7 @@ impl Backend for PrimitiveInstBackend {
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
-struct PrimitiveInst {
+struct PrimitiveUse {
     name: String,
     params: Vec<PrimitiveParam>,
 }
@@ -67,7 +67,7 @@ struct PrimitiveParam {
 fn gen_primitive_set(
     ctx: &ir::Context,
     main_comp: &ir::Component,
-    primitive_set: &mut HashSet<PrimitiveInst>,
+    primitive_set: &mut HashSet<PrimitiveUse>,
 ) {
     for cell in main_comp.cells.iter() {
         let cell_ref = cell.borrow();
@@ -85,7 +85,7 @@ fn gen_primitive_set(
                     };
                     curr_params.push(param);
                 }
-                let curr_primitive = PrimitiveInst {
+                let curr_primitive = PrimitiveUse {
                     name: name.to_string(),
                     params: curr_params,
                 };
@@ -106,10 +106,10 @@ fn gen_primitive_set(
 
 /// Write the collected set of primitive instantiations to a JSON file.
 fn write_json(
-    primitive_set: HashSet<PrimitiveInst>,
+    primitive_set: HashSet<PrimitiveUse>,
     file: &mut OutputFile,
 ) -> Result<(), io::Error> {
-    let created_vec: Vec<PrimitiveInst> = primitive_set.into_iter().collect();
+    let created_vec: Vec<PrimitiveUse> = primitive_set.into_iter().collect();
     serde_json::to_writer_pretty(file.get_write(), &created_vec)?;
     Ok(())
 }

--- a/calyx-backend/src/primitives.rs
+++ b/calyx-backend/src/primitives.rs
@@ -5,7 +5,7 @@
 //! Usage: -b primitive-inst [-o <OUTPUT_FILE>]
 //! Adapted from resources.rs.
 
-use std::{collections::BTreeMap, collections::HashSet, io};
+use std::{collections::HashSet, io};
 
 use crate::traits::Backend;
 use calyx_ir as ir;
@@ -53,7 +53,13 @@ impl Backend for PrimitiveInstBackend {
 #[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 struct PrimitiveInst {
     name: String,
-    params: Vec<BTreeMap<String, u64>>,
+    params: Vec<PrimitiveParam>,
+}
+
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+struct PrimitiveParam {
+    param_name: String,
+    param_value: u64,
 }
 
 /// Accumulates a set with each primitive with a given set of parameters
@@ -73,9 +79,11 @@ fn gen_primitive_set(
             } => {
                 let mut curr_params = Vec::new();
                 for (param_name, param_size) in param_binding.iter() {
-                    let mut param_binding = BTreeMap::new();
-                    param_binding.insert(param_name.to_string(), *param_size);
-                    curr_params.push(param_binding);
+                    let param = PrimitiveParam {
+                        param_name: param_name.to_string(),
+                        param_value: param_size.clone(),
+                    };
+                    curr_params.push(param);
                 }
                 let curr_primitive = PrimitiveInst {
                     name: name.to_string(),

--- a/calyx-backend/src/primitives.rs
+++ b/calyx-backend/src/primitives.rs
@@ -1,7 +1,10 @@
-//! Primitive listing backend for the Calyx compiler.
+//! Primitive instantiations backend for the Calyx compiler.
+//!
 //! Transforms an [`ir::Context`](crate::ir::Context) into a JSON file that
 //! records the unique primitive instantiations in a program.
-//! Adapted from resources.rs backend.
+//! Usage: -b primitive-inst [-o <OUTPUT_FILE>]
+//! Adapted from resources.rs.
+
 use std::{collections::BTreeMap, collections::HashSet, io};
 
 use crate::traits::Backend;

--- a/calyx-backend/src/primitives.rs
+++ b/calyx-backend/src/primitives.rs
@@ -56,7 +56,7 @@ struct PrimitiveInst {
     params: Vec<BTreeMap<String, u64>>,
 }
 
-/// Counts the number of each primitive with a given set of parameters
+/// Accumulates a set with each primitive with a given set of parameters
 /// in the program with entrypoint `main_comp`.
 fn gen_primitive_set(
     ctx: &ir::Context,
@@ -96,6 +96,7 @@ fn gen_primitive_set(
     }
 }
 
+/// Write the collected set of primitive instantiations to a JSON file.
 fn write_json(
     primitive_set: HashSet<PrimitiveInst>,
     file: &mut OutputFile,

--- a/calyx-backend/src/primitives.rs
+++ b/calyx-backend/src/primitives.rs
@@ -1,0 +1,103 @@
+//! Primitive listing backend for the Calyx compiler.
+//! Transforms an [`ir::Context`](crate::ir::Context) into a JSON file that
+//! records the unique primitive instantiations in a program.
+//! Adapted from resources.rs backend.
+use std::{collections::HashSet, io};
+
+use crate::traits::Backend;
+use calyx_ir as ir;
+use calyx_utils::{CalyxResult, OutputFile};
+use serde::{Deserialize, Serialize};
+
+#[derive(Default)]
+pub struct PrimitiveInstBackend;
+
+impl Backend for PrimitiveInstBackend {
+    fn name(&self) -> &'static str {
+        "resources"
+    }
+
+    /// OK to run this analysis on any Calyx program
+    fn validate(_ctx: &ir::Context) -> CalyxResult<()> {
+        Ok(())
+    }
+
+    /// Don't need to take care of this for this pass
+    fn link_externs(
+        _ctx: &ir::Context,
+        _file: &mut OutputFile,
+    ) -> CalyxResult<()> {
+        Ok(())
+    }
+
+    fn emit(ctx: &ir::Context, file: &mut OutputFile) -> CalyxResult<()> {
+        let main_comp = ctx
+            .components
+            .iter()
+            .find(|comp| comp.name == ctx.entrypoint)
+            .unwrap();
+
+        let primitive_set: &mut HashSet<PrimitiveInstantiation> =
+            &mut HashSet::new();
+
+        gen_primitive_set(ctx, main_comp, primitive_set);
+
+        write_json(primitive_set.clone(), file)?;
+
+        Ok(())
+    }
+}
+
+#[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+struct PrimitiveInstantiation {
+    name: String,
+    params: Vec<u64>,
+}
+
+/// Counts the number of each primitive with a given set of parameters
+/// in the program with entrypoint `main_comp`.
+fn gen_primitive_set(
+    ctx: &ir::Context,
+    main_comp: &ir::Component,
+    primitive_set: &mut HashSet<PrimitiveInstantiation>,
+) {
+    for cell in main_comp.cells.iter() {
+        let cell_ref = cell.borrow();
+        match &cell_ref.prototype {
+            ir::CellType::Primitive {
+                name,
+                param_binding,
+                ..
+            } => {
+                let mut curr_params = Vec::new();
+                for (_, size) in param_binding.iter() {
+                    curr_params.push(size.clone());
+                }
+                let curr_primitive = PrimitiveInstantiation {
+                    name: name.to_string(),
+                    params: curr_params,
+                };
+                (*primitive_set).insert(curr_primitive);
+            }
+            ir::CellType::Component { name } => {
+                let component = ctx
+                    .components
+                    .iter()
+                    .find(|comp| comp.name == name)
+                    .unwrap();
+                gen_primitive_set(ctx, component, primitive_set);
+            }
+            _ => (),
+        }
+    }
+}
+
+fn write_json(
+    primitive_set: HashSet<PrimitiveInstantiation>,
+    file: &mut OutputFile,
+) -> Result<(), io::Error> {
+    let created_vec: Vec<PrimitiveInstantiation> =
+        primitive_set.into_iter().collect();
+    serde_json::to_writer(file.get_write(), &created_vec)?;
+    Ok(())
+}

--- a/calyx-backend/src/primitives.rs
+++ b/calyx-backend/src/primitives.rs
@@ -98,6 +98,6 @@ fn write_json(
 ) -> Result<(), io::Error> {
     let created_vec: Vec<PrimitiveInstantiation> =
         primitive_set.into_iter().collect();
-    serde_json::to_writer(file.get_write(), &created_vec)?;
+    serde_json::to_writer_pretty(file.get_write(), &created_vec)?;
     Ok(())
 }

--- a/calyx-backend/src/primitives.rs
+++ b/calyx-backend/src/primitives.rs
@@ -71,8 +71,7 @@ fn gen_primitive_set(
                 let mut curr_params = Vec::new();
                 for (param_name, param_size) in param_binding.iter() {
                     let mut param_binding = BTreeMap::new();
-                    param_binding
-                        .insert(param_name.to_string(), param_size.clone());
+                    param_binding.insert(param_name.to_string(), *param_size);
                     curr_params.push(param_binding);
                 }
                 let curr_primitive = PrimitiveInst {

--- a/calyx-backend/src/primitives.rs
+++ b/calyx-backend/src/primitives.rs
@@ -81,7 +81,7 @@ fn gen_primitive_set(
                 for (param_name, param_size) in param_binding.iter() {
                     let param = PrimitiveParam {
                         param_name: param_name.to_string(),
-                        param_value: param_size.clone(),
+                        param_value: *param_size,
                     };
                     curr_params.push(param);
                 }

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -4,8 +4,8 @@ use argh::FromArgs;
 use calyx_backend::SexpBackend;
 use calyx_backend::{
     xilinx::{XilinxInterfaceBackend, XilinxXmlBackend},
-    Backend, BackendOpt, FirrtlBackend, MlirBackend, ResourcesBackend,
-    VerilogBackend, YxiBackend,
+    Backend, BackendOpt, FirrtlBackend, MlirBackend, PrimitiveInstBackend,
+    ResourcesBackend, VerilogBackend, YxiBackend,
 };
 use calyx_ir as ir;
 use calyx_utils::{CalyxResult, Error, OutputFile};
@@ -168,6 +168,10 @@ impl Opts {
             }
             BackendOpt::Firrtl => {
                 let backend = FirrtlBackend;
+                backend.run(context, self.output)
+            }
+            BackendOpt::PrimitiveInst => {
+                let backend = PrimitiveInstBackend;
                 backend.run(context, self.output)
             }
             BackendOpt::Calyx => {

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -4,7 +4,7 @@ use argh::FromArgs;
 use calyx_backend::SexpBackend;
 use calyx_backend::{
     xilinx::{XilinxInterfaceBackend, XilinxXmlBackend},
-    Backend, BackendOpt, FirrtlBackend, MlirBackend, PrimitiveInstBackend,
+    Backend, BackendOpt, FirrtlBackend, MlirBackend, PrimitiveUsesBackend,
     ResourcesBackend, VerilogBackend, YxiBackend,
 };
 use calyx_ir as ir;
@@ -170,8 +170,8 @@ impl Opts {
                 let backend = FirrtlBackend;
                 backend.run(context, self.output)
             }
-            BackendOpt::PrimitiveInst => {
-                let backend = PrimitiveInstBackend;
+            BackendOpt::PrimitiveUses => {
+                let backend = PrimitiveUsesBackend;
                 backend.run(context, self.output)
             }
             BackendOpt::Calyx => {


### PR DESCRIPTION
This PR contains a new backend that lists all of the unique instantiations of primitives within a program into a JSON file. This is necessary for my Calyx-FIRRTL efforts because FIRRTL does not support parameterization of modules, and therefore I have to generate individual FIRRTL modules that each correspond to a specific primitive instantiation in Calyx. This backend is the first step, and the produced JSON file will be processed by a script that I will write next. I'll also add fud2 support for this backend soon.
As a side note, this backend would also be similarly useful for the BTOR2-Cider efforts as described in #1845 under **Generation Scaffolding**.

This backend borrowed a lot of code from the Resource Estimation backend, which I'm very thankful for :slightly_smiling_face: 

Please let me know if there's any points I can improve here!! Also, I'm personally not a fan of the namings I used (`primitive-inst`, `primtives.rs`, etc) but didn't have any better ideas, so I'd really appreciate any suggestions on that front :slightly_smiling_face: 

### Usage
You can run the backend by using the `-b primitive-inst` flag, and the optional `-o <OUTPUT_FILE>` flag to write the JSON to a file.

ex) Running with `language-tutorial-mem`:
```
cargo run -- examples/tutorial/language-tutorial-mem.futil -b primitive-inst -o p.json
```
we get in `p.json`...
```
[
  {
    "name": "std_mem_d1",
    "params": [
      {
        "param_name": "WIDTH",
        "param_value": 32
      },
      {
        "param_name": "SIZE",
        "param_value": 1
      },
      {
        "param_name": "IDX_SIZE",
        "param_value": 1
      }
    ]
  }
]
```