### PR TITLE
fud2: Embed resources in executable, in release mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,7 @@ version = "0.0.2"
 dependencies = [
  "anyhow",
  "fud-core",
+ "manifest-dir-macros",
 ]
 
 [[package]]
@@ -1061,6 +1062,18 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "manifest-dir-macros"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6d40de1ccdbf8bde2eaa0750595478a368f7b3a3f89c426e3454f64e29f593"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
 
 [[package]]
 name = "memchr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,7 @@ version = "0.0.2"
 dependencies = [
  "anyhow",
  "fud-core",
+ "include_dir",
  "manifest-dir-macros",
 ]
 
@@ -937,6 +938,25 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "include_dir"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "indexmap"

--- a/docs/running-calyx/fud2.md
+++ b/docs/running-calyx/fud2.md
@@ -24,10 +24,8 @@ Run the following command to edit `fud2`'s configuration file (usually `~/.confi
 fud2 edit-config
 ```
 
-Add the following fields:
+Add these lines:
 ```toml
-rsrc = "<path to calyx checkout>/fud2/rsrc"
-
 [calyx]
 base = "<path to calyx checkout>"
 ```

--- a/fud2/Cargo.toml
+++ b/fud2/Cargo.toml
@@ -16,6 +16,7 @@ description = "Compiler driver for the Calyx infrastructure"
 fud-core = { path = "fud-core", version = "0.0.2" }
 anyhow.workspace = true
 manifest-dir-macros = "0.1"
+include_dir = "0.7"
 
 [[bin]]
 name = "fud2"

--- a/fud2/Cargo.toml
+++ b/fud2/Cargo.toml
@@ -15,6 +15,7 @@ description = "Compiler driver for the Calyx infrastructure"
 [dependencies]
 fud-core = { path = "fud-core", version = "0.0.2" }
 anyhow.workspace = true
+manifest-dir-macros = "0.1"
 
 [[bin]]
 name = "fud2"

--- a/fud2/fud-core/src/cli.rs
+++ b/fud2/fud-core/src/cli.rs
@@ -217,6 +217,9 @@ fn get_resource(driver: &Driver, cmd: GetResource) -> anyhow::Result<()> {
     // Try copying a resource file from the resource directory.
     if let Some(rsrc_dir) = &driver.rsrc_dir {
         let from_path = rsrc_dir.join(&cmd.filename);
+        if !from_path.exists() {
+            bail!("resource file not found: {}", cmd.filename);
+        }
         log::info!("copying {} to {}", cmd.filename, to_path);
         std::fs::copy(from_path, to_path)?;
         return Ok(());

--- a/fud2/fud-core/src/cli.rs
+++ b/fud2/fud-core/src/cli.rs
@@ -57,7 +57,7 @@ pub struct EditConfig {
 pub struct GetResource {
     /// the filename to extract
     #[argh(positional)]
-    input: Option<String>,
+    filename: String,
 
     /// destination for the resource file
     #[argh(option, short = 'o')]
@@ -203,7 +203,12 @@ fn edit_config(driver: &Driver, cmd: EditConfig) -> anyhow::Result<()> {
 }
 
 fn get_resource(driver: &Driver, cmd: GetResource) -> anyhow::Result<()> {
-    println!("hello!");
+    if let Some(rsrc_dir) = &driver.rsrc_dir {
+        dbg!(&rsrc_dir);
+        todo!("copy the file")
+    } else {
+        todo!("extract the file")
+    }
     Ok(())
 }
 

--- a/fud2/fud-core/src/exec/driver.rs
+++ b/fud2/fud-core/src/exec/driver.rs
@@ -16,6 +16,7 @@ pub struct Driver {
     pub setups: PrimaryMap<SetupRef, Setup>,
     pub states: PrimaryMap<StateRef, State>,
     pub ops: PrimaryMap<OpRef, Operation>,
+    pub rsrc_dir: Option<Utf8PathBuf>,
 }
 
 impl Driver {
@@ -192,6 +193,7 @@ pub struct DriverBuilder {
     setups: PrimaryMap<SetupRef, Setup>,
     states: PrimaryMap<StateRef, State>,
     ops: PrimaryMap<OpRef, Operation>,
+    rsrc_dir: Option<Utf8PathBuf>,
 }
 
 impl DriverBuilder {
@@ -201,6 +203,7 @@ impl DriverBuilder {
             setups: Default::default(),
             states: Default::default(),
             ops: Default::default(),
+            rsrc_dir: None,
         }
     }
 
@@ -272,12 +275,17 @@ impl DriverBuilder {
         )
     }
 
+    pub fn rsrc_dir(&mut self, path: &str) {
+        self.rsrc_dir = Some(path.into());
+    }
+
     pub fn build(self) -> Driver {
         Driver {
             name: self.name,
             setups: self.setups,
             states: self.states,
             ops: self.ops,
+            rsrc_dir: self.rsrc_dir,
         }
     }
 }

--- a/fud2/fud-core/src/exec/driver.rs
+++ b/fud2/fud-core/src/exec/driver.rs
@@ -2,12 +2,15 @@ use super::{OpRef, Operation, Request, Setup, SetupRef, State, StateRef};
 use crate::{run, utils};
 use camino::{Utf8Path, Utf8PathBuf};
 use cranelift_entity::{PrimaryMap, SecondaryMap};
+use std::collections::HashMap;
 
 #[derive(PartialEq)]
 enum Destination {
     State(StateRef),
     Op(OpRef),
 }
+
+type FileData = HashMap<&'static str, &'static [u8]>;
 
 /// A Driver encapsulates a set of States and the Operations that can transform between them. It
 /// contains all the machinery to perform builds in a given ecosystem.
@@ -17,6 +20,7 @@ pub struct Driver {
     pub states: PrimaryMap<StateRef, State>,
     pub ops: PrimaryMap<OpRef, Operation>,
     pub rsrc_dir: Option<Utf8PathBuf>,
+    pub rsrc_files: Option<FileData>,
 }
 
 impl Driver {
@@ -194,6 +198,7 @@ pub struct DriverBuilder {
     states: PrimaryMap<StateRef, State>,
     ops: PrimaryMap<OpRef, Operation>,
     rsrc_dir: Option<Utf8PathBuf>,
+    rsrc_files: Option<FileData>,
 }
 
 impl DriverBuilder {
@@ -204,6 +209,7 @@ impl DriverBuilder {
             states: Default::default(),
             ops: Default::default(),
             rsrc_dir: None,
+            rsrc_files: None,
         }
     }
 
@@ -279,6 +285,10 @@ impl DriverBuilder {
         self.rsrc_dir = Some(path.into());
     }
 
+    pub fn rsrc_files(&mut self, files: FileData) {
+        self.rsrc_files = Some(files);
+    }
+
     pub fn build(self) -> Driver {
         Driver {
             name: self.name,
@@ -286,6 +296,7 @@ impl DriverBuilder {
             states: self.states,
             ops: self.ops,
             rsrc_dir: self.rsrc_dir,
+            rsrc_files: self.rsrc_files,
         }
     }
 }

--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -233,6 +233,17 @@ impl<'a> Run<'a> {
             self.plan.workdir.clone(),
         );
 
+        // Emit preamble.
+        emitter.var(
+            "build-tool",
+            std::env::current_exe()
+                .expect("executable path unknown")
+                .to_str()
+                .expect("invalid executable name"),
+        )?;
+        emitter.rule("get-rsrc", "$build-tool get-rsrc $out")?;
+        writeln!(emitter.out)?;
+
         // Emit the setup for each operation used in the plan, only once.
         let mut done_setups = HashSet::<SetupRef>::new();
         for (op, _) in &self.plan.steps {

--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -400,4 +400,9 @@ impl Emitter {
         writeln!(self.out, "  {} = {}", name, value)?;
         Ok(())
     }
+
+    /// Add a build command to extract a resource file into the build directory.
+    pub fn rsrc(&mut self, filename: &str) -> std::io::Result<()> {
+        self.build_cmd(&[filename], "get-rsrc", &[], &[])
+    }
 }

--- a/fud2/src/main.rs
+++ b/fud2/src/main.rs
@@ -96,7 +96,7 @@ fn build_driver(bld: &mut DriverBuilder) {
         e.rule("json-data", "$json_dat --to-json $out $in")?;
 
         // The Verilog testbench.
-        e.build_cmd(&["tb.sv"], "get-rsrc", &[], &[])?; // TODO Shortcut for this!
+        e.rsrc("tb.sv")?;
 
         // The input data file. `sim.data` is required.
         let data_name = e.config_val("sim.data")?;

--- a/fud2/src/main.rs
+++ b/fud2/src/main.rs
@@ -8,6 +8,10 @@ use fud_core::{
 #[cfg(debug_assertions)]
 const RSRC_DIR: &str = manifest_dir_macros::directory_path!("rsrc");
 
+#[cfg(not(debug_assertions))]
+const RSRC_FILES: include_dir::Dir =
+    include_dir::include_dir!("$CARGO_MANIFEST_DIR/rsrc");
+
 fn setup_calyx(
     bld: &mut DriverBuilder,
     verilog: StateRef,
@@ -470,6 +474,15 @@ fn main() -> anyhow::Result<()> {
 
     #[cfg(debug_assertions)]
     bld.rsrc_dir(RSRC_DIR);
+
+    #[cfg(not(debug_assertions))]
+    {
+        let rsrc_data: std::collections::HashMap<_, _> = RSRC_FILES
+            .files()
+            .map(|file| (file.path().to_str().unwrap(), file.contents()))
+            .collect();
+        bld.rsrc_files(rsrc_data);
+    }
 
     let driver = bld.build();
     cli::cli(&driver)


### PR DESCRIPTION
As part of #1899 (see also #1878 for context), this change addresses fud2's need for external "resource" files. The idea is, in release builds of fud2, to embed all these files into the executable using [the `include_dir` crate](https://docs.rs/include_dir/latest/include_dir/). To get access to these files, Ninja builds "extract" the resource files by calling back into fud2. Specifically, there is a new `fud2 get-rsrc` subcommand that Ninja files invoke to obtain specific resource files.

For example, here are some excerpts from a simulation build (`fud2 lti.futil --to dat --through icarus -s sim.data=t.json -v -m emit`):

```ninja
build-tool = /Users/asampson/Documents/cu/research/calyx/target/debug/fud2
rule get-rsrc
  command = $build-tool get-rsrc $out
```

Every build now includes the above preamble to allow "callbacks" to fud2. Then, for instance, the Python script for data conversion works like this:

```ninja
build json-dat.py: get-rsrc
rule hex-data
  command = $python json-dat.py --from-json $in $out
# ...
build $datadir: hex-data $sim_data | json-dat.py
```

Previously, we used `json-dat.py` directly from its location in the fud2 source tree. Now, we extract it into the build directory first. The build command needs an implicit dependency on the Python script to make this happen.

I added a utility `e.rsrc("filename")` to the fud2 emitter to make this dance easy to emit.

In debug mode, to avoid the build-time cost of embedding, fud2 instead obtains files from the `rsrc` directory. Build scripts are unchanged w/r/t release builds; they still go through `fud2 get-rsrc`. For consistency, fud2 now uses `$CARGO_MANIFEST_DIR` to find this directory—meaning that the `rsrc` config key is no longer required to use fud2. (So I removed it from the docs.)

One possible improvement here: I'm not sure `include_dir` is the best crate for this. There are many options; it would be great to go with something popular/well-tested. This is probably fine for now, since it's easy to swap out later?