### PR TITLE
Deploy docs on `main`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ name: Docs website
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   playground:


### PR DESCRIPTION
Overlooked this during the reorg! Simple fix (`master` -> `main`)