### PR TITLE
bump rust versions to stable

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install stable
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.69.0
+          toolchain: stable
           override: true
           components: rustfmt, clippy
     - name: Check formatting

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install stable
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: stable
+          toolchain: 1.76.0
           override: true
           components: rustfmt, clippy
     - name: Check formatting

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official rust image as a parent image.
-FROM rust:latest
+FROM rust:1.76
 
 # Connect to the Calux repository.
 LABEL org.opencontainers.image.source https://github.com/calyxir/calyx
@@ -12,6 +12,7 @@ RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/ap
     apt-get install -y jq python3.10 python3-pip sbt make autoconf g++ flex bison libfl2 libfl-dev default-jdk ninja-build build-essential cmake autoconf gperf
 
 # Install python dependencies
+RUN rm /usr/lib/python3.11/EXTERNALLY-MANAGED
 RUN python3 -m pip install numpy flit prettytable wheel hypothesis pytest simplejson cocotb==1.6.2
 # Current cocotb-bus has a bug that is fixed in more up to date repo
 RUN python3 -m pip install git+https://github.com/cocotb/cocotb-bus.git cocotbext-axi

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,13 @@ RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/ap
     echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list && \
     curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
     apt-get update -y && \
-    apt-get install -y jq python3.10 python3-pip sbt make autoconf g++ flex bison libfl2 libfl-dev default-jdk ninja-build build-essential cmake autoconf gperf
+    apt-get install -y jq python3.10 python3-pip python3-venv sbt make autoconf g++ flex bison libfl2 libfl-dev default-jdk ninja-build build-essential cmake autoconf gperf
+
+# Setup python venv to install python dependencies. Python no longer supports installing packages globally into your system
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 # Install python dependencies
-RUN rm /usr/lib/python3.11/EXTERNALLY-MANAGED
 RUN python3 -m pip install numpy flit prettytable wheel hypothesis pytest simplejson cocotb==1.6.2
 # Current cocotb-bus has a bug that is fixed in more up to date repo
 RUN python3 -m pip install git+https://github.com/cocotb/cocotb-bus.git cocotbext-axi
@@ -26,7 +29,7 @@ RUN autoconf && ./configure && make && make install
 
 # Install Icarus verilog
 WORKDIR /home
-RUN git clone --depth 1 --branch v11_0 https://github.com/steveicarus/iverilog
+RUN git clone --depth 1 --branch v12_0 https://github.com/steveicarus/iverilog
 WORKDIR /home/iverilog
 RUN sh autoconf.sh && ./configure && make && make install
 
@@ -44,7 +47,7 @@ RUN cp ../cmake/config.cmake . && \
     cmake -G Ninja .. && ninja && \
     python3 -m pip install -Iv antlr4-python3-runtime==4.7.2
 WORKDIR /home/tvm/python
-RUN python3 setup.py bdist_wheel && python3 -m pip install --user dist/tvm-*.whl
+RUN python3 setup.py bdist_wheel && python3 -m pip install dist/tvm-*.whl
 
 # Install Dahlia
 WORKDIR /home

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official rust image as a parent image.
-FROM rust:1.70
+FROM rust:latest
 
 # Connect to the Calux repository.
 LABEL org.opencontainers.image.source https://github.com/calyxir/calyx

--- a/calyx-backend/src/firrtl.rs
+++ b/calyx-backend/src/firrtl.rs
@@ -86,7 +86,7 @@ fn emit_component<F: io::Write>(
 
     // Inputs and Outputs
     let sig = comp.signature.borrow();
-    for (_idx, port_ref) in sig.ports.iter().enumerate() {
+    for port_ref in &sig.ports {
         let port = port_ref.borrow();
         emit_port(port, true, f)?;
     }

--- a/calyx-opt/src/analysis/compute_static.rs
+++ b/calyx-opt/src/analysis/compute_static.rs
@@ -82,13 +82,9 @@ impl WithStatic for ir::Seq {
     type Info = CompTime;
     fn compute_static(&mut self, extra: &Self::Info) -> Option<u64> {
         // Go through each stmt in the seq, and try to calculate the latency.
-        self.stmts.iter_mut().fold(Some(0), |acc, stmt| {
-            match (acc, stmt.update_static(extra)) {
-                (Some(cur_latency), Some(stmt_latency)) => {
-                    Some(cur_latency + stmt_latency)
-                }
-                (_, _) => None,
-            }
+        self.stmts.iter_mut().try_fold(0, |cur_latency, stmt| {
+            stmt.update_static(extra)
+                .map(|stmt_latency| cur_latency + stmt_latency)
         })
     }
 }
@@ -97,13 +93,9 @@ impl WithStatic for ir::Par {
     type Info = CompTime;
     fn compute_static(&mut self, extra: &Self::Info) -> Option<u64> {
         // Go through each stmt in the par, and try to calculate the latency.
-        self.stmts.iter_mut().fold(Some(0), |acc, stmt| {
-            match (acc, stmt.update_static(extra)) {
-                (Some(cur_latency), Some(stmt_latency)) => {
-                    Some(std::cmp::max(cur_latency, stmt_latency))
-                }
-                (_, _) => None,
-            }
+        self.stmts.iter_mut().try_fold(0, |cur_latency, stmt| {
+            stmt.update_static(extra)
+                .map(|stmt_latency| std::cmp::max(cur_latency, stmt_latency))
         })
     }
 }

--- a/calyx-opt/src/analysis/inference_analysis.rs
+++ b/calyx-opt/src/analysis/inference_analysis.rs
@@ -441,7 +441,7 @@ impl InferenceAnalysis {
             log::debug!("FAIL: No path between @go and @done port");
             return None;
         }
-        let first_path = paths.get(0).unwrap();
+        let first_path = paths.first().unwrap();
 
         // Sum the latencies of each primitive along the path.
         let mut latency_sum = 0;

--- a/calyx-opt/src/passes/cell_share.rs
+++ b/calyx-opt/src/passes/cell_share.rs
@@ -387,9 +387,7 @@ impl Visitor for CellShare {
         let mut coloring: rewriter::RewriteMap<ir::Cell> = HashMap::new();
         let mut comp_share_freqs: HashMap<ir::CellType, HashMap<i64, i64>> =
             HashMap::new();
-        let comb_bound = self.bounds.get(0).unwrap_or(&None);
-        let reg_bound = self.bounds.get(1).unwrap_or(&None);
-        let other_bound = self.bounds.get(2).unwrap_or(&None);
+        let [comb_bound, reg_bound, other_bound] = &self.bounds;
         for (cell_type, mut graph) in graphs_by_type {
             // getting bound, based on self.bounds and cell_type
             let bound = {


### PR DESCRIPTION
Bumps the rust version to stable. Let me know if you want to pin a particular version, or if it's ok to just use the docker image `rust:latest` and the toolchain `stable`.