### PR TITLE
Docs: multicomponent tutorial fud command fix 

### DIFF
--- a/docs/lang/multi-component.md
+++ b/docs/lang/multi-component.md
@@ -41,5 +41,5 @@ The component executes the two groups in-order.
 
 To see the output from running this component, run the command:
 ```
-fud e examples/futil/multi-component.futil --to vcd_json
+fud e examples/futil/multi-component.futil --to vcd
 ```


### PR DESCRIPTION
Old fud command containing flag --to vcd_json resulted in stack overflow error. Changed command to use flag --to vcd.