### PR TITLE
Clean up AXI generator channels

### DIFF
--- a/yxi/axi-calyx/axi-combined-calyx.futil
+++ b/yxi/axi-calyx/axi-combined-calyx.futil
@@ -47,7 +47,7 @@ component m_arread_channel(
       is_arvalid = std_reg(1);
 
       // gets set high with ARVALID and remains high
-      arvalid_was_high = std_reg(1);
+      ar_handshake_occurred = std_reg(1);
       // TODO(nathanielnrn): should arguably eventually live in `s_axi_control`
       // but for now will live here.
       ref base_addr = std_reg(64);
@@ -78,20 +78,17 @@ component m_arread_channel(
       // this contains blocking logic previously in its own group
       group do_ar_transfer {
           //assert ARVALID as long as this is the first time we are asserting it
-          is_arvalid.in = !arvalid_was_high.out ? 1'b1;
+          is_arvalid.in = !ar_handshake_occurred.out ? 1'b1;
           
-          // TODO(nathanielnrn): in theory should be able to get rid of arvalid_was_high
-          // but for now we will be explicit and reduce this in generation maybe. Not sure
-          // it even matters.
 
           // This makes ARVALID go low after a single cycle.
           // Without it it stays high for 2 cycles
           // See issue #1828: https://github.com/calyxir/calyx/issues/1828
-          is_arvalid.in = is_arvalid.out & ARREADY & arvalid_was_high.out ? 1'b0;
+          is_arvalid.in = is_arvalid.out & ARREADY & ar_handshake_occurred.out ? 1'b0;
           is_arvalid.write_en = 1'b1;
 
-          arvalid_was_high.in = !(is_arvalid.out & ARREADY) & !arvalid_was_high.out ? 1'b1;
-          arvalid_was_high.write_en = !(is_arvalid.out & ARREADY) & !arvalid_was_high.out ? 1'b1;
+          ar_handshake_occurred.in = !(is_arvalid.out & ARREADY) & !ar_handshake_occurred.out ? 1'b1;
+          ar_handshake_occurred.write_en = !(is_arvalid.out & ARREADY) & !ar_handshake_occurred.out ? 1'b1;
 
 
           // drive output signals for transfer  
@@ -143,7 +140,7 @@ component m_arread_channel(
               seq{
                   par {
                       invoke bt_reg(in=1'b0)();
-                      invoke arvalid_was_high(in=1'b0)();
+                      invoke ar_handshake_occurred(in=1'b0)();
                   }
                   do_ar_transfer;
                   invoke is_arvalid(in=1'b0)();
@@ -412,7 +409,7 @@ component m_awwrite_channel(
       is_awvalid = std_reg(1);
 
       // gets set high with AWVALID and remains high
-      awvalid_was_high = std_reg(1);
+      aw_handshake_occurred = std_reg(1);
       // TODO(nathanielnrn): should arguably eventually live in `s_axi_control`
       // but for now will live here.
       ref base_addr = std_reg(64);
@@ -446,17 +443,17 @@ component m_awwrite_channel(
       // this contains blocking logic previously in its own group
       group do_aw_transfer {
           //assert AWVALID
-          is_awvalid.in = !awvalid_was_high.out ? 1'b1;
+          is_awvalid.in = !(is_awvalid.out & AWREADY) & !aw_handshake_occurred.out ? 1'b1;
           
-          // TODO(nathanielnrn): in theory should be able to get rid of awvalid_was_high
+          // TODO(nathanielnrn): in theory should be able to get rid of aw_handshake_occurred
           // but for now we will be explicit and reduce this in generation maybe. Not sure
           // it even matters.
           // This makes AWVALID go low after a single cycle. Without it it stays high for 2.
-          is_awvalid.in = is_awvalid.out & AWREADY & awvalid_was_high.out ? 1'b0;
+          is_awvalid.in = (is_awvalid.out & AWREADY) | aw_handshake_occurred.out ? 1'b0;
           is_awvalid.write_en = 1'b1;
 
-          awvalid_was_high.in = !(is_awvalid.out & AWREADY) & !awvalid_was_high.out ? 1'b1;
-          awvalid_was_high.write_en = !(is_awvalid.out & AWREADY) & !awvalid_was_high.out ? 1'b1;
+          aw_handshake_occurred.in = is_awvalid.out & AWREADY ? 1'b1;
+          aw_handshake_occurred.write_en = !aw_handshake_occurred.out ? 1'b1;
 
 
           // drive output signals for transfer  
@@ -514,7 +511,7 @@ component m_awwrite_channel(
               seq{
                   par {
 		            invoke bt_reg(in=1'b0)();
-		            invoke awvalid_was_high(in=1'b0)();
+		            invoke aw_handshake_occurred(in=1'b0)();
                   }
                   do_aw_transfer;
 		          invoke is_awvalid(in=1'b0)();
@@ -540,7 +537,7 @@ component m_write_channel(
       // on the data we read from cocotb
       ref internal_mem = seq_mem_d1(32, 8, 64);
       wvalid = std_reg(1);
-      wvalid_was_high = std_reg(1);
+      w_handshake_occurred = std_reg(1);
       // used internally to access our seq_mem_d1
       ref curr_addr = std_reg(64);
       ref base_addr = std_reg(64);
@@ -580,14 +577,14 @@ component m_write_channel(
 
         //NOTE: wvalid.in = 1'b1; does not work, it leaves WVALID high for 2 cycles
         // this both asserts and deasserts one cycle later
-        wvalid.in = !(wvalid.out & WREADY & wvalid_was_high.out) ? 1'b1;
-        // TODO(nathanielnrn): Can prob get rid of wvalid_was_high
-        wvalid.in = (wvalid.out & WREADY) & wvalid_was_high.out ? 1'b0;
+        wvalid.in = !(wvalid.out & WREADY) & !w_handshake_occurred.out ? 1'b1;
+        // TODO(nathanielnrn): Can prob get rid of w_handshake_occurred
+        wvalid.in = (wvalid.out & WREADY) | w_handshake_occurred.out ? 1'b0;
         wvalid.write_en = 1'b1;
 
         //set to 1 after valid has been high even once
-        wvalid_was_high.in = !(wvalid.out & WREADY & wvalid_was_high.out) ? 1'b1;
-        wvalid_was_high.write_en = !(wvalid.out & WREADY & wvalid_was_high.out) ? 1'b1;
+        w_handshake_occurred.in = wvalid.out & WREADY ? 1'b1;
+        w_handshake_occurred.write_en = !w_handshake_occurred.out ? 1'b1;
 
      
         // set data output based on curr_addr register
@@ -650,6 +647,7 @@ component m_write_channel(
                 incr_curr_addr;
                 incr_curr_trnsfr_count;
                 incr_base_addr;
+                invoke w_handshake_occurred(in=1'b0)();
               }
           }
         }

--- a/yxi/axi-calyx/axi-combined-calyx.futil
+++ b/yxi/axi-calyx/axi-combined-calyx.futil
@@ -50,7 +50,7 @@ component m_arread_channel(
       ar_handshake_occurred = std_reg(1);
       // TODO(nathanielnrn): should arguably eventually live in `s_axi_control`
       // but for now will live here.
-      ref base_addr = std_reg(64);
+      ref curr_addr_axi = std_reg(64);
       
       // number of trasfers in a transaction. This is sent to subordinate
       txn_len = std_reg(8);
@@ -92,7 +92,7 @@ component m_arread_channel(
 
 
           // drive output signals for transfer  
-          ARADDR = base_addr.out;
+          ARADDR = curr_addr_axi.out;
           // see link above, needs to match data width to host.
           // In this case 2^2 = 4 bytes = 32 bits = width of our data_bus.
           ARSIZE = 3'b010; 
@@ -171,9 +171,9 @@ component m_read_channel(
       // on the data we read from cocotb
       ref data_received = seq_mem_d1(32, 8, 64);
       is_rdy = std_reg(1);
-      ref curr_addr = std_reg(64);
+      ref curr_addr_internal_mem = std_reg(64);
       //need to increment this
-      ref base_addr = std_reg(64);
+      ref curr_addr_axi = std_reg(64);
       
       // registered because RLAST is high with last transfer, not after
       // before this was registered we were terminating immediately with
@@ -184,8 +184,8 @@ component m_read_channel(
       read_data_reg = std_reg(32);
 
       //address of seq_d1_mem we are writing to
-      curr_addr_adder = std_add(64);
-      base_addr_adder = std_add(64);
+      curr_addr_internal_mem_adder = std_add(64);
+      curr_addr_axi_adder = std_add(64);
 
       // block_transfer reg to avoid combinational loops
       // Used to block any servicing until handshake occurs. 
@@ -243,27 +243,27 @@ component m_read_channel(
           is_rdy.write_en = 1'b1;
 
           //write the data we received during transfer to seq_d1_mem
-          data_received.addr0 = curr_addr.out;
+          data_received.addr0 = curr_addr_internal_mem.out;
           data_received.write_en = 1'b1;
           data_received.write_data = read_data_reg.out;
           receive_r_transfer[done] = data_received.write_done;
 
       }
 
-      group incr_curr_addr{
-          curr_addr_adder.left = 64'd1 ;
-          curr_addr_adder.right = curr_addr.out;
-          curr_addr.in = curr_addr_adder.out;
-          curr_addr.write_en = 1'b1;
-          incr_curr_addr[done] = curr_addr.done;
+      group incr_curr_addr_internal_mem{
+          curr_addr_internal_mem_adder.left = 64'd1 ;
+          curr_addr_internal_mem_adder.right = curr_addr_internal_mem.out;
+          curr_addr_internal_mem.in = curr_addr_internal_mem_adder.out;
+          curr_addr_internal_mem.write_en = 1'b1;
+          incr_curr_addr_internal_mem[done] = curr_addr_internal_mem.done;
       }
 
-      group incr_base_addr{
-          base_addr_adder.left = 64'd4; //32-bit/8. TODO:parameterize via mem width
-          base_addr_adder.right = base_addr.out;
-          base_addr.in = base_addr_adder.out;
-          base_addr.write_en= 1'b1;
-          incr_base_addr[done] = base_addr.done;
+      group incr_curr_addr_axi{
+          curr_addr_axi_adder.left = 64'd4; //32-bit/8. TODO:parameterize via mem width
+          curr_addr_axi_adder.right = curr_addr_axi.out;
+          curr_addr_axi.in = curr_addr_axi_adder.out;
+          curr_addr_axi.write_en= 1'b1;
+          incr_curr_addr_axi[done] = curr_addr_axi.done;
       }
   }
   control{
@@ -274,8 +274,8 @@ component m_read_channel(
               block_transfer;
               receive_r_transfer;
               par{
-                  incr_curr_addr;
-                  incr_base_addr;
+                  incr_curr_addr_internal_mem;
+                  incr_curr_addr_axi;
               }
           }
       }
@@ -412,7 +412,7 @@ component m_awwrite_channel(
       aw_handshake_occurred = std_reg(1);
       // TODO(nathanielnrn): should arguably eventually live in `s_axi_control`
       // but for now will live here.
-      ref base_addr = std_reg(64);
+      ref curr_addr_axi = std_reg(64);
 
       //we write to this here and read from it in m_write_channel
       ref max_trnsfrs = std_reg(8);
@@ -457,7 +457,7 @@ component m_awwrite_channel(
 
 
           // drive output signals for transfer  
-          AWADDR = base_addr.out;
+          AWADDR = curr_addr_axi.out;
           // see link above, needs to match data width to host.
           // In this case 2^2 = 4 bytes = 32 bits = width of our data_bus.
           AWSIZE = 3'b010; 
@@ -539,8 +539,8 @@ component m_write_channel(
       wvalid = std_reg(1);
       w_handshake_occurred = std_reg(1);
       // used internally to access our seq_mem_d1
-      ref curr_addr = std_reg(64);
-      ref base_addr = std_reg(64);
+      ref curr_addr_internal_mem = std_reg(64);
+      ref curr_addr_axi = std_reg(64);
       
       //this increments
       curr_trnsfr_count = std_reg(8); //between 0 and 255, add +1 for transfer count
@@ -553,8 +553,8 @@ component m_write_channel(
       n_finished_last_trnsfr = std_reg(1);
 
       //used for address of seq_d1_mem we are reading from
-      curr_addr_adder = std_add(64);
-      base_addr_adder = std_add(64);
+      curr_addr_internal_mem_adder = std_add(64);
+      curr_addr_axi_adder = std_add(64);
       curr_trnsfr_count_adder = std_add(8);
 
 
@@ -587,8 +587,8 @@ component m_write_channel(
         w_handshake_occurred.write_en = !w_handshake_occurred.out ? 1'b1;
 
      
-        // set data output based on curr_addr register
-        internal_mem.addr0 = curr_addr.out;
+        // set data output based on curr_addr_internal_mem register
+        internal_mem.addr0 = curr_addr_internal_mem.out;
         internal_mem.read_en = 1'b1;
         WDATA = internal_mem.read_data;
         
@@ -609,20 +609,20 @@ component m_write_channel(
         do_write_transfer[done] = bt_reg.out;
       }
 
-      group incr_curr_addr{
-          curr_addr_adder.left = 64'd1 ;
-          curr_addr_adder.right = curr_addr.out;
-          curr_addr.in = curr_addr_adder.out;
-          curr_addr.write_en = 1'b1;
-          incr_curr_addr[done] = curr_addr.done;
+      group incr_curr_addr_internal_mem{
+          curr_addr_internal_mem_adder.left = 64'd1 ;
+          curr_addr_internal_mem_adder.right = curr_addr_internal_mem.out;
+          curr_addr_internal_mem.in = curr_addr_internal_mem_adder.out;
+          curr_addr_internal_mem.write_en = 1'b1;
+          incr_curr_addr_internal_mem[done] = curr_addr_internal_mem.done;
       }
       
-      group incr_base_addr{
-          base_addr_adder.left = 64'd4; //32-bit/8. TODO:parameterize via mem width
-          base_addr_adder.right = base_addr.out;
-          base_addr.in = base_addr_adder.out;
-          base_addr.write_en= 1'b1;
-          incr_base_addr[done] = base_addr.done;
+      group incr_curr_addr_axi{
+          curr_addr_axi_adder.left = 64'd4; //32-bit/8. TODO:parameterize via mem width
+          curr_addr_axi_adder.right = curr_addr_axi.out;
+          curr_addr_axi.in = curr_addr_axi_adder.out;
+          curr_addr_axi.write_en= 1'b1;
+          incr_curr_addr_axi[done] = curr_addr_axi.done;
       }
 
       group incr_curr_trnsfr_count {
@@ -637,16 +637,16 @@ component m_write_channel(
   control{
       seq{
 
-        invoke curr_addr(in=64'b0)(); //reset curr_addr
+        invoke curr_addr_internal_mem(in=64'b0)(); //reset curr_addr_internal_mem
 	    invoke n_finished_last_trnsfr(in=1'b1)(); //init reg
         while n_finished_last_trnsfr.out{
           seq{
 	          invoke bt_reg(in=1'b0)();
               do_write_transfer;
               par{
-                incr_curr_addr;
+                incr_curr_addr_internal_mem;
                 incr_curr_trnsfr_count;
-                incr_base_addr;
+                incr_curr_addr_axi;
                 invoke w_handshake_occurred(in=1'b0)();
               }
           }
@@ -857,12 +857,12 @@ component main(
 
         //original read stuff
 
-        curr_addr_A0 = std_reg(64);
-        base_addr_A0 = std_reg(64);
-        curr_addr_B0 = std_reg(64);
-        base_addr_B0 = std_reg(64);
-        curr_addr_Sum0 = std_reg(64);
-        base_addr_Sum0 = std_reg(64);
+        curr_addr_internal_mem_A0 = std_reg(64);
+        curr_addr_axi_A0 = std_reg(64);
+        curr_addr_internal_mem_B0 = std_reg(64);
+        curr_addr_axi_B0 = std_reg(64);
+        curr_addr_internal_mem_Sum0 = std_reg(64);
+        curr_addr_axi_Sum0 = std_reg(64);
 
         A0_read_channel = m_read_channel();
         A0_arread_channel = m_arread_channel();
@@ -921,19 +921,19 @@ component main(
         seq{
             //read stuff
             par{
-                //init base_addresses
+                //init curr_addr_axiesses
                 //TODO: get this from kernel.xml
-                invoke base_addr_A0(in = 64'x1000)();
-                invoke base_addr_B0(in = 64'x1000)();
-                invoke base_addr_Sum0(in = 64'x1000)();
-                invoke curr_addr_A0(in = 64'x0000)();
-                invoke curr_addr_B0(in = 64'x0000)();
-                invoke curr_addr_Sum0(in = 64'x0000)();
+                invoke curr_addr_axi_A0(in = 64'x1000)();
+                invoke curr_addr_axi_B0(in = 64'x1000)();
+                invoke curr_addr_axi_Sum0(in = 64'x1000)();
+                invoke curr_addr_internal_mem_A0(in = 64'x0000)();
+                invoke curr_addr_internal_mem_B0(in = 64'x0000)();
+                invoke curr_addr_internal_mem_Sum0(in = 64'x0000)();
             }
             par{
               seq{
                 //A0 reads
-                invoke A0_arread_channel[base_addr = base_addr_A0]
+                invoke A0_arread_channel[curr_addr_axi = curr_addr_axi_A0]
                 (
                 ARESET = m0_ARESET,
                 ARREADY = m0_ARREADY
@@ -946,9 +946,9 @@ component main(
                 ARBURST = m0_ARBURST
                 );
 
-                //invoke curr_addr_A0(in = base_addr_A0.out)(); //set curr_addr to base_address
+                //invoke curr_addr_internal_mem_A0(in = curr_addr_axi_A0.out)(); //set curr_addr_internal_mem to curr_addr_axiess
 
-                invoke A0_read_channel[data_received = A0, curr_addr = curr_addr_A0, base_addr = base_addr_A0]
+                invoke A0_read_channel[data_received = A0, curr_addr_internal_mem = curr_addr_internal_mem_A0, curr_addr_axi = curr_addr_axi_A0]
                 (
                 ARESET = m0_ARESET,
                 RVALID = m0_RVALID,
@@ -963,7 +963,7 @@ component main(
 
 
               seq{ //B0 reads
-                invoke B0_arread_channel[base_addr = base_addr_B0]
+                invoke B0_arread_channel[curr_addr_axi = curr_addr_axi_B0]
                 (
                 ARESET = m1_ARESET,
                 ARREADY = m1_ARREADY
@@ -976,9 +976,9 @@ component main(
                 ARBURST = m1_ARBURST
                 );
 
-                //invoke curr_addr_B0(in = base_addr_B0.out)(); //set curr_addr to base_address
+                //invoke curr_addr_internal_mem_B0(in = curr_addr_axi_B0.out)(); //set curr_addr_internal_mem to curr_addr_axiess
 
-                invoke B0_read_channel[data_received = B0, curr_addr = curr_addr_B0, base_addr = base_addr_B0]
+                invoke B0_read_channel[data_received = B0, curr_addr_internal_mem = curr_addr_internal_mem_B0, curr_addr_axi = curr_addr_axi_B0]
                 (
                 ARESET = m1_ARESET,
                 RVALID = m1_RVALID,
@@ -991,7 +991,7 @@ component main(
                 );
               }
               seq{ //Sum0 reads
-                invoke Sum0_arread_channel[base_addr = base_addr_Sum0]
+                invoke Sum0_arread_channel[curr_addr_axi = curr_addr_axi_Sum0]
                 (
                 ARESET = m2_ARESET,
                 ARREADY = m2_ARREADY
@@ -1004,9 +1004,9 @@ component main(
                 ARBURST = m2_ARBURST
                 );
 
-                //invoke curr_addr_Sum0(in = base_addr_Sum0.out)(); //set curr_addr to base_address
+                //invoke curr_addr_internal_mem_Sum0(in = curr_addr_axi_Sum0.out)(); //set curr_addr_internal_mem to curr_addr_axiess
 
-                invoke Sum0_read_channel[data_received = Sum0, curr_addr = curr_addr_Sum0, base_addr = base_addr_Sum0]
+                invoke Sum0_read_channel[data_received = Sum0, curr_addr_internal_mem = curr_addr_internal_mem_Sum0, curr_addr_axi = curr_addr_axi_Sum0]
                 (
                 ARESET = m2_ARESET,
                 RVALID = m2_RVALID,
@@ -1026,16 +1026,16 @@ component main(
             invoke vec_add_cell[A0 = A0, B0 = B0, Sum0 = Sum0]()();
             //end compute stuff
 
-            //reset base_addr registers before writing
+            //reset curr_addr_axi registers before writing
             par{
-                invoke base_addr_A0(in = 64'x1000)();
-                invoke base_addr_B0(in = 64'x1000)();
-                invoke base_addr_Sum0(in = 64'x1000)();
+                invoke curr_addr_axi_A0(in = 64'x1000)();
+                invoke curr_addr_axi_B0(in = 64'x1000)();
+                invoke curr_addr_axi_Sum0(in = 64'x1000)();
             }
             //write stuff
             par {
                 seq { //A0 writes
-                    invoke A0_awwrite_channel[base_addr = base_addr_A0, max_trnsfrs = max_trnsfrs]
+                    invoke A0_awwrite_channel[curr_addr_axi = curr_addr_axi_A0, max_trnsfrs = max_trnsfrs]
                     (
                     ARESET = m0_ARESET,
                     AWREADY = m0_AWREADY
@@ -1049,9 +1049,9 @@ component main(
                     AWPROT = m0_AWPROT
                     );
 
-                    //invoke curr_addr_A0(in = base_addr_A0.out)(); //set curr_addr to base_address
+                    //invoke curr_addr_internal_mem_A0(in = curr_addr_axi_A0.out)(); //set curr_addr_internal_mem to curr_addr_axiess
 
-                    invoke A0_write_channel[internal_mem = A0, curr_addr = curr_addr_A0, max_trnsfrs = max_trnsfrs, base_addr = base_addr_A0]
+                    invoke A0_write_channel[internal_mem = A0, curr_addr_internal_mem = curr_addr_internal_mem_A0, max_trnsfrs = max_trnsfrs, curr_addr_axi = curr_addr_axi_A0]
                     (
                     ARESET = m0_ARESET,
                     WREADY = m0_WREADY
@@ -1065,7 +1065,7 @@ component main(
                     invoke A0_bresp_channel(BVALID = m0_BVALID)(BREADY = m0_BREADY);
                 }
                 seq { //B0 writes
-                    invoke B0_awwrite_channel[base_addr = base_addr_B0, max_trnsfrs = max_trnsfrs]
+                    invoke B0_awwrite_channel[curr_addr_axi = curr_addr_axi_B0, max_trnsfrs = max_trnsfrs]
                     (
                     ARESET = m1_ARESET,
                     AWREADY = m1_AWREADY
@@ -1079,9 +1079,9 @@ component main(
                     AWPROT = m1_AWPROT
                     );
 
-                    //invoke curr_addr_B0(in = base_addr_B0.out)(); //set curr_addr to base_address
+                    //invoke curr_addr_internal_mem_B0(in = curr_addr_axi_B0.out)(); //set curr_addr_internal_mem to curr_addr_axiess
 
-                    invoke B0_write_channel[internal_mem = B0, curr_addr = curr_addr_B0, max_trnsfrs = max_trnsfrs, base_addr = base_addr_B0]
+                    invoke B0_write_channel[internal_mem = B0, curr_addr_internal_mem = curr_addr_internal_mem_B0, max_trnsfrs = max_trnsfrs, curr_addr_axi = curr_addr_axi_B0]
                     (
                     ARESET = m1_ARESET,
                     WREADY = m1_WREADY
@@ -1096,7 +1096,7 @@ component main(
                 }
 
                 seq { //Sum0 writes
-                    invoke Sum0_awwrite_channel[base_addr = base_addr_Sum0, max_trnsfrs = max_trnsfrs]
+                    invoke Sum0_awwrite_channel[curr_addr_axi = curr_addr_axi_Sum0, max_trnsfrs = max_trnsfrs]
                     (
                     ARESET = m2_ARESET,
                     AWREADY = m2_AWREADY
@@ -1110,9 +1110,9 @@ component main(
                     AWPROT = m2_AWPROT
                     );
 
-                    //invoke curr_addr_Sum0(in = base_addr_Sum0.out)(); //set curr_addr to base_address
+                    //invoke curr_addr_internal_mem_Sum0(in = curr_addr_axi_Sum0.out)(); //set curr_addr_internal_mem to curr_addr_axiess
 
-                    invoke Sum0_write_channel[internal_mem = Sum0, curr_addr = curr_addr_Sum0, max_trnsfrs = max_trnsfrs, base_addr = base_addr_Sum0]
+                    invoke Sum0_write_channel[internal_mem = Sum0, curr_addr_internal_mem = curr_addr_internal_mem_Sum0, max_trnsfrs = max_trnsfrs, curr_addr_axi = curr_addr_axi_Sum0]
                     (
                     ARESET = m2_ARESET,
                     WREADY = m2_WREADY


### PR DESCRIPTION
See #1865.
This PR touches both the hardcoded calyx implementation as well as the generator.
Doing this PR has made me realize we should start making efforts to get rid of the hardcoded implementation as things will pretty easily drift out of sync otherwise. 

1. Renames `base_addr` and `curr_addr` to `curr_addr_axi` and `curr_addr_interal_mem` respectively
2. Asserts a few properties we expect from our yxi input. Namely widths being divisible by 8 and mem sizes being powers of 
3. Simplifies the `was_high` signals, see the issue for more details. This is the thing I'm most unsure of w.r.t the correctness of the implementation. This ended up deviating a bit from the talk @sampsyo and I had. If anyone takes a look at this part I'd be happy to hear any and all feedback/thoughts.

After this there is still a need to refactor out shared channels in the generator.