### PR TITLE
Add component attributes to builder

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -76,6 +76,7 @@ class ComponentBuilder:
         self.prog = prog
         self.component: ast.Component = ast.Component(
             name,
+            attributes = [],
             inputs=[],
             outputs=[],
             structs=cells,
@@ -111,6 +112,11 @@ class ComponentBuilder:
         """
         self.component.outputs.append(ast.PortDef(ast.CompVar(name), size))
         return self.this()[name]
+
+    def attribute(self, name: str, value: int) -> None:
+        """Declare an attribute on the component.
+        """
+        self.component.attributes.append(ast.CompAttribute(name, value))
 
     def this(self) -> ThisBuilder:
         """Get a handle to the component's `this` cell.

--- a/calyx-py/calyx/py_ast.py
+++ b/calyx-py/calyx/py_ast.py
@@ -56,11 +56,11 @@ class Component:
     def __init__(
         self,
         name: str,
-        attributes: list[CompAttribute],
         inputs: list[PortDef],
         outputs: list[PortDef],
         structs: list[Structure],
         controls: Control,
+        attributes: Optional[list[CompAttribute]] = None,
         latency: Optional[int] = None,
     ):
         self.name = name
@@ -89,7 +89,7 @@ class Component:
         ins = ", ".join([s.doc() for s in self.inputs])
         outs = ", ".join([s.doc() for s in self.outputs])
         latency_annotation = (
-            f"static<{self.latency}>" if self.latency is not None else ""
+                f"static<{self.latency}> " if self.latency is not None else ""
         )
         attribute_annotation = f"<{', '.join([f'{a.doc()}' for a in self.attributes])}>" if self.attributes else ""
         signature = f"{latency_annotation}component {self.name}{attribute_annotation}({ins}) -> ({outs})"

--- a/calyx-py/calyx/py_ast.py
+++ b/calyx-py/calyx/py_ast.py
@@ -45,6 +45,7 @@ class Program(Emittable):
 @dataclass
 class Component:
     name: str
+    attributes : list[Attribute]
     inputs: list[PortDef]
     outputs: list[PortDef]
     wires: list[Structure]
@@ -55,15 +56,17 @@ class Component:
     def __init__(
         self,
         name: str,
+        attributes: list[CompAttribute],
         inputs: list[PortDef],
         outputs: list[PortDef],
         structs: list[Structure],
         controls: Control,
         latency: Optional[int] = None,
     ):
+        self.name = name
+        self.attributes = attributes
         self.inputs = inputs
         self.outputs = outputs
-        self.name = name
         self.controls = controls
         self.latency = latency
 
@@ -85,14 +88,28 @@ class Component:
     def doc(self) -> str:
         ins = ", ".join([s.doc() for s in self.inputs])
         outs = ", ".join([s.doc() for s in self.outputs])
-        latency_annotation = (
-            f"static<{self.latency}> " if self.latency is not None else ""
-        )
-        signature = f"{latency_annotation}component {self.name}({ins}) -> ({outs})"
+        if(self.latency):
+            self.attributes.append(CompAttribute("static",self.latency))
+        attribute_annotation = ", ".join(f"<{a.doc}>" for a in self.attributes)
+        signature = f"{attribute_annotation}component {self.name}({ins}) -> ({outs})"
         cells = block("cells", [c.doc() for c in self.cells])
         wires = block("wires", [w.doc() for w in self.wires])
         controls = block("control", [self.controls.doc()])
         return block(signature, [cells, wires, controls])
+
+
+#Attribute
+@dataclass
+class Attribute(Emittable):
+    pass
+
+@dataclass
+class CompAttribute(Attribute):
+    name: str
+    value: int
+
+    def doc(self) -> str:
+        return f"\"{self.name}\"={self.value}"
 
 
 # Ports

--- a/calyx-py/calyx/py_ast.py
+++ b/calyx-py/calyx/py_ast.py
@@ -88,10 +88,11 @@ class Component:
     def doc(self) -> str:
         ins = ", ".join([s.doc() for s in self.inputs])
         outs = ", ".join([s.doc() for s in self.outputs])
-        if(self.latency):
-            self.attributes.append(CompAttribute("static",self.latency))
-        attribute_annotation = ", ".join(f"<{a.doc}>" for a in self.attributes)
-        signature = f"{attribute_annotation}component {self.name}({ins}) -> ({outs})"
+        latency_annotation = (
+            f"static<{self.latency}>" if self.latency is not None else ""
+        )
+        attribute_annotation = f"<{', '.join([f'{a.doc()}' for a in self.attributes])}>" if self.attributes else ""
+        signature = f"{latency_annotation}component {self.name}{attribute_annotation}({ins}) -> ({outs})"
         cells = block("cells", [c.doc() for c in self.cells])
         wires = block("wires", [w.doc() for w in self.wires])
         controls = block("control", [self.controls.doc()])

--- a/calyx-py/test/example.py
+++ b/calyx-py/test/example.py
@@ -63,7 +63,12 @@ controls = SeqComp([Enable(update_operands), Enable(compute_sum)])
 
 # Create the component.
 main_component = Component(
-    name="main", inputs=[], outputs=[], structs=cells + wires, controls=controls
+    name="main",
+    attributes=[],
+    inputs=[],
+    outputs=[],
+    structs=cells + wires,
+    controls=controls,
 )
 
 # Create the Calyx program.

--- a/calyx-py/test/if.py
+++ b/calyx-py/test/if.py
@@ -42,7 +42,12 @@ wires = [
 controls = If(CompPort(lt, "out"), cond, Enable(true), Enable(false))
 
 main_component = Component(
-    name="main", inputs=[], outputs=[], structs=cells + wires, controls=controls
+    name="main",
+    attributes=[],
+    inputs=[],
+    outputs=[],
+    structs=cells + wires,
+    controls=controls,
 )
 
 # Create the Calyx program.

--- a/calyx-py/test/invoke.py
+++ b/calyx-py/test/invoke.py
@@ -37,6 +37,7 @@ foo_wires = [
 
 foo_component = Component(
     name="foo",
+    attributes=[],
     inputs=[PortDef(CompVar("a"), 32)],
     outputs=[PortDef(CompVar("out"), 32)],
     structs=foo_cells + foo_wires,
@@ -83,6 +84,7 @@ controls = [
 
 main_component = Component(
     name="main",
+    attributes=[],
     inputs=[],
     outputs=[],
     structs=cells + wires,

--- a/docs/builder/ref.md
+++ b/docs/builder/ref.md
@@ -93,6 +93,21 @@ def add_my_component(prog):
 
 Note that it's possible to [create a handle][hndl] to input and output ports.
 
+### Defining Component Attributes
+
+Components can be given attributes. Similar to ports, just specify the name of the attribute and its value.
+Note that `attribute(name, value)` does not create a handle to the attribute.
+
+```python
+my_component.attribute("my_attribute", 1)
+```
+
+Will create a component that looks like:
+
+```
+component my_component<"my_attribute"=1>(...) -> (...) {
+```
+
 ### Multi-Component Designs
 
 Calyx supports [multi-component designs][multi]. The [top-level example][top] demonstrates how to construct multi-component designs using the library.

--- a/docs/builder/ref.md
+++ b/docs/builder/ref.md
@@ -96,7 +96,7 @@ Note that it's possible to [create a handle][hndl] to input and output ports.
 ### Defining Component Attributes
 
 Components can be given attributes. Similar to ports, just specify the name of the attribute and its value.
-Note that `attribute(name, value)` does not create a handle to the attribute.
+Note that `attribute(name, value)` does not return a handle to the attribute.
 
 ```python
 my_component.attribute("my_attribute", 1)


### PR DESCRIPTION
Allows to add attributes to components within the builder. This is needed as part of our AXI-wrapper generator #1733
Something like:

```
my_comp = prog.component("my_comp")
my_comp.attribute("my_attr", 1)
```

will produce a component signature that looks like:

```
component my_comp<"my_attr"=1>(...) -> (...)
```
I added note of this in the reference doc. Didn't think this warranted changing/adding any [tests](https://github.com/calyxir/calyx/tree/main/calyx-py/test) but can do that if we want.

---
I made sure this works with a little snippet of python uses this, but didn't think it was warranted to go into the repo, included here for completeness:

```
from calyx.builder import Builder
def add_attr_check(prog):
    my_comp = prog.component("my_component")
    my_comp.attribute("attr1", 7)
    my_comp.attribute("attr2", 1)


def build():
    prog = Builder()
    add_attr_check(prog)
    return prog.program

if __name__ == "__main__":
    build().emit()
```

emits:

```
component m_bresp_channel<"attr1"=7, "attr2"=1>() -> () {
  cells {

  }
  wires {

  }
  control {

  }
}
```