### PR TITLE
Add stallable primitives

### DIFF
--- a/calyx-stdlib/src/primitives.rs
+++ b/calyx-stdlib/src/primitives.rs
@@ -32,7 +32,7 @@ load_prims! { SYNC, "sync.futil", "sync.sv" }
 pub const COMPILE_LIB: (&str, &str) =
     ("compile.futil", include_str!("../primitives/compile.futil"));
 
-pub const KNOWN_LIBS: [(&str, [(&str, &str); 2]); 7] = [
+pub const KNOWN_LIBS: [(&str, [(&str, &str); 2]); 8] = [
     ("core", CORE),
     ("binary_operators", BINARY_OPERATORS),
     ("math", MATH),

--- a/calyx-stdlib/src/primitives.rs
+++ b/calyx-stdlib/src/primitives.rs
@@ -25,6 +25,7 @@ load_prims! { MATH, "math.futil", "math.sv" }
 load_prims! { COMB_MEMORIES, "memories/comb.futil", "memories/comb.sv" }
 load_prims! { SEQ_MEMORIES, "memories/seq.futil", "memories/seq.sv" }
 load_prims! { PIPELINED, "pipelined.futil", "pipelined.sv" }
+load_prims! { STALLABLE, "stallable.futil", "stallable.sv" }
 load_prims! { SYNC, "sync.futil", "sync.sv" }
 
 /// The core primitive in the compiler
@@ -38,5 +39,6 @@ pub const KNOWN_LIBS: [(&str, [(&str, &str); 2]); 7] = [
     ("comb_memories", COMB_MEMORIES),
     ("seq_memories", SEQ_MEMORIES),
     ("pipelined", PIPELINED),
+    ("stallable", STALLABLE),
     ("sync", SYNC),
 ];

--- a/primitives/stallable.futil
+++ b/primitives/stallable.futil
@@ -1,0 +1,14 @@
+extern "stallable.sv" {
+    // A latency-sensitive multiplier that takes 4 cycles to compute its result.
+    // If stall is set to a value of 1, the multiplier will stall until the value is
+    // set back to 0.
+    static<4> primitive stallable_mult[WIDTH] (
+        @clk clk: 1,
+        @reset reset: 1,
+        stall: 1,
+        left: WIDTH,
+        right: WIDTH
+    ) -> (
+        out: WIDTH
+    );
+}

--- a/primitives/stallable.sv
+++ b/primitives/stallable.sv
@@ -1,6 +1,3 @@
-
-/// This is mostly used for testing the static guarantees currently.
-/// A realistic implementation would probably take four cycles.
 module stallable_mult #(
     parameter WIDTH = 32
 ) (

--- a/primitives/stallable.sv
+++ b/primitives/stallable.sv
@@ -1,0 +1,38 @@
+
+/// This is mostly used for testing the static guarantees currently.
+/// A realistic implementation would probably take four cycles.
+module stallable_mult #(
+    parameter WIDTH = 32
+) (
+    input wire clk,
+    input wire reset,
+    input wire stall,
+    // inputs
+    input wire [WIDTH-1:0] left,
+    input wire [WIDTH-1:0] right,
+    // The input has been committed
+    output wire [WIDTH-1:0] out
+);
+
+logic [WIDTH-1:0] lt, rt, buff0, buff1, buff2, tmp_prod;
+
+assign out = buff2;
+assign tmp_prod = lt * rt;
+
+always_ff @(posedge clk) begin
+    if (reset) begin
+        lt <= 0;
+        rt <= 0;
+        buff0 <= 0;
+        buff1 <= 0;
+        buff2 <= 0;
+    end else if (!stall) begin
+        lt <= left;
+        rt <= right;
+        buff0 <= tmp_prod;
+        buff1 <= buff0;
+        buff2 <= buff1;
+    end
+end
+
+endmodule


### PR DESCRIPTION
Create a file for stallable primitives and add a stallable multiplier. Stallable primitives are very similar to pipelined primitives but have to ability to stall if an input stall signal is set to 1. When stall is 1, the multiplier will hold all values in inner registers at their current state until the stall value returns to 0. These kinds of primitives are useful for stallable pipelines which can arise when dealing with input dependent dynamic behavior.

I'm adding this as a separate primitives file instead of just changing the pipelined primitives to add a stall signal because in most use cases of pipelined primitives we don't want this signal. It likely could be optimized away by RTL synthesis, but I don't want users to have to think about it if they don't have to.