### PR TITLE
[fud2] Add `list` subcommand

### DIFF
--- a/fud2/fud-core/src/cli.rs
+++ b/fud2/fud-core/src/cli.rs
@@ -64,6 +64,11 @@ pub struct GetResource {
     output: Option<Utf8PathBuf>,
 }
 
+/// list the available states and ops
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "list")]
+pub struct ListCommand {}
+
 /// supported subcommands
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand)]
@@ -73,6 +78,9 @@ pub enum Subcommand {
 
     /// extract a resource file
     GetResource(GetResource),
+
+    /// list the available states and ops
+    List(ListCommand),
 }
 
 #[derive(FromArgs)]
@@ -245,6 +253,10 @@ pub fn cli(driver: &Driver) -> anyhow::Result<()> {
         }
         Some(Subcommand::GetResource(cmd)) => {
             return get_resource(driver, cmd);
+        }
+        Some(Subcommand::List(_)) => {
+            driver.print_info();
+            return Ok(());
         }
         None => {}
     }

--- a/fud2/fud-core/src/exec/driver.rs
+++ b/fud2/fud-core/src/exec/driver.rs
@@ -124,6 +124,10 @@ impl Driver {
         }
     }
 
+    /// Concot a plan to carry out the requested build.
+    ///
+    /// This works by searching for a path through the available operations from the input state
+    /// to the output state. If no such path exists in the operation graph, we return None.
     pub fn plan(&self, req: Request) -> Option<Plan> {
         // Find a path through the states.
         let path =
@@ -164,6 +168,9 @@ impl Driver {
         })
     }
 
+    /// Infer the state of a file based on its extension.
+    ///
+    /// Multiple states can use the same extension. The first state registered "wins."
     pub fn guess_state(&self, path: &Utf8Path) -> Option<StateRef> {
         let ext = path.extension()?;
         self.states
@@ -172,6 +179,7 @@ impl Driver {
             .map(|(state, _)| state)
     }
 
+    /// Look up a state by its name.
     pub fn get_state(&self, name: &str) -> Option<StateRef> {
         self.states
             .iter()
@@ -179,6 +187,7 @@ impl Driver {
             .map(|(state, _)| state)
     }
 
+    /// Look an operation by its name.
     pub fn get_op(&self, name: &str) -> Option<OpRef> {
         self.ops
             .iter()
@@ -189,6 +198,29 @@ impl Driver {
     /// The working directory to use when running a build.
     pub fn default_workdir(&self) -> Utf8PathBuf {
         format!(".{}", &self.name).into()
+    }
+
+    /// Print a list of registered states and operations to stdout.
+    pub fn print_info(&self) {
+        println!("States:");
+        for (_, state) in self.states.iter() {
+            print!("  {}:", state.name);
+            for ext in &state.extensions {
+                print!(" .{}", ext);
+            }
+            println!();
+        }
+
+        println!();
+        println!("Operations:");
+        for (_, op) in self.ops.iter() {
+            println!(
+                "  {}: {} -> {}",
+                op.name,
+                self.states[op.input].name,
+                self.states[op.output].name
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Just a really small task from #1878! This new `fud2 list` command just prints a list of all the registered states and operations, in case you forget a name or whatever.

The current output is:

```
$ fud2 list
States:
  verilog: .sv .v
  calyx: .futil
  dahlia: .fuse
  mrxl: .mrxl
  dat: .json
  vcd: .vcd
  sim: .exe
  verilog-noverify: .sv
  firrtl: .fir
  primitive-uses-json: .json
  debug:
  xo: .xo
  xclbin: .xclbin

Operations:
  calyx-to-verilog: calyx -> verilog
  dahlia-to-calyx: dahlia -> calyx
  mrxl-to-calyx: mrxl -> calyx
  simulate: sim -> dat
  trace: sim -> vcd
  calyx-noverify: calyx -> verilog-noverify
  icarus: verilog-noverify -> sim
  calyx-to-firrtl: calyx -> firrtl
  firrtl: firrtl -> verilog
  firrtl-noverify: firrtl -> verilog-noverify
  primitive-uses: calyx -> primitive-uses-json
  verilator: verilog -> sim
  interp: calyx -> dat
  debug: calyx -> debug
  xo: calyx -> xo
  xclbin: xo -> xclbin
  xrt: xclbin -> dat
  xrt-trace: xclbin -> vcd
```