### PR TITLE
Initial fud2 import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+
+[[package]]
 name = "argh"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +91,15 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "atty"
@@ -168,6 +183,12 @@ name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
+name = "bytemuck"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
 
 [[package]]
 name = "byteorder"
@@ -301,6 +322,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +422,12 @@ checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.103.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e3ee532fc4776c69bcedf7e62f9632cbb3f35776fa9a525cdade3195baa3f7"
 
 [[package]]
 name = "criterion"
@@ -702,6 +735,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fake"
+version = "0.6.1"
+dependencies = [
+ "anyhow",
+ "argh",
+ "camino",
+ "cranelift-entity",
+ "figment",
+ "pathdiff",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +762,19 @@ dependencies = [
  "cfg-if",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "figment"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6e5bc7bd59d60d0d45a6ccab6cf0f4ce28698fb4e81e750ddf229c9b824026"
+dependencies = [
+ "atomic",
+ "serde",
+ "toml",
+ "uncased",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -740,6 +799,14 @@ dependencies = [
  "num",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "fud2"
+version = "0.6.1"
+dependencies = [
+ "anyhow",
+ "fake",
 ]
 
 [[package]]
@@ -1154,6 +1221,15 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+dependencies = [
+ "camino",
+]
 
 [[package]]
 name = "pest"
@@ -1599,6 +1675,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,6 +1991,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,6 +2047,15 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check 0.9.4",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -2171,6 +2299,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.5.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1931d78a9c73861da0134f453bb1f790ce49b2e30eba8410b4b79bac72b46a2d"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ members = [
     "web/rust",
     "tools/data_gen",
     "cider-dap",
+    "fud2",
+    "fud2/fake",
 ]
 exclude = ["site"]
 
@@ -43,6 +45,7 @@ pest = "2"
 pest_derive = "2"
 pest_consume = "1"
 argh = "0.1"
+anyhow = "1"
 calyx-utils = { path = "calyx-utils", version = "0.6.1" }
 calyx-ir = { path = "calyx-ir", version = "0.6.1" }
 calyx-frontend = { path = "calyx-frontend", version = "0.6.1" }

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -14,7 +14,7 @@
 
 # Running Calyx Programs
 
-- [`fud`: The Calyx Driver](./running-calyx/fud/index.md)
+- [fud: The Calyx Driver](./running-calyx/fud/index.md)
   - [Examples](./running-calyx/fud/examples.md)
   - [Xilinx Tools](./running-calyx/fud/xilinx.md)
     - [AXI Generation](./running-calyx/fud/axi-gen.md)
@@ -22,6 +22,7 @@
   - [Multiple Paths](./running-calyx/fud/multiple-paths.md)
   - [CIRCT](./running-calyx/fud/circt.md)
   - [Resource Estimation](./running-calyx/fud/resource-estimation.md)
+- [fud2: Experimental Driver](./running-calyx/fud2.md)
 - [Interfacing with Calyx RTL](./running-calyx/interfacing.md)
 - [The Calyx Interpreter](./running-calyx/interpreter.md)
 

--- a/docs/running-calyx/fud2.md
+++ b/docs/running-calyx/fud2.md
@@ -1,0 +1,78 @@
+# fud2: An Experimental Successor to fud
+
+[fud][] is the compiler driver tool for orchestrating the Calyx ecosystem.
+fud2 is an experiment in building a new driver that works like fud that adds some fundamental new capabilities and resolves some underlying problems.
+
+"Original" fud is still the right tool for almost all jobs; fud2 is in an experimental phase and does not support everything fud can do.
+Someday, fud2 may supplant fud, but it needs more work before it is ready to do that.
+Until then, fud remains your first choice for all your build-related needs.
+
+[fud]: ./fud/index.md
+
+## Set Up
+
+fud2 is a Rust tool, so you can build it along with everything else in this monorepo with `cargo build`.
+You might then want to do something like ``ln -s `pwd`/target/debug/fud2 ~/.local/bin`` for easy access to the `fud2` binary.
+
+fud2 depends on [Ninja][].
+Install it using your OS package manager or by downloading a binary.
+
+Create a configuration file at `~/.config/fud2.toml`, using the path to your checkout of the Calyx git repository:
+
+```toml
+data = ".../calyx/fud2/data"
+
+[calyx]
+base = ".../calyx"
+```
+
+Now you're ready to use fud2.
+
+[ninja]: https://ninja-build.org
+
+## General Use
+
+You can see complete command-line documentation with `fud2 --help`.
+But generally, you want to do something like this:
+
+    $ fud2 <IN> -o <OUT>
+
+For example, use this to compile a Calyx program to Verilog:
+
+    $ fud2 foo.futil -o bar.sv
+
+fud2 tries to automatically guess the input and output formats using filename extensions.
+If that doesn't work, you can choose for it with `--from <state>` and `--to <state>`;
+for example, this is a more explicit version of the above:
+
+    $ fud2 foo.futil -o bar.sv --from calyx --to verilog
+
+You can also omit the input and output filenames to instead use stdin and stdout.
+In that case, `--from` and `--to` respectively are required.
+So here's yet another way to do the same thing:
+
+    $ fud2 --from calyx --to verilog < foo.futil > bar.sv
+
+This is handy if you just want to print the result of a build to the console:
+
+    $ fud2 foo.futil --to verilog
+
+Some operations use other configuration options, which can come from either your `fud2.toml` or the command line.
+Use `--set key=value` to override any such option.
+
+## Advanced Options
+
+Here are some options you might need:
+
+* By default, fud2 runs the build in a directory called `.fud2` within the working directory. It automatically deletes this directory when the build is done.
+    * It can be useful to keep this build directory around for debugging or as a "cache" for future builds. Use `--keep` to prevent fud2 from deleting the build directory.
+    * You can also tell fud2 to use a different build directory with `--dir`. If you give it an existing directory, it will never be deleted, even without `--keep`. (Only "fresh" build directories are automatically cleaned up.)
+* If you don't like the operation path that fud2 selected for your build, you can control it with `--through <OP>`. fud2 will search the operation graph for a path that contains that op. You can provide this option multiple times; fud2 will look for paths that contain *all* these operations, in order.
+* You can choose one of several modes with `-m <NAME>`:
+    * `run`: Actually execute a build. The default.
+    * `gen`: Generate the Ninja build file in the build directory, but don't actually run the build. The default `run` mode is therefore approximately like doing `fud2 -m gen && ninja -C .fud2`.
+    * `emit`: Just print the Ninja build file to stdout. The `gen` mode is therefore approximately `fud2 -m emit > .fud2/build.ninja`.
+    * `plan`: Print a brief description of the plan, i.e., the sequence of operations that the build would run.
+    * `dot`: Print a [GraphViz][] depiction of the plan. Try `fud2 -m dot | dot -Tpdf > graph.pdf` and take a look.
+
+[graphviz]: https://graphviz.org

--- a/fud2/Cargo.toml
+++ b/fud2/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "fud2"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+fake = { path = "fake" }
+anyhow.workspace = true

--- a/fud2/data/gen_xo.tcl
+++ b/fud2/data/gen_xo.tcl
@@ -1,0 +1,46 @@
+if { $::argc < 1 } {
+    #puts "ERROR: Program \"$::argv0\" requires 1 argument!\n"
+    puts "ERROR: Executable name unspecified\n"
+    puts "Usage: $::argv0 <xoname> $::argv <axi_name> \n"
+    exit
+}
+
+# Define a process that pops an element off of the list
+proc lvarpop {upVar {index 0}} {
+  upvar $upVar list;
+  if {![info exists list]} { return "-1" }
+  set top [lindex $list $index];
+  set list [concat [lrange $list 0 [expr $index - 1]] [lrange $list [expr $index +1] end]]
+  return $top;
+}
+
+set xoname [lindex $::argv 0]
+set path_to_packaged "./packaged_kernel"
+
+# Make a temporary Vivado project.
+create_project -force kernel_pack "./tmp_kernel_pack"
+
+# Add all Verilog files in the current working directory.
+add_files -norecurse [glob *.v *.sv]
+
+# I don't really understand any of this.
+ipx::package_project -root_dir $path_to_packaged -vendor capra.cs.cornell.edu -library RTLKernel -taxonomy /KernelIP -import_files -set_current false
+ipx::unload_core $path_to_packaged/component.xml
+ipx::edit_ip_in_project -upgrade true -name tmp_edit_project -directory $path_to_packaged $path_to_packaged/component.xml
+set_property sdx_kernel true [ipx::current_core]
+set_property sdx_kernel_type rtl [ipx::current_core]
+
+# Declare bus interfaces.
+ipx::associate_bus_interfaces -busif s_axi_control -clock ap_clk [ipx::current_core]
+lvarpop argv
+foreach busname $argv {
+    ipx::associate_bus_interfaces -busif $busname -clock ap_clk [ipx::current_core]
+}
+
+# Close & save the temporary project.
+ipx::update_checksums [ipx::current_core]
+ipx::save_core [ipx::current_core]
+close_project -delete
+
+# Package the project as an .xo file.
+package_xo -xo_path ${xoname} -kernel_name Toplevel -ip_directory ${path_to_packaged} -kernel_xml ./kernel.xml

--- a/fud2/data/get-ports.py
+++ b/fud2/data/get-ports.py
@@ -1,0 +1,12 @@
+import xml.etree.ElementTree as ET
+import sys
+
+
+def get_ports(kernel_xml):
+    tree = ET.parse(kernel_xml)
+    for port in tree.findall(".//port[@mode='master']"):
+        yield port.attrib["name"]
+
+
+if __name__ == "__main__":
+    print(' '.join(get_ports(sys.argv[1])))

--- a/fud2/data/interp-dat.py
+++ b/fud2/data/interp-dat.py
@@ -1,0 +1,43 @@
+import simplejson
+import sys
+import pathlib
+from fud.stages.interpreter import convert_to_json, parse_from_json
+
+
+def data2interp(in_file):
+    """Convert a fud-style JSON data file to Cider-ready JSON.
+
+    The output file is hard-coded to be `data.json`.
+    """
+    round_float_to_fixed = True
+    with open(in_file) as f:
+        convert_to_json(
+            '.',
+            simplejson.load(f, use_decimal=True),
+            round_float_to_fixed,
+        )
+
+
+def interp2data(in_file, orig_file):
+    """Convert the Cider's output JSON to fud-style JSON.
+
+    Print the result to stdout.
+    """
+    with open(in_file) as f:
+        out = parse_from_json(f, pathlib.Path(orig_file))
+    simplejson.dump(
+        out,
+        sys.stdout,
+        indent=2,
+        sort_keys=True,
+        use_decimal=True,
+    )
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == '--to-interp':
+        data2interp(*sys.argv[2:])
+    elif sys.argv[1] == '--from-interp':
+        interp2data(*sys.argv[2:])
+    else:
+        print("specify --to-interp or --from-interp", file=sys.stderr)

--- a/fud2/data/json-dat.py
+++ b/fud2/data/json-dat.py
@@ -1,0 +1,54 @@
+"""Convert between fud-style JSON and hex data files.
+
+Use the machinery from "old fud" to convert a JSON data file into a
+directory of flat hex-encoded files, suitable for loading into a
+hardware simulator, and back again.
+"""
+from fud.stages.verilator.json_to_dat import convert2dat, convert2json
+import simplejson
+import sys
+import os
+import re
+
+
+def json2dat(in_file, out_dir):
+    os.makedirs(out_dir, exist_ok=True)
+    round_float_to_fixed = True
+    with open(in_file) as json:
+        convert2dat(
+            out_dir,
+            simplejson.load(json, use_decimal=True),
+            "dat",
+            round_float_to_fixed,
+        )
+
+
+def dat2json(out_file, in_dir, sim_log=None):
+    mem = convert2json(in_dir, "out")
+
+    if sim_log:
+        cycles = 0
+        with open(sim_log) as f:
+            for line in f:
+                match = re.search(r"Simulated\s+((-)?\d+) cycles", line)
+                if match:
+                    cycles = int(match.group(1))
+                    break
+        out = {
+            "cycles": cycles,
+            "memories": mem,
+        }
+    else:
+        out = mem
+
+    with open(out_file, 'w') as f:
+        simplejson.dump(out, f, indent=2, sort_keys=True, use_decimal=True)
+
+
+if __name__ == '__main__':
+    if sys.argv[1] == '--from-json':
+        json2dat(*sys.argv[2:])
+    elif sys.argv[1] == '--to-json':
+        dat2json(*sys.argv[2:])
+    else:
+        print("specify --from-json or --to-json", file=sys.stderr)

--- a/fud2/data/primitives-for-firrtl.sv
+++ b/fud2/data/primitives-for-firrtl.sv
@@ -1,0 +1,330 @@
+module std_mem_d1 #(
+    parameter WIDTH = 32,
+    parameter SIZE = 16,
+    parameter IDX_SIZE = 4
+) (
+   input wire                logic [IDX_SIZE-1:0] addr0,
+   input wire                logic [ WIDTH-1:0] write_data,
+   input wire                logic write_en,
+   input wire                logic clk,
+   input wire                logic reset,
+   output logic [ WIDTH-1:0] read_data,
+   output logic              done
+);
+
+   logic [WIDTH-1:0]         mem[SIZE-1:0];
+
+   initial begin
+      $readmemh({"sim_data/mem.dat"}, mem);
+   end
+   final begin
+      $writememh({"sim_data/mem.out"}, mem);
+   end
+
+  /* verilator lint_off WIDTH */
+  assign read_data = mem[addr0];
+
+  always_ff @(posedge clk) begin
+    if (reset)
+      done <= '0;
+    else if (write_en)
+      done <= '1;
+    else
+      done <= '0;
+  end
+
+  always_ff @(posedge clk) begin
+    if (!reset && write_en)
+      mem[addr0] <= write_data;
+  end
+
+  // Check for out of bounds access
+  `ifdef VERILATOR
+    always_comb begin
+      if (addr0 >= SIZE)
+        $error(
+          "std_mem_d1: Out of bounds access\n",
+          "addr0: %0d\n", addr0,
+          "SIZE: %0d", SIZE
+        );
+    end
+  `endif
+endmodule
+
+/**
+ * Core primitives for Calyx.
+ * Implements core primitives used by the compiler.
+ *
+ * Conventions:
+ * - All parameter names must be SNAKE_CASE and all caps.
+ * - Port names must be snake_case, no caps.
+ */
+`default_nettype none
+
+module std_slice #(
+    parameter IN_WIDTH  = 32,
+    parameter OUT_WIDTH = 32
+) (
+   input wire                   logic [ IN_WIDTH-1:0] in,
+   output logic [OUT_WIDTH-1:0] out
+);
+  assign out = in[OUT_WIDTH-1:0];
+
+  `ifdef VERILATOR
+    always_comb begin
+      if (IN_WIDTH < OUT_WIDTH)
+        $error(
+          "std_slice: Input width less than output width\n",
+          "IN_WIDTH: %0d", IN_WIDTH,
+          "OUT_WIDTH: %0d", OUT_WIDTH
+        );
+    end
+  `endif
+endmodule
+
+module std_pad #(
+    parameter IN_WIDTH  = 32,
+    parameter OUT_WIDTH = 32
+) (
+   input wire logic [IN_WIDTH-1:0]  in,
+   output logic     [OUT_WIDTH-1:0] out
+);
+  localparam EXTEND = OUT_WIDTH - IN_WIDTH;
+  assign out = { {EXTEND {1'b0}}, in};
+
+  `ifdef VERILATOR
+    always_comb begin
+      if (IN_WIDTH > OUT_WIDTH)
+        $error(
+          "std_pad: Output width less than input width\n",
+          "IN_WIDTH: %0d", IN_WIDTH,
+          "OUT_WIDTH: %0d", OUT_WIDTH
+        );
+    end
+  `endif
+endmodule
+
+module std_cat #(
+  parameter LEFT_WIDTH  = 32,
+  parameter RIGHT_WIDTH = 32,
+  parameter OUT_WIDTH = 64
+) (
+  input wire logic [LEFT_WIDTH-1:0] left,
+  input wire logic [RIGHT_WIDTH-1:0] right,
+  output logic [OUT_WIDTH-1:0] out
+);
+  assign out = {left, right};
+
+  `ifdef VERILATOR
+    always_comb begin
+      if (LEFT_WIDTH + RIGHT_WIDTH != OUT_WIDTH)
+        $error(
+          "std_cat: Output width must equal sum of input widths\n",
+          "LEFT_WIDTH: %0d", LEFT_WIDTH,
+          "RIGHT_WIDTH: %0d", RIGHT_WIDTH,
+          "OUT_WIDTH: %0d", OUT_WIDTH
+        );
+    end
+  `endif
+endmodule
+
+module std_not #(
+    parameter WIDTH = 32
+) (
+   input wire               logic [WIDTH-1:0] in,
+   output logic [WIDTH-1:0] out
+);
+  assign out = ~in;
+endmodule
+
+module std_and #(
+    parameter WIDTH = 32
+) (
+   input wire               logic [WIDTH-1:0] left,
+   input wire               logic [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+  assign out = left & right;
+endmodule
+
+module std_or #(
+    parameter WIDTH = 32
+) (
+   input wire               logic [WIDTH-1:0] left,
+   input wire               logic [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+  assign out = left | right;
+endmodule
+
+module std_xor #(
+    parameter WIDTH = 32
+) (
+   input wire               logic [WIDTH-1:0] left,
+   input wire               logic [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+  assign out = left ^ right;
+endmodule
+
+module std_sub #(
+    parameter WIDTH = 32
+) (
+   input wire               logic [WIDTH-1:0] left,
+   input wire               logic [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+  assign out = left - right;
+endmodule
+
+module std_gt #(
+    parameter WIDTH = 32
+) (
+   input wire   logic [WIDTH-1:0] left,
+   input wire   logic [WIDTH-1:0] right,
+   output logic out
+);
+  assign out = left > right;
+endmodule
+
+module std_lt #(
+    parameter WIDTH = 32
+) (
+   input wire   logic [WIDTH-1:0] left,
+   input wire   logic [WIDTH-1:0] right,
+   output logic out
+);
+  assign out = left < right;
+endmodule
+
+module std_eq #(
+    parameter WIDTH = 32
+) (
+   input wire   logic [WIDTH-1:0] left,
+   input wire   logic [WIDTH-1:0] right,
+   output logic out
+);
+  assign out = left == right;
+endmodule
+
+module std_neq #(
+    parameter WIDTH = 32
+) (
+   input wire   logic [WIDTH-1:0] left,
+   input wire   logic [WIDTH-1:0] right,
+   output logic out
+);
+  assign out = left != right;
+endmodule
+
+module std_ge #(
+    parameter WIDTH = 32
+) (
+    input wire   logic [WIDTH-1:0] left,
+    input wire   logic [WIDTH-1:0] right,
+    output logic out
+);
+  assign out = left >= right;
+endmodule
+
+module std_le #(
+    parameter WIDTH = 32
+) (
+   input wire   logic [WIDTH-1:0] left,
+   input wire   logic [WIDTH-1:0] right,
+   output logic out
+);
+  assign out = left <= right;
+endmodule
+
+module std_lsh #(
+    parameter WIDTH = 32
+) (
+   input wire               logic [WIDTH-1:0] left,
+   input wire               logic [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+  assign out = left << right;
+endmodule
+
+module std_rsh #(
+    parameter WIDTH = 32
+) (
+   input wire               logic [WIDTH-1:0] left,
+   input wire               logic [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+  assign out = left >> right;
+endmodule
+
+/// this primitive is intended to be used
+/// for lowering purposes (not in source programs)
+module std_mux #(
+    parameter WIDTH = 32
+) (
+   input wire               logic cond,
+   input wire               logic [WIDTH-1:0] tru,
+   input wire               logic [WIDTH-1:0] fal,
+   output logic [WIDTH-1:0] out
+);
+  assign out = cond ? tru : fal;
+endmodule
+
+`default_nettype wire
+
+module undef #(
+    parameter WIDTH = 32
+) (
+   output logic [WIDTH-1:0] out
+);
+assign out = 'x;
+endmodule
+
+module std_const #(
+    parameter WIDTH = 32,
+    parameter VALUE = 32
+) (
+   output logic [WIDTH-1:0] out
+);
+assign out = VALUE;
+endmodule
+
+module std_wire #(
+    parameter WIDTH = 32
+) (
+   input logic [WIDTH-1:0] in,
+   output logic [WIDTH-1:0] out
+);
+assign out = in;
+endmodule
+
+module std_add #(
+    parameter WIDTH = 32
+) (
+   input logic [WIDTH-1:0] left,
+   input logic [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+assign out = left + right;
+endmodule
+
+module std_reg #(
+    parameter WIDTH = 32
+) (
+   input logic [WIDTH-1:0] in,
+   input logic write_en,
+   input logic clk,
+   input logic reset,
+   output logic [WIDTH-1:0] out,
+   output logic done
+);
+always_ff @(posedge clk) begin
+    if (reset) begin
+       out <= 0;
+       done <= 0;
+    end else if (write_en) begin
+      out <= in;
+      done <= 1'd1;
+    end else done <= 1'd0;
+  end
+endmodule

--- a/fud2/data/tb.sv
+++ b/fud2/data/tb.sv
@@ -1,0 +1,77 @@
+module TOP;
+
+// Signals for the main module.
+logic go, done, clk, reset;
+main #() main (
+  .go(go),
+  .clk(clk),
+  .reset(reset),
+  .done(done)
+);
+
+localparam RESET_CYCLES = 3;
+
+// Cycle counter. Make this signed to catch errors with cycle simulation
+// counts.
+logic signed [63:0] cycle_count;
+
+always_ff @(posedge clk) begin
+  cycle_count <= cycle_count + 1;
+end
+
+always_ff @(posedge clk) begin
+  // Reset the design for a few cycles
+  if (cycle_count < RESET_CYCLES) begin
+    reset <= 1;
+    go <= 0;
+  end else begin
+    reset <= 0;
+    go <= 1;
+  end
+end
+
+// Output location of the VCD file
+string OUT;
+// Disable VCD tracing
+int NOTRACE;
+// Maximum number of cycles to simulate
+longint CYCLE_LIMIT;
+// Dummy variable to track value returned by $value$plusargs
+int CODE;
+
+initial begin
+  CODE = $value$plusargs("OUT=%s", OUT);
+  CODE = $value$plusargs("CYCLE_LIMIT=%d", CYCLE_LIMIT);
+  if (CYCLE_LIMIT != 0) begin
+    $display("cycle limit set to %d", CYCLE_LIMIT);
+  end
+  CODE = $value$plusargs("NOTRACE=%d", NOTRACE);
+  if (NOTRACE == 0) begin
+    $display("VCD tracing enabled");
+    $dumpfile(OUT);
+    $dumpvars(0,main);
+  end else begin
+    $display("VCD tracing disabled");
+  end
+
+  // Initial values
+  go = 0;
+  clk = 0;
+  reset = 1;
+  cycle_count = 0;
+
+  forever begin
+    #10 clk = ~clk;
+    if (cycle_count > RESET_CYCLES && done == 1) begin
+      // Subtract 1 because the cycle counter is incremented at the end of the
+      // cycle.
+      $display("Simulated %d cycles", cycle_count - RESET_CYCLES - 1);
+      $finish;
+    end else if (cycle_count != 0 && cycle_count == CYCLE_LIMIT + RESET_CYCLES) begin
+      $display("reached limit of %d cycles", CYCLE_LIMIT);
+      $finish;
+    end
+  end
+end
+
+endmodule

--- a/fud2/data/xrt.ini
+++ b/fud2/data/xrt.ini
@@ -1,0 +1,4 @@
+[Runtime]
+runtime_log=xrt.log
+[Emulation]
+print_infos_in_console=true

--- a/fud2/data/xrt_trace.ini
+++ b/fud2/data/xrt_trace.ini
@@ -1,0 +1,7 @@
+[Runtime]
+runtime_log=xrt.log
+[Emulation]
+print_infos_in_console=true
+debug_mode=batch
+user_pre_sim_script=pre_sim.tcl
+user_post_sim_script=post_sim.tcl

--- a/fud2/fake/Cargo.toml
+++ b/fud2/fake/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "fake"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+argh.workspace = true
+cranelift-entity = "0.103.0"
+serde.workspace = true
+figment = { version = "0.10.12", features = ["toml"] }
+pathdiff = { version = "0.2.1", features = ["camino"] }
+camino = "1.1.6"
+anyhow.workspace = true

--- a/fud2/fake/src/cli.rs
+++ b/fud2/fake/src/cli.rs
@@ -101,7 +101,9 @@ fn from_state(driver: &Driver, args: &FakeArgs) -> anyhow::Result<StateRef> {
 
 fn to_state(driver: &Driver, args: &FakeArgs) -> anyhow::Result<StateRef> {
     match &args.to {
-        Some(name) => driver.get_state(name).ok_or(anyhow!("unknown --to state")),
+        Some(name) => {
+            driver.get_state(name).ok_or(anyhow!("unknown --to state"))
+        }
         None => match &args.output {
             Some(out) => driver
                 .guess_state(out)

--- a/fud2/fake/src/cli.rs
+++ b/fud2/fake/src/cli.rs
@@ -1,0 +1,185 @@
+use crate::driver::{Driver, Request, StateRef};
+use crate::run::Run;
+use anyhow::{anyhow, bail};
+use argh::FromArgs;
+use camino::{Utf8Path, Utf8PathBuf};
+use std::fmt::Display;
+use std::str::FromStr;
+
+enum Mode {
+    EmitNinja,
+    ShowPlan,
+    ShowDot,
+    Generate,
+    Run,
+}
+
+impl FromStr for Mode {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "emit" => Ok(Mode::EmitNinja),
+            "plan" => Ok(Mode::ShowPlan),
+            "gen" => Ok(Mode::Generate),
+            "run" => Ok(Mode::Run),
+            "dot" => Ok(Mode::ShowDot),
+            _ => Err("unknown mode".to_string()),
+        }
+    }
+}
+
+impl Display for Mode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Mode::EmitNinja => write!(f, "emit"),
+            Mode::ShowPlan => write!(f, "plan"),
+            Mode::Generate => write!(f, "gen"),
+            Mode::Run => write!(f, "run"),
+            Mode::ShowDot => write!(f, "dot"),
+        }
+    }
+}
+
+#[derive(FromArgs)]
+/// A generic compiler driver.
+struct FakeArgs {
+    /// the input file
+    #[argh(positional)]
+    input: Option<Utf8PathBuf>,
+
+    /// the output file
+    #[argh(option, short = 'o')]
+    output: Option<Utf8PathBuf>,
+
+    /// the state to start from
+    #[argh(option)]
+    from: Option<String>,
+
+    /// the state to produce
+    #[argh(option)]
+    to: Option<String>,
+
+    /// execution mode (run, plan, emit, gen, dot)
+    #[argh(option, short = 'm', default = "Mode::Run")]
+    mode: Mode,
+
+    /// working directory for the build
+    #[argh(option)]
+    dir: Option<Utf8PathBuf>,
+
+    /// in run mode, keep the temporary directory
+    #[argh(switch)]
+    keep: Option<bool>,
+
+    /// set a configuration variable (key=value)
+    #[argh(option, short = 's')]
+    set: Vec<String>,
+
+    /// route the conversion through a specific operation
+    #[argh(option)]
+    through: Vec<String>,
+
+    /// verbose ouput
+    #[argh(switch, short = 'v')]
+    verbose: Option<bool>,
+}
+
+fn from_state(driver: &Driver, args: &FakeArgs) -> anyhow::Result<StateRef> {
+    match &args.from {
+        Some(name) => driver
+            .get_state(name)
+            .ok_or(anyhow!("unknown --from state")),
+        None => match args.input {
+            Some(ref input) => driver
+                .guess_state(input)
+                .ok_or(anyhow!("could not infer input state")),
+            None => bail!("specify an input file or use --from"),
+        },
+    }
+}
+
+fn to_state(driver: &Driver, args: &FakeArgs) -> anyhow::Result<StateRef> {
+    match &args.to {
+        Some(name) => driver.get_state(name).ok_or(anyhow!("unknown --to state")),
+        None => match &args.output {
+            Some(out) => driver
+                .guess_state(out)
+                .ok_or(anyhow!("could not infer output state")),
+            None => Err(anyhow!("specify an output file or use --to")),
+        },
+    }
+}
+
+fn get_request(driver: &Driver, args: &FakeArgs) -> anyhow::Result<Request> {
+    // The default working directory (if not specified) depends on the mode.
+    let default_workdir = driver.default_workdir();
+    let workdir = args.dir.as_deref().unwrap_or_else(|| match args.mode {
+        Mode::Generate | Mode::Run => default_workdir.as_ref(),
+        _ => Utf8Path::new("."),
+    });
+
+    // Find all the operations to route through.
+    let through: Result<Vec<_>, _> = args
+        .through
+        .iter()
+        .map(|s| {
+            driver
+                .get_op(s)
+                .ok_or(anyhow!("unknown --through op {}", s))
+        })
+        .collect();
+
+    Ok(Request {
+        start_file: args.input.clone(),
+        start_state: from_state(driver, args)?,
+        end_file: args.output.clone(),
+        end_state: to_state(driver, args)?,
+        through: through?,
+        workdir: workdir.into(),
+    })
+}
+
+pub fn cli(driver: &Driver) -> anyhow::Result<()> {
+    let args: FakeArgs = argh::from_env();
+
+    // Make a plan.
+    let req = get_request(driver, &args)?;
+    let workdir = req.workdir.clone();
+    let plan = driver.plan(req).ok_or(anyhow!("could not find path"))?;
+
+    // Configure.
+    let mut run = Run::new(driver, plan);
+
+    // Override some global config options.
+    if let Some(keep) = args.keep {
+        run.global_config.keep_build_dir = keep;
+    }
+    if let Some(verbose) = args.verbose {
+        run.global_config.verbose = verbose;
+    }
+
+    // Use `--set` arguments to override configuration values.
+    for set in args.set {
+        let mut parts = set.splitn(2, '=');
+        let key = parts.next().unwrap();
+        let value = parts
+            .next()
+            .ok_or(anyhow!("--set arguments must be in key=value form"))?;
+        let dict = figment::util::nest(key, value.into());
+        run.config_data = run
+            .config_data
+            .merge(figment::providers::Serialized::defaults(dict));
+    }
+
+    // Execute.
+    match args.mode {
+        Mode::ShowPlan => run.show(),
+        Mode::ShowDot => run.show_dot(),
+        Mode::EmitNinja => run.emit_to_stdout()?,
+        Mode::Generate => run.emit_to_dir(&workdir)?,
+        Mode::Run => run.emit_and_run(&workdir)?,
+    }
+
+    Ok(())
+}

--- a/fud2/fake/src/config.rs
+++ b/fud2/fake/src/config.rs
@@ -1,0 +1,41 @@
+use figment::{
+    providers::{Format, Serialized, Toml},
+    Figment,
+};
+use serde::{Deserialize, Serialize};
+use std::{env, path::Path};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GlobalConfig {
+    /// The `ninja` command to execute in `run` mode.
+    pub ninja: String,
+
+    /// Never delete the temporary directory used to execute ninja in `run` mode.
+    pub keep_build_dir: bool,
+
+    /// Enable verbose output.
+    pub verbose: bool,
+}
+
+impl Default for GlobalConfig {
+    fn default() -> Self {
+        Self {
+            ninja: "ninja".to_string(),
+            keep_build_dir: false,
+            verbose: false,
+        }
+    }
+}
+
+/// Load configuration data from the standard config file location.
+pub(crate) fn load_config(name: &str) -> Figment {
+    // The configuration is usually at `~/.config/driver_name.toml`.
+    let config_base = env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
+        let home = env::var("HOME").expect("$HOME not set");
+        home + "/.config"
+    });
+    let config_path = Path::new(&config_base).join(name).with_extension("toml");
+
+    // Use our defaults, overridden by the TOML config file.
+    Figment::from(Serialized::defaults(GlobalConfig::default())).merge(Toml::file(config_path))
+}

--- a/fud2/fake/src/config.rs
+++ b/fud2/fake/src/config.rs
@@ -37,5 +37,6 @@ pub(crate) fn load_config(name: &str) -> Figment {
     let config_path = Path::new(&config_base).join(name).with_extension("toml");
 
     // Use our defaults, overridden by the TOML config file.
-    Figment::from(Serialized::defaults(GlobalConfig::default())).merge(Toml::file(config_path))
+    Figment::from(Serialized::defaults(GlobalConfig::default()))
+        .merge(Toml::file(config_path))
 }

--- a/fud2/fake/src/driver.rs
+++ b/fud2/fake/src/driver.rs
@@ -89,7 +89,11 @@ pub struct Driver {
 impl Driver {
     /// Find a chain of Operations from the `start` state to the `end`, which may be a state or the
     /// final operation in the chain.
-    fn find_path_segment(&self, start: StateRef, end: Destination) -> Option<Vec<OpRef>> {
+    fn find_path_segment(
+        &self,
+        start: StateRef,
+        end: Destination,
+    ) -> Option<Vec<OpRef>> {
         // Our start state is the input.
         let mut visited = SecondaryMap::<StateRef, bool>::new();
         visited[start] = true;
@@ -158,13 +162,15 @@ impl Driver {
 
         // Build path segments through each through required operation.
         for op in through {
-            let segment = self.find_path_segment(cur_state, Destination::Op(*op))?;
+            let segment =
+                self.find_path_segment(cur_state, Destination::Op(*op))?;
             op_path.extend(segment);
             cur_state = self.ops[*op].output;
         }
 
         // Build the final path segment to the destination state.
-        let segment = self.find_path_segment(cur_state, Destination::State(end))?;
+        let segment =
+            self.find_path_segment(cur_state, Destination::State(end))?;
         op_path.extend(segment);
 
         Some(op_path)
@@ -183,7 +189,8 @@ impl Driver {
 
     pub fn plan(&self, req: Request) -> Option<Plan> {
         // Find a path through the states.
-        let path = self.find_path(req.start_state, req.end_state, &req.through)?;
+        let path =
+            self.find_path(req.start_state, req.end_state, &req.through)?;
 
         let mut steps: Vec<(OpRef, Utf8PathBuf)> = vec![];
 
@@ -289,7 +296,11 @@ impl DriverBuilder {
         })
     }
 
-    pub fn add_setup<T: run::EmitSetup + 'static>(&mut self, name: &str, emit: T) -> SetupRef {
+    pub fn add_setup<T: run::EmitSetup + 'static>(
+        &mut self,
+        name: &str,
+        emit: T,
+    ) -> SetupRef {
         self.setups.push(Setup {
             name: name.into(),
             emit: Box::new(emit),

--- a/fud2/fake/src/driver.rs
+++ b/fud2/fake/src/driver.rs
@@ -1,0 +1,389 @@
+use crate::run;
+use camino::{Utf8Path, Utf8PathBuf};
+use cranelift_entity::{entity_impl, PrimaryMap, SecondaryMap};
+use pathdiff::diff_utf8_paths;
+
+/// A State is a type of file that Operations produce or consume.
+pub struct State {
+    /// The name of the state, for the UI.
+    pub name: String,
+
+    /// The file extensions that this state can be represented by.
+    ///
+    /// The first extension in the list is used when generating a new filename for the state. If
+    /// the list is empty, this is a "pseudo-state" that doesn't correspond to an actual file.
+    /// Pseudo-states can only be final outputs; they are appropraite for representing actions that
+    /// interact directly with the user, for example.
+    pub extensions: Vec<String>,
+}
+
+/// A reference to a State.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct StateRef(u32);
+entity_impl!(StateRef, "state");
+
+/// An Operation transforms files from one State to another.
+pub struct Operation {
+    pub name: String,
+    pub input: StateRef,
+    pub output: StateRef,
+    pub setups: Vec<SetupRef>,
+    pub emit: Box<dyn run::EmitBuild>,
+}
+
+/// A reference to an Operation.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct OpRef(u32);
+entity_impl!(OpRef, "op");
+
+/// A Setup runs at configuration time and produces Ninja machinery for Operations.
+pub struct Setup {
+    pub name: String,
+    pub emit: Box<dyn run::EmitSetup>,
+}
+
+/// A reference to a Setup.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct SetupRef(u32);
+entity_impl!(SetupRef, "setup");
+
+impl State {
+    /// Check whether a filename extension indicates this state.
+    fn ext_matches(&self, ext: &str) -> bool {
+        self.extensions.iter().any(|e| e == ext)
+    }
+
+    /// Is this a "pseudo-state": doesn't correspond to an actual file, and must be an output state?
+    fn is_pseudo(&self) -> bool {
+        self.extensions.is_empty()
+    }
+}
+
+/// Get a version of `path` that works when the working directory is `base`. This is
+/// opportunistically a relative path, but we can always fall back to an absolute path to make sure
+/// the path still works.
+pub fn relative_path(path: &Utf8Path, base: &Utf8Path) -> Utf8PathBuf {
+    match diff_utf8_paths(path, base) {
+        Some(p) => p,
+        None => path
+            .canonicalize_utf8()
+            .expect("could not get absolute path"),
+    }
+}
+
+#[derive(PartialEq)]
+enum Destination {
+    State(StateRef),
+    Op(OpRef),
+}
+
+/// A Driver encapsulates a set of States and the Operations that can transform between them. It
+/// contains all the machinery to perform builds in a given ecosystem.
+pub struct Driver {
+    pub name: String,
+    pub setups: PrimaryMap<SetupRef, Setup>,
+    pub states: PrimaryMap<StateRef, State>,
+    pub ops: PrimaryMap<OpRef, Operation>,
+}
+
+impl Driver {
+    /// Find a chain of Operations from the `start` state to the `end`, which may be a state or the
+    /// final operation in the chain.
+    fn find_path_segment(&self, start: StateRef, end: Destination) -> Option<Vec<OpRef>> {
+        // Our start state is the input.
+        let mut visited = SecondaryMap::<StateRef, bool>::new();
+        visited[start] = true;
+
+        // Build the incoming edges for each vertex.
+        let mut breadcrumbs = SecondaryMap::<StateRef, Option<OpRef>>::new();
+
+        // Breadth-first search.
+        let mut state_queue: Vec<StateRef> = vec![start];
+        while !state_queue.is_empty() {
+            let cur_state = state_queue.remove(0);
+
+            // Finish when we reach the goal vertex.
+            if end == Destination::State(cur_state) {
+                break;
+            }
+
+            // Traverse any edge from the current state to an unvisited state.
+            for (op_ref, op) in self.ops.iter() {
+                if op.input == cur_state && !visited[op.output] {
+                    state_queue.push(op.output);
+                    visited[op.output] = true;
+                    breadcrumbs[op.output] = Some(op_ref);
+                }
+
+                // Finish when we reach the goal edge.
+                if end == Destination::Op(op_ref) {
+                    break;
+                }
+            }
+        }
+
+        // Traverse the breadcrumbs backward to build up the path back from output to input.
+        let mut op_path: Vec<OpRef> = vec![];
+        let mut cur_state = match end {
+            Destination::State(state) => state,
+            Destination::Op(op) => {
+                op_path.push(op);
+                self.ops[op].input
+            }
+        };
+        while cur_state != start {
+            match breadcrumbs[cur_state] {
+                Some(op) => {
+                    op_path.push(op);
+                    cur_state = self.ops[op].input;
+                }
+                None => return None,
+            }
+        }
+        op_path.reverse();
+
+        Some(op_path)
+    }
+
+    /// Find a chain of operations from the `start` state to the `end` state, passing through each
+    /// `through` operation in order.
+    pub fn find_path(
+        &self,
+        start: StateRef,
+        end: StateRef,
+        through: &[OpRef],
+    ) -> Option<Vec<OpRef>> {
+        let mut cur_state = start;
+        let mut op_path: Vec<OpRef> = vec![];
+
+        // Build path segments through each through required operation.
+        for op in through {
+            let segment = self.find_path_segment(cur_state, Destination::Op(*op))?;
+            op_path.extend(segment);
+            cur_state = self.ops[*op].output;
+        }
+
+        // Build the final path segment to the destination state.
+        let segment = self.find_path_segment(cur_state, Destination::State(end))?;
+        op_path.extend(segment);
+
+        Some(op_path)
+    }
+
+    /// Generate a filename with an extension appropriate for the given State.
+    fn gen_name(&self, stem: &str, state: StateRef) -> Utf8PathBuf {
+        let state = &self.states[state];
+        if state.is_pseudo() {
+            Utf8PathBuf::from(format!("_pseudo_{}", state.name))
+        } else {
+            // TODO avoid collisions in case we reuse extensions...
+            Utf8PathBuf::from(stem).with_extension(&state.extensions[0])
+        }
+    }
+
+    pub fn plan(&self, req: Request) -> Option<Plan> {
+        // Find a path through the states.
+        let path = self.find_path(req.start_state, req.end_state, &req.through)?;
+
+        let mut steps: Vec<(OpRef, Utf8PathBuf)> = vec![];
+
+        // Get the initial input filename and the stem to use to generate all intermediate filenames.
+        let (stdin, start_file) = match req.start_file {
+            Some(path) => (false, relative_path(&path, &req.workdir)),
+            None => (true, "stdin".into()),
+        };
+        let stem = start_file.file_stem().unwrap();
+
+        // Generate filenames for each step.
+        steps.extend(path.into_iter().map(|op| {
+            let filename = self.gen_name(stem, self.ops[op].output);
+            (op, filename)
+        }));
+
+        // If we have a specified output filename, use that instead of the generated one.
+        let stdout = if let Some(end_file) = req.end_file {
+            // TODO Can we just avoid generating the unused filename in the first place?
+            let last_step = steps.last_mut().expect("no steps");
+            last_step.1 = relative_path(&end_file, &req.workdir);
+            false
+        } else {
+            // Print to stdout if the last state is a real (non-pseudo) state.
+            !self.states[req.end_state].is_pseudo()
+        };
+
+        Some(Plan {
+            start: start_file,
+            steps,
+            workdir: req.workdir,
+            stdin,
+            stdout,
+        })
+    }
+
+    pub fn guess_state(&self, path: &Utf8Path) -> Option<StateRef> {
+        let ext = path.extension()?;
+        self.states
+            .iter()
+            .find(|(_, state_data)| state_data.ext_matches(ext))
+            .map(|(state, _)| state)
+    }
+
+    pub fn get_state(&self, name: &str) -> Option<StateRef> {
+        self.states
+            .iter()
+            .find(|(_, state_data)| state_data.name == name)
+            .map(|(state, _)| state)
+    }
+
+    pub fn get_op(&self, name: &str) -> Option<OpRef> {
+        self.ops
+            .iter()
+            .find(|(_, op_data)| op_data.name == name)
+            .map(|(op, _)| op)
+    }
+
+    /// The working directory to use when running a build.
+    pub fn default_workdir(&self) -> Utf8PathBuf {
+        format!(".{}", &self.name).into()
+    }
+}
+
+pub struct DriverBuilder {
+    name: String,
+    setups: PrimaryMap<SetupRef, Setup>,
+    states: PrimaryMap<StateRef, State>,
+    ops: PrimaryMap<OpRef, Operation>,
+}
+
+impl DriverBuilder {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            setups: Default::default(),
+            states: Default::default(),
+            ops: Default::default(),
+        }
+    }
+
+    pub fn state(&mut self, name: &str, extensions: &[&str]) -> StateRef {
+        self.states.push(State {
+            name: name.to_string(),
+            extensions: extensions.iter().map(|s| s.to_string()).collect(),
+        })
+    }
+
+    fn add_op<T: run::EmitBuild + 'static>(
+        &mut self,
+        name: &str,
+        setups: &[SetupRef],
+        input: StateRef,
+        output: StateRef,
+        emit: T,
+    ) -> OpRef {
+        self.ops.push(Operation {
+            name: name.into(),
+            setups: setups.into(),
+            input,
+            output,
+            emit: Box::new(emit),
+        })
+    }
+
+    pub fn add_setup<T: run::EmitSetup + 'static>(&mut self, name: &str, emit: T) -> SetupRef {
+        self.setups.push(Setup {
+            name: name.into(),
+            emit: Box::new(emit),
+        })
+    }
+
+    pub fn setup(&mut self, name: &str, func: run::EmitSetupFn) -> SetupRef {
+        self.add_setup(name, func)
+    }
+
+    pub fn op(
+        &mut self,
+        name: &str,
+        setups: &[SetupRef],
+        input: StateRef,
+        output: StateRef,
+        build: run::EmitBuildFn,
+    ) -> OpRef {
+        self.add_op(name, setups, input, output, build)
+    }
+
+    pub fn rule(
+        &mut self,
+        setups: &[SetupRef],
+        input: StateRef,
+        output: StateRef,
+        rule_name: &str,
+    ) -> OpRef {
+        self.add_op(
+            rule_name,
+            setups,
+            input,
+            output,
+            run::EmitRuleBuild {
+                rule_name: rule_name.to_string(),
+            },
+        )
+    }
+
+    pub fn build(self) -> Driver {
+        Driver {
+            name: self.name,
+            setups: self.setups,
+            states: self.states,
+            ops: self.ops,
+        }
+    }
+}
+
+/// A request to the Driver directing it what to build.
+#[derive(Debug)]
+pub struct Request {
+    /// The input format.
+    pub start_state: StateRef,
+
+    /// The output format to produce.
+    pub end_state: StateRef,
+
+    /// The filename to read the input from, or None to read from stdin.
+    pub start_file: Option<Utf8PathBuf>,
+
+    /// The filename to write the output to, or None to print to stdout.
+    pub end_file: Option<Utf8PathBuf>,
+
+    /// A sequence of operators to route the conversion through.
+    pub through: Vec<OpRef>,
+
+    /// The working directory for the build.
+    pub workdir: Utf8PathBuf,
+}
+
+#[derive(Debug)]
+pub struct Plan {
+    /// The input to the first step.
+    pub start: Utf8PathBuf,
+
+    /// The chain of operations to run and each step's output file.
+    pub steps: Vec<(OpRef, Utf8PathBuf)>,
+
+    /// The directory that the build will happen in.
+    pub workdir: Utf8PathBuf,
+
+    /// Read the first input from stdin.
+    pub stdin: bool,
+
+    /// Write the final output to stdout.
+    pub stdout: bool,
+}
+
+impl Plan {
+    pub fn end(&self) -> &Utf8Path {
+        match self.steps.last() {
+            Some((_, path)) => path,
+            None => &self.start,
+        }
+    }
+}

--- a/fud2/fake/src/lib.rs
+++ b/fud2/fake/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod cli;
+pub mod config;
+pub mod driver;
+pub mod run;
+
+pub use driver::{Driver, DriverBuilder};

--- a/fud2/fake/src/run.rs
+++ b/fud2/fake/src/run.rs
@@ -1,0 +1,351 @@
+use crate::config;
+use crate::driver::{relative_path, Driver, OpRef, Plan, SetupRef, StateRef};
+use camino::{Utf8Path, Utf8PathBuf};
+use std::collections::{HashMap, HashSet};
+use std::io::Write;
+use std::process::Command;
+
+/// An error that arises while emitting the Ninja file.
+#[derive(Debug)]
+pub enum EmitError {
+    Io(std::io::Error),
+    MissingConfig(String),
+}
+
+impl From<std::io::Error> for EmitError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl std::fmt::Display for EmitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            EmitError::Io(e) => write!(f, "{}", e),
+            EmitError::MissingConfig(s) => write!(f, "missing required config key: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for EmitError {}
+
+pub type EmitResult = std::result::Result<(), EmitError>;
+
+/// Code to emit a Ninja `build` command.
+pub trait EmitBuild {
+    fn build(&self, emitter: &mut Emitter, input: &str, output: &str) -> EmitResult;
+}
+
+pub type EmitBuildFn = fn(&mut Emitter, &str, &str) -> EmitResult;
+
+impl EmitBuild for EmitBuildFn {
+    fn build(&self, emitter: &mut Emitter, input: &str, output: &str) -> EmitResult {
+        self(emitter, input, output)
+    }
+}
+
+// TODO make this unnecessary...
+/// A simple `build` emitter that just runs a Ninja rule.
+pub struct EmitRuleBuild {
+    pub rule_name: String,
+}
+
+impl EmitBuild for EmitRuleBuild {
+    fn build(&self, emitter: &mut Emitter, input: &str, output: &str) -> EmitResult {
+        emitter.build(&self.rule_name, input, output)?;
+        Ok(())
+    }
+}
+
+/// Code to emit Ninja code at the setup stage.
+pub trait EmitSetup {
+    fn setup(&self, emitter: &mut Emitter) -> EmitResult;
+}
+
+pub type EmitSetupFn = fn(&mut Emitter) -> EmitResult;
+
+impl EmitSetup for EmitSetupFn {
+    fn setup(&self, emitter: &mut Emitter) -> EmitResult {
+        self(emitter)
+    }
+}
+
+pub struct Run<'a> {
+    pub driver: &'a Driver,
+    pub plan: Plan,
+    pub config_data: figment::Figment,
+    pub global_config: config::GlobalConfig,
+}
+
+impl<'a> Run<'a> {
+    pub fn new(driver: &'a Driver, plan: Plan) -> Self {
+        let config_data = config::load_config(&driver.name);
+        let global_config: config::GlobalConfig =
+            config_data.extract().expect("failed to load config");
+        Self {
+            driver,
+            plan,
+            config_data,
+            global_config,
+        }
+    }
+
+    /// Just print the plan for debugging purposes.
+    pub fn show(self) {
+        if self.plan.stdin {
+            println!("(stdin) -> {}", self.plan.start);
+        } else {
+            println!("start: {}", self.plan.start);
+        }
+        for (op, file) in self.plan.steps {
+            println!("{}: {} -> {}", op, self.driver.ops[op].name, file);
+        }
+        if self.plan.stdout {
+            println!("-> (stdout)");
+        }
+    }
+
+    /// Print a GraphViz representation of the plan.
+    pub fn show_dot(self) {
+        println!("digraph plan {{");
+        println!("  rankdir=LR;");
+        println!("  node[shape=box];");
+
+        // Record the states and ops that are actually used in the plan.
+        let mut states: HashMap<StateRef, String> = HashMap::new();
+        let mut ops: HashSet<OpRef> = HashSet::new();
+        let first_op = self.plan.steps[0].0;
+        states.insert(self.driver.ops[first_op].input, self.plan.start.to_string());
+        for (op, file) in &self.plan.steps {
+            states.insert(self.driver.ops[*op].output, file.to_string());
+            ops.insert(*op);
+        }
+
+        // Show all states.
+        for (state_ref, state) in self.driver.states.iter() {
+            print!("  {} [", state_ref);
+            if let Some(filename) = states.get(&state_ref) {
+                print!(
+                    "label=\"{}\n{}\" penwidth=3 fillcolor=gray style=filled",
+                    state.name, filename
+                );
+            } else {
+                print!("label=\"{}\"", state.name);
+            }
+            println!("];");
+        }
+
+        // Show all operations.
+        for (op_ref, op) in self.driver.ops.iter() {
+            print!("  {} -> {} [label=\"{}\"", op.input, op.output, op.name);
+            if ops.contains(&op_ref) {
+                print!(" penwidth=3");
+            }
+            println!("];");
+        }
+
+        println!("}}");
+    }
+
+    /// Print the `build.ninja` file to stdout.
+    pub fn emit_to_stdout(&self) -> EmitResult {
+        self.emit(std::io::stdout())
+    }
+
+    /// Ensure that a directory exists and write `build.ninja` inside it.
+    pub fn emit_to_dir(&self, dir: &Utf8Path) -> EmitResult {
+        std::fs::create_dir_all(dir)?;
+        let ninja_path = dir.join("build.ninja");
+        let ninja_file = std::fs::File::create(ninja_path)?;
+
+        self.emit(ninja_file)
+    }
+
+    /// Emit `build.ninja` to a temporary directory and then actually execute ninja.
+    pub fn emit_and_run(&self, dir: &Utf8Path) -> EmitResult {
+        // Emit the Ninja file.
+        let stale_dir = dir.exists();
+        self.emit_to_dir(dir)?;
+
+        // Capture stdin.
+        if self.plan.stdin {
+            let stdin_file = std::fs::File::create(self.plan.workdir.join(&self.plan.start))?;
+            std::io::copy(
+                &mut std::io::stdin(),
+                &mut std::io::BufWriter::new(stdin_file),
+            )?;
+        }
+
+        // Run `ninja` in the working directory.
+        let mut cmd = Command::new(&self.global_config.ninja);
+        cmd.current_dir(dir);
+        if self.plan.stdout && !self.global_config.verbose {
+            // When we're printing to stdout, suppress Ninja's output by default.
+            cmd.stdout(std::process::Stdio::null());
+        }
+        cmd.status()?;
+
+        // Emit stdout.
+        if self.plan.stdout {
+            let stdout_file = std::fs::File::open(self.plan.workdir.join(self.plan.end()))?;
+            std::io::copy(
+                &mut std::io::BufReader::new(stdout_file),
+                &mut std::io::stdout(),
+            )?;
+        }
+
+        // Remove the temporary directory unless it already existed at the start *or* the user specified `--keep`.
+        if !self.global_config.keep_build_dir && !stale_dir {
+            std::fs::remove_dir_all(dir)?;
+        }
+
+        Ok(())
+    }
+
+    fn emit<T: Write + 'static>(&self, out: T) -> EmitResult {
+        let mut emitter = Emitter::new(out, self.config_data.clone(), self.plan.workdir.clone());
+
+        // Emit the setup for each operation used in the plan, only once.
+        let mut done_setups = HashSet::<SetupRef>::new();
+        for (op, _) in &self.plan.steps {
+            for setup in &self.driver.ops[*op].setups {
+                if done_setups.insert(*setup) {
+                    let setup = &self.driver.setups[*setup];
+                    writeln!(emitter.out, "# {}", setup.name)?;
+                    setup.emit.setup(&mut emitter)?;
+                    writeln!(emitter.out)?;
+                }
+            }
+        }
+
+        // Emit the build commands for each step in the plan.
+        emitter.comment("build targets")?;
+        let mut last_file = &self.plan.start;
+        for (op, out_file) in &self.plan.steps {
+            let op = &self.driver.ops[*op];
+            op.emit
+                .build(&mut emitter, last_file.as_str(), out_file.as_str())?;
+            last_file = out_file;
+        }
+        writeln!(emitter.out)?;
+
+        // Mark the last file as the default target.
+        writeln!(emitter.out, "default {}", last_file)?;
+
+        Ok(())
+    }
+}
+
+pub struct Emitter {
+    pub out: Box<dyn Write>,
+    pub config_data: figment::Figment,
+    pub workdir: Utf8PathBuf,
+}
+
+impl Emitter {
+    fn new<T: Write + 'static>(
+        out: T,
+        config_data: figment::Figment,
+        workdir: Utf8PathBuf,
+    ) -> Self {
+        Self {
+            out: Box::new(out),
+            config_data,
+            workdir,
+        }
+    }
+
+    /// Fetch a configuration value, or panic if it's missing.
+    pub fn config_val(&self, key: &str) -> Result<String, EmitError> {
+        self.config_data
+            .extract_inner::<String>(key)
+            .map_err(|_| EmitError::MissingConfig(key.to_string()))
+    }
+
+    /// Fetch a configuration value, using a default if it's missing.
+    pub fn config_or(&self, key: &str, default: &str) -> String {
+        self.config_data
+            .extract_inner::<String>(key)
+            .unwrap_or_else(|_| default.into())
+    }
+
+    /// Emit a Ninja variable declaration for `name` based on the configured value for `key`.
+    pub fn config_var(&mut self, name: &str, key: &str) -> EmitResult {
+        self.var(name, &self.config_val(key)?)?;
+        Ok(())
+    }
+
+    /// Emit a Ninja variable declaration for `name` based on the configured value for `key`, or a
+    /// default value if it's missing.
+    pub fn config_var_or(&mut self, name: &str, key: &str, default: &str) -> std::io::Result<()> {
+        self.var(name, &self.config_or(key, default))
+    }
+
+    /// Emit a Ninja variable declaration.
+    pub fn var(&mut self, name: &str, value: &str) -> std::io::Result<()> {
+        writeln!(self.out, "{} = {}", name, value)
+    }
+
+    /// Emit a Ninja rule definition.
+    pub fn rule(&mut self, name: &str, command: &str) -> std::io::Result<()> {
+        writeln!(self.out, "rule {}", name)?;
+        writeln!(self.out, "  command = {}", command)
+    }
+
+    /// Emit a simple Ninja build command with one dependency.
+    pub fn build(&mut self, rule: &str, input: &str, output: &str) -> std::io::Result<()> {
+        self.build_cmd(&[output], rule, &[input], &[])
+    }
+
+    /// Emit a Ninja build command.
+    pub fn build_cmd(
+        &mut self,
+        targets: &[&str],
+        rule: &str,
+        deps: &[&str],
+        implicit_deps: &[&str],
+    ) -> std::io::Result<()> {
+        write!(self.out, "build")?;
+        for target in targets {
+            write!(self.out, " {}", target)?;
+        }
+        write!(self.out, ": {}", rule)?;
+        for dep in deps {
+            write!(self.out, " {}", dep)?;
+        }
+        if !implicit_deps.is_empty() {
+            write!(self.out, " |")?;
+            for dep in implicit_deps {
+                write!(self.out, " {}", dep)?;
+            }
+        }
+        writeln!(self.out)?;
+        Ok(())
+    }
+
+    /// Emit a Ninja comment.
+    pub fn comment(&mut self, text: &str) -> std::io::Result<()> {
+        writeln!(self.out, "# {}", text)?;
+        Ok(())
+    }
+
+    /// Add a file to the build directory.
+    pub fn add_file(&self, name: &str, contents: &[u8]) -> std::io::Result<()> {
+        let path = self.workdir.join(name);
+        std::fs::write(path, contents)?;
+        Ok(())
+    }
+
+    /// Get a path to an external file. The input `path` may be relative to our original
+    /// invocation; we make it relative to the build directory so it can safely be used in the
+    /// Ninja file.
+    pub fn external_path(&self, path: &Utf8Path) -> Utf8PathBuf {
+        relative_path(path, &self.workdir)
+    }
+
+    /// Add a variable parameter to a rule or build command.
+    pub fn arg(&mut self, name: &str, value: &str) -> std::io::Result<()> {
+        writeln!(self.out, "  {} = {}", name, value)?;
+        Ok(())
+    }
+}

--- a/fud2/src/main.rs
+++ b/fud2/src/main.rs
@@ -1,0 +1,394 @@
+use fake::{
+    cli,
+    run::{EmitResult, Emitter},
+    Driver, DriverBuilder,
+};
+
+fn build_driver() -> Driver {
+    let mut bld = DriverBuilder::new("fud2");
+
+    // Calyx.
+    let calyx = bld.state("calyx", &["futil"]);
+    let verilog = bld.state("verilog", &["sv", "v"]);
+    let calyx_setup = bld.setup("Calyx compiler", |e| {
+        e.config_var("calyx_base", "calyx.base")?;
+        e.config_var_or("calyx_exe", "calyx.exe", "$calyx_base/target/debug/calyx")?;
+        e.rule(
+            "calyx",
+            "$calyx_exe -l $calyx_base -b $backend $args $in > $out",
+        )?;
+        Ok(())
+    });
+    bld.op(
+        "calyx-to-verilog",
+        &[calyx_setup],
+        calyx,
+        verilog,
+        |e, input, output| {
+            e.build_cmd(&[output], "calyx", &[input], &[])?;
+            e.arg("backend", "verilog")?;
+            Ok(())
+        },
+    );
+
+    // Dahlia.
+    let dahlia = bld.state("dahlia", &["fuse"]);
+    let dahlia_setup = bld.setup("Dahlia compiler", |e| {
+        e.var("dahlia_exec", "/Users/asampson/cu/research/dahlia/fuse")?;
+        e.rule(
+            "dahlia-to-calyx",
+            "$dahlia_exec -b calyx --lower -l error $in -o $out",
+        )?;
+        Ok(())
+    });
+    bld.rule(&[dahlia_setup], dahlia, calyx, "dahlia-to-calyx");
+
+    // MrXL.
+    let mrxl = bld.state("mrxl", &["mrxl"]);
+    let mrxl_setup = bld.setup("MrXL compiler", |e| {
+        e.var("mrxl_exec", "mrxl")?;
+        e.rule("mrxl-to-calyx", "$mrxl_exec $in > $out")?;
+        Ok(())
+    });
+    bld.rule(&[mrxl_setup], mrxl, calyx, "mrxl-to-calyx");
+
+    // Shared machinery for RTL simulators.
+    let dat = bld.state("dat", &["json"]);
+    let vcd = bld.state("vcd", &["vcd"]);
+    let simulator = bld.state("sim", &["exe"]);
+    let sim_setup = bld.setup("RTL simulation", |e| {
+        // Data conversion to and from JSON.
+        e.config_var_or("python", "python", "python3")?;
+        e.var(
+            "json_dat",
+            &format!("$python {}/json-dat.py", e.config_val("data")?),
+        )?;
+        e.rule("hex-data", "$json_dat --from-json $in $out")?;
+        e.rule("json-data", "$json_dat --to-json $out $in")?;
+
+        // The Verilog testbench.
+        e.var("testbench", &format!("{}/tb.sv", e.config_val("data")?))?;
+
+        // The input data file. `sim.data` is required.
+        let data_name = e.config_val("sim.data")?;
+        let data_path = e.external_path(data_name.as_ref());
+        e.var("sim_data", data_path.as_str())?;
+
+        // Produce the data directory.
+        e.var("datadir", "sim_data")?;
+        e.build("hex-data", "$sim_data", "$datadir")?;
+
+        // Rule for simulation execution.
+        e.rule(
+            "sim-run",
+            "./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle_limit $args > $out",
+        )?;
+
+        // More shared configuration.
+        e.config_var_or("cycle_limit", "sim.cycle_limit", "500000000")?;
+
+        Ok(())
+    });
+    bld.op(
+        "simulate",
+        &[sim_setup],
+        simulator,
+        dat,
+        |e, input, output| {
+            e.build_cmd(&["sim.log"], "sim-run", &[input, "$datadir"], &[])?;
+            e.arg("bin", input)?;
+            e.arg("args", "+NOTRACE=1")?;
+            e.build_cmd(&[output], "json-data", &["$datadir", "sim.log"], &[])?;
+            Ok(())
+        },
+    );
+    bld.op("trace", &[sim_setup], simulator, vcd, |e, input, output| {
+        e.build_cmd(&["sim.log", output], "sim-run", &[input, "$datadir"], &[])?;
+        e.arg("bin", input)?;
+        e.arg("args", &format!("+NOTRACE=0 +OUT={}", output))?;
+        Ok(())
+    });
+
+    // Icarus Verilog.
+    let verilog_noverify = bld.state("verilog-noverify", &["sv"]);
+    let icarus_setup = bld.setup("Icarus Verilog", |e| {
+        e.var("iverilog", "iverilog")?;
+        e.rule("icarus-compile", "$iverilog -g2012 -o $out $testbench $in")?;
+        Ok(())
+    });
+    bld.op(
+        "calyx-noverify",
+        &[calyx_setup],
+        calyx,
+        verilog_noverify,
+        |e, input, output| {
+            // Icarus requires a special --disable-verify version of Calyx code.
+            e.build_cmd(&[output], "calyx", &[input], &[])?;
+            e.arg("backend", "verilog")?;
+            e.arg("args", "--disable-verify")?;
+            Ok(())
+        },
+    );
+    bld.op(
+        "icarus",
+        &[sim_setup, icarus_setup],
+        verilog_noverify,
+        simulator,
+        |e, input, output| {
+            e.build("icarus-compile", input, output)?;
+            Ok(())
+        },
+    );
+
+    // Calyx to FIRRTL.
+    let firrtl = bld.state("firrtl", &["fir"]);
+    bld.op(
+        "calyx-to-firrtl",
+        &[calyx_setup],
+        calyx,
+        firrtl,
+        |e, input, output| {
+            e.build_cmd(&[output], "calyx", &[input], &[])?;
+            e.arg("backend", "firrtl")?;
+            Ok(())
+        },
+    );
+
+    // The FIRRTL compiler.
+    let firrtl_setup = bld.setup("Firrtl to Verilog compiler", |e| {
+        e.config_var("firrtl_exe", "firrtl.exe")?;
+        e.rule("firrtl", "$firrtl_exe -i $in -o $out -X sverilog")?;
+
+        e.var(
+            "primitives-for-firrtl",
+            &format!("{}/primitives-for-firrtl.sv", e.config_val("data")?),
+        )?;
+        e.rule("add-firrtl-prims", "cat $primitives-for-firrtl $in > $out")?;
+
+        Ok(())
+    });
+    fn firrtl_compile(e: &mut Emitter, input: &str, output: &str) -> EmitResult {
+        let tmp_verilog = "partial.sv";
+        e.build_cmd(&[tmp_verilog], "firrtl", &[input], &[])?;
+        e.build_cmd(&[output], "add-firrtl-prims", &[tmp_verilog], &[])?;
+        Ok(())
+    }
+    bld.op("firrtl", &[firrtl_setup], firrtl, verilog, firrtl_compile);
+    // This is a bit of a hack, but the Icarus-friendly "noverify" state is identical for this path
+    // (since FIRRTL compilation doesn't come with verification).
+    bld.op(
+        "firrtl-noverify",
+        &[firrtl_setup],
+        firrtl,
+        verilog_noverify,
+        firrtl_compile,
+    );
+
+    // primitive-uses backend
+    let primitive_uses_json = bld.state("primitive-uses-json", &["json"]);
+    bld.op(
+        "primitive-uses",
+        &[calyx_setup],
+        calyx,
+        primitive_uses_json,
+        |e, input, output| {
+            e.build_cmd(&[output], "calyx", &[input], &[])?;
+            e.arg("backend", "primitive-uses")?;
+            Ok(())
+        },
+    );
+
+    // Verilator.
+    let verilator_setup = bld.setup("Verilator", |e| {
+        e.config_var_or("verilator", "verilator.exe", "verilator")?;
+        e.config_var_or("cycle_limit", "sim.cycle_limit", "500000000")?;
+        e.rule(
+            "verilator-compile",
+            "$verilator $in $testbench --trace --binary --top-module TOP -fno-inline -Mdir $out_dir",
+        )?;
+        e.rule("cp", "cp $in $out")?;
+        Ok(())
+    });
+    bld.op(
+        "verilator",
+        &[sim_setup, verilator_setup],
+        verilog,
+        simulator,
+        |e, input, output| {
+            let out_dir = "verilator-out";
+            let sim_bin = format!("{}/VTOP", out_dir);
+            e.build("verilator-compile", input, &sim_bin)?;
+            e.arg("out_dir", out_dir)?;
+            e.build("cp", &sim_bin, output)?;
+            Ok(())
+        },
+    );
+
+    // Interpreter.
+    let debug = bld.state("debug", &[]); // A pseudo-state.
+    let cider_setup = bld.setup("Cider interpreter", |e| {
+        e.config_var_or("cider", "cider.exe", "$calyx_base/target/debug/cider")?;
+        e.rule(
+            "cider",
+            "$cider -l $calyx_base --raw --data data.json $in > $out",
+        )?;
+        e.rule(
+            "cider-debug",
+            "$cider -l $calyx_base --data data.json $in debug || true",
+        )?;
+        e.arg("pool", "console")?;
+
+        // TODO Can we reduce the duplication around `rsrc_dir` and `$python`?
+        let rsrc_dir = e.config_val("data")?;
+        e.var("interp-dat", &format!("{}/interp-dat.py", rsrc_dir))?;
+        e.config_var_or("python", "python", "python3")?;
+        e.rule("dat-to-interp", "$python $interp-dat --to-interp $in")?;
+        e.rule(
+            "interp-to-dat",
+            "$python $interp-dat --from-interp $in $sim_data > $out",
+        )?;
+        e.build_cmd(&["data.json"], "dat-to-interp", &["$sim_data"], &[])?;
+        Ok(())
+    });
+    bld.op(
+        "interp",
+        &[sim_setup, calyx_setup, cider_setup],
+        calyx,
+        dat,
+        |e, input, output| {
+            let out_file = "interp_out.json";
+            e.build_cmd(&[out_file], "cider", &[input], &["data.json"])?;
+            e.build_cmd(&[output], "interp-to-dat", &[out_file], &["$sim_data"])?;
+            Ok(())
+        },
+    );
+    bld.op(
+        "debug",
+        &[sim_setup, calyx_setup, cider_setup],
+        calyx,
+        debug,
+        |e, input, output| {
+            e.build_cmd(&[output], "cider-debug", &[input], &["data.json"])?;
+            Ok(())
+        },
+    );
+
+    // Xilinx compilation.
+    let xo = bld.state("xo", &["xo"]);
+    let xclbin = bld.state("xclbin", &["xclbin"]);
+    let xilinx_setup = bld.setup("Xilinx tools", |e| {
+        // Locations for Vivado and Vitis installations.
+        e.config_var("vivado_dir", "xilinx.vivado")?;
+        e.config_var("vitis_dir", "xilinx.vitis")?;
+
+        // Package a Verilog program as an `.xo` file.
+        let rsrc_dir = e.config_val("data")?;
+        e.var("gen_xo_tcl", &format!("{}/gen_xo.tcl", rsrc_dir))?;
+        e.var("get_ports", &format!("{}/get-ports.py", rsrc_dir))?;
+        e.config_var_or("python", "python", "python3")?;
+        e.rule("gen-xo", "$vivado_dir/bin/vivado -mode batch -source $gen_xo_tcl -tclargs $out `$python $get_ports kernel.xml`")?;
+        e.arg("pool", "console")?;  // Lets Ninja stream the tool output "live."
+
+        // Compile an `.xo` file to an `.xclbin` file, which is where the actual EDA work occurs.
+        e.config_var_or("xilinx_mode", "xilinx.mode", "hw_emu")?;
+        e.config_var_or("platform", "xilinx.device", "xilinx_u50_gen3x16_xdma_201920_3")?;
+        e.rule("compile-xclbin", "$vitis_dir/bin/v++ -g -t $xilinx_mode --platform $platform --save-temps --profile.data all:all:all --profile.exec all:all:all -lo $out $in")?;
+        e.arg("pool", "console")?;
+
+        Ok(())
+    });
+    bld.op(
+        "xo",
+        &[calyx_setup, xilinx_setup],
+        calyx,
+        xo,
+        |e, input, output| {
+            // Emit the Verilog itself in "synthesis mode."
+            e.build_cmd(&["main.sv"], "calyx", &[input], &[])?;
+            e.arg("backend", "verilog")?;
+            e.arg("args", "--synthesis -p external")?;
+
+            // Extra ingredients for the `.xo` package.
+            e.build_cmd(&["toplevel.v"], "calyx", &[input], &[])?;
+            e.arg("backend", "xilinx")?;
+            e.build_cmd(&["kernel.xml"], "calyx", &[input], &[])?;
+            e.arg("backend", "xilinx-xml")?;
+
+            // Package the `.xo`.
+            e.build_cmd(
+                &[output],
+                "gen-xo",
+                &[],
+                &["main.sv", "toplevel.v", "kernel.xml"],
+            )?;
+            Ok(())
+        },
+    );
+    bld.op("xclbin", &[xilinx_setup], xo, xclbin, |e, input, output| {
+        e.build_cmd(&[output], "compile-xclbin", &[input], &[])?;
+        Ok(())
+    });
+
+    // Xilinx execution.
+    // TODO Only does `hw_emu` for now...
+    let xrt_setup = bld.setup("Xilinx execution via XRT", |e| {
+        // Generate `emconfig.json`.
+        e.rule("emconfig", "$vitis_dir/bin/emconfigutil --platform $platform")?;
+        e.build_cmd(&["emconfig.json"], "emconfig", &[], &[])?;
+
+        // Execute via the `xclrun` tool.
+        e.config_var("xrt_dir", "xilinx.xrt")?;
+        e.rule("xclrun", "bash -c 'source $vitis_dir/settings64.sh ; source $xrt_dir/setup.sh ; XRT_INI_PATH=$xrt_ini EMCONFIG_PATH=. XCL_EMULATION_MODE=$xilinx_mode $python -m fud.xclrun --out $out $in'")?;
+        e.arg("pool", "console")?;
+
+        // "Pre-sim" and "post-sim" scripts for simulation.
+        e.rule("echo", "echo $contents > $out")?;
+        e.build_cmd(&["pre_sim.tcl"], "echo", &[""], &[""])?;
+        e.arg("contents", "open_vcd\\\\nlog_vcd *\\\\n")?;
+        e.build_cmd(&["post_sim.tcl"], "echo", &[""], &[""])?;
+        e.arg("contents", "close_vcd\\\\n")?;
+
+        Ok(())
+    });
+    bld.op(
+        "xrt",
+        &[xilinx_setup, sim_setup, xrt_setup],
+        xclbin,
+        dat,
+        |e, input, output| {
+            e.build_cmd(
+                &[output],
+                "xclrun",
+                &[input, "$sim_data"],
+                &["emconfig.json"],
+            )?;
+            let rsrc_dir = e.config_val("data")?;
+            e.arg("xrt_ini", &format!("{}/xrt.ini", rsrc_dir))?;
+            Ok(())
+        },
+    );
+    bld.op(
+        "xrt-trace",
+        &[xilinx_setup, sim_setup, xrt_setup],
+        xclbin,
+        vcd,
+        |e, input, output| {
+            e.build_cmd(
+                &[output], // TODO not the VCD, yet...
+                "xclrun",
+                &[input, "$sim_data"],
+                &["emconfig.json", "pre_sim.tcl", "post_sim.tcl"],
+            )?;
+            let rsrc_dir = e.config_val("data")?;
+            e.arg("xrt_ini", &format!("{}/xrt_trace.ini", rsrc_dir))?;
+            Ok(())
+        },
+    );
+
+    bld.build()
+}
+
+fn main() -> anyhow::Result<()> {
+    let driver = build_driver();
+    cli::cli(&driver)
+}

--- a/fud2/src/main.rs
+++ b/fud2/src/main.rs
@@ -12,7 +12,11 @@ fn build_driver() -> Driver {
     let verilog = bld.state("verilog", &["sv", "v"]);
     let calyx_setup = bld.setup("Calyx compiler", |e| {
         e.config_var("calyx_base", "calyx.base")?;
-        e.config_var_or("calyx_exe", "calyx.exe", "$calyx_base/target/debug/calyx")?;
+        e.config_var_or(
+            "calyx_exe",
+            "calyx.exe",
+            "$calyx_base/target/debug/calyx",
+        )?;
         e.rule(
             "calyx",
             "$calyx_exe -l $calyx_base -b $backend $args $in > $out",
@@ -103,7 +107,12 @@ fn build_driver() -> Driver {
         },
     );
     bld.op("trace", &[sim_setup], simulator, vcd, |e, input, output| {
-        e.build_cmd(&["sim.log", output], "sim-run", &[input, "$datadir"], &[])?;
+        e.build_cmd(
+            &["sim.log", output],
+            "sim-run",
+            &[input, "$datadir"],
+            &[],
+        )?;
         e.arg("bin", input)?;
         e.arg("args", &format!("+NOTRACE=0 +OUT={}", output))?;
         Ok(())
@@ -167,7 +176,11 @@ fn build_driver() -> Driver {
 
         Ok(())
     });
-    fn firrtl_compile(e: &mut Emitter, input: &str, output: &str) -> EmitResult {
+    fn firrtl_compile(
+        e: &mut Emitter,
+        input: &str,
+        output: &str,
+    ) -> EmitResult {
         let tmp_verilog = "partial.sv";
         e.build_cmd(&[tmp_verilog], "firrtl", &[input], &[])?;
         e.build_cmd(&[output], "add-firrtl-prims", &[tmp_verilog], &[])?;
@@ -227,7 +240,11 @@ fn build_driver() -> Driver {
     // Interpreter.
     let debug = bld.state("debug", &[]); // A pseudo-state.
     let cider_setup = bld.setup("Cider interpreter", |e| {
-        e.config_var_or("cider", "cider.exe", "$calyx_base/target/debug/cider")?;
+        e.config_var_or(
+            "cider",
+            "cider.exe",
+            "$calyx_base/target/debug/cider",
+        )?;
         e.rule(
             "cider",
             "$cider -l $calyx_base --raw --data data.json $in > $out",
@@ -258,7 +275,12 @@ fn build_driver() -> Driver {
         |e, input, output| {
             let out_file = "interp_out.json";
             e.build_cmd(&[out_file], "cider", &[input], &["data.json"])?;
-            e.build_cmd(&[output], "interp-to-dat", &[out_file], &["$sim_data"])?;
+            e.build_cmd(
+                &[output],
+                "interp-to-dat",
+                &[out_file],
+                &["$sim_data"],
+            )?;
             Ok(())
         },
     );


### PR DESCRIPTION
This adds the code from https://github.com/sampsyo/fake/commit/8365aa3946d78076ad7c11a972fe2b3ff1a1c420. I also added some extremely basic documentation.

There is a lot more work to be done on fud2 before it is viable as a day-to-day tool. This PR is the first step in [my proposal for a migration plan](https://github.com/orgs/calyxir/discussions/1837#discussioncomment-8101678), i.e.:

1. open this PR and merge fud2 into the Calyx monorepo
2. open a bunch of issues to map out what needs to be done (including basic functionality in fake, lots of new capabilities to cover the ops fud already supports, and much more documentation)
3. slowly roll things forward guided by those issues and the ecosystem's demands
4. someday later, reassess what it would take to do a proper replacement

In that entire foreseen future, fud remains the primary option and fud2 remains "experimental." Changing that is a problem for another day, at step 4.