### PR TITLE
Supporting external writes to registers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ version = "0.6.1"
 dependencies = [
  "calyx-frontend",
  "calyx-ir",
+ "calyx-stdlib",
  "calyx-utils",
  "csv",
  "itertools 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ calyx-ir = { path = "calyx-ir", version = "0.6.1" }
 calyx-frontend = { path = "calyx-frontend", version = "0.6.1" }
 calyx-opt = { path = "calyx-opt", version = "0.6.1" }
 calyx-backend = { path = "calyx-backend", version = "0.6.1" }
+calyx-stdlib = { path = "calyx-stdlib", version = "0.6.1" }
 
 [workspace.dependencies.petgraph]
 version = "0.6"

--- a/calyx-backend/Cargo.toml
+++ b/calyx-backend/Cargo.toml
@@ -26,6 +26,7 @@ smallvec.workspace = true
 calyx-utils.workspace = true
 calyx-frontend.workspace = true
 calyx-ir.workspace = true
+calyx-stdlib.workspace = true
 
 csv = { version = "1.1", optional = true }
 vast = "0.3.1"

--- a/calyx-ir/src/structure.rs
+++ b/calyx-ir/src/structure.rs
@@ -422,6 +422,11 @@ impl Cell {
         self.attributes.get(attr.into())
     }
 
+    /// Return true if this cell has the given attribute.
+    pub fn has_attribute<A: Into<Attribute>>(&self, attr: A) -> bool {
+        self.attributes.has(attr.into())
+    }
+
     /// Add a new attribute to the group.
     pub fn add_attribute<A: Into<Attribute>>(&mut self, attr: A, value: u64) {
         self.attributes.insert(attr.into(), value);

--- a/calyx-stdlib/src/lib.rs
+++ b/calyx-stdlib/src/lib.rs
@@ -1,3 +1,8 @@
+mod memories;
 mod primitives;
 
+pub use memories::{
+    is_loadable, load_path, SEQ_MEM_D1, SEQ_MEM_D2, SEQ_MEM_D3, SEQ_MEM_D4,
+    STD_MEM_D1, STD_MEM_D2, STD_MEM_D3, STD_MEM_D4, STD_REG,
+};
 pub use primitives::{COMPILE_LIB, KNOWN_LIBS};

--- a/calyx-stdlib/src/memories.rs
+++ b/calyx-stdlib/src/memories.rs
@@ -1,0 +1,44 @@
+//! Verilog-level names for the primitives
+
+/// Register
+pub const STD_REG: &str = "std_reg";
+
+// Memories
+pub const STD_MEM_D1: &str = "std_mem_d1";
+pub const STD_MEM_D2: &str = "std_mem_d2";
+pub const STD_MEM_D3: &str = "std_mem_d3";
+pub const STD_MEM_D4: &str = "std_mem_d4";
+
+// Sequential Memories
+pub const SEQ_MEM_D1: &str = "seq_mem_d1";
+pub const SEQ_MEM_D2: &str = "seq_mem_d2";
+pub const SEQ_MEM_D3: &str = "seq_mem_d3";
+pub const SEQ_MEM_D4: &str = "seq_mem_d4";
+
+/// The primitive supports loading input value from a file using `readmemh` and
+/// `writememh` calls in Verilog.
+pub fn is_loadable(type_name: &str) -> bool {
+    matches!(
+        type_name,
+        STD_REG
+            | STD_MEM_D1
+            | STD_MEM_D2
+            | STD_MEM_D3
+            | STD_MEM_D4
+            | SEQ_MEM_D1
+            | SEQ_MEM_D2
+            | SEQ_MEM_D3
+            | SEQ_MEM_D4
+    )
+}
+
+/// Verilog module path to load values into.
+pub fn load_path(type_name: &str) -> &str {
+    match type_name {
+        STD_REG => "mem",
+        STD_MEM_D1 | STD_MEM_D2 | STD_MEM_D3 | STD_MEM_D4 => "mem",
+        SEQ_MEM_D1 => "mem",
+        SEQ_MEM_D2 | SEQ_MEM_D3 | SEQ_MEM_D4 => "mem.mem",
+        _ => unreachable!("Unknown loadable primitive: {type_name}"),
+    }
+}

--- a/primitives/compile.futil
+++ b/primitives/compile.futil
@@ -31,12 +31,14 @@ primitive std_reg<"state_share"=1>[WIDTH](
 )
 // ANCHOR_END: std_reg_def
 {
+  logic [WIDTH-1:0] mem;
+  assign out = mem;
   always_ff @(posedge clk) begin
     if (reset) begin
-       out <= 0;
+       mem <= 0;
        done <= 0;
     end else if (write_en) begin
-      out <= in;
+      mem <= in;
       done <= 1'd1;
     end else done <= 1'd0;
   end


### PR DESCRIPTION
Support adding `@external` to `std_reg`. However, I'm holding off the merge because it requires changing what register's encoding looks like which might make synthesis tools freak out. @andrewb1999 thoughts on this new encoding of registers?

Without this, `$readmemh` and `$writememh` do not actually work since they expect memories.