### PR TITLE
[Calyx-FIRRTL] Initialize output ports

### DIFF
--- a/calyx-backend/src/firrtl.rs
+++ b/calyx-backend/src/firrtl.rs
@@ -95,7 +95,7 @@ fn emit_component<F: io::Write>(
     }
 
     // write invalid statements for all output ports.
-    for (_idx, port_ref) in sig.ports.iter().enumerate() {
+    for port_ref in sig.ports.iter() {
         let port = port_ref.as_ref();
         if port.borrow().direction == calyx_frontend::Direction::Input {
             write_invalid_initialization(port, f)?;

--- a/calyx-backend/src/firrtl.rs
+++ b/calyx-backend/src/firrtl.rs
@@ -97,18 +97,15 @@ fn emit_component<F: io::Write>(
     // FIXME: very hacky and code-cloney. I just need to get something to work for the deadline...
     for (_idx, port_ref) in sig.ports.iter().enumerate() {
         let port = port_ref.borrow();
-        match port.direction {
-            // hack to prevent FIRRTL to not get angry about non-initialized output ports.
-            calyx_frontend::Direction::Input => {
-                writeln!(
-                    f,
-                    "{}{} is invalid ; invalidate all output ports.",
-                    SPACING.repeat(2),
-                    port.name
-                )?;
-                dst_set.insert(port.canonical());
-            }
-            _ => {}
+        // hack to prevent FIRRTL to not get angry about non-initialized output ports.
+        if port.direction == calyx_frontend::Direction::Input {
+            writeln!(
+                f,
+                "{}{} is invalid ; invalidate all output ports.",
+                SPACING.repeat(2),
+                port.name
+            )?;
+            dst_set.insert(port.canonical());
         }
     }
 

--- a/calyx-backend/src/firrtl.rs
+++ b/calyx-backend/src/firrtl.rs
@@ -82,6 +82,8 @@ fn emit_component<F: io::Write>(
     comp: &ir::Component,
     f: &mut F,
 ) -> io::Result<()> {
+    let mut dst_set: HashSet<ir::Canonical> = HashSet::new();
+
     writeln!(f, "{}module {}:", SPACING, comp.name)?;
 
     // Inputs and Outputs
@@ -89,6 +91,25 @@ fn emit_component<F: io::Write>(
     for port_ref in &sig.ports {
         let port = port_ref.borrow();
         emit_port(port, true, f)?;
+    }
+
+    // write invalid statements for all output ports.
+    // FIXME: very hacky and code-cloney. I just need to get something to work for the deadline...
+    for (_idx, port_ref) in sig.ports.iter().enumerate() {
+        let port = port_ref.borrow();
+        match port.direction {
+            // hack to prevent FIRRTL to not get angry about non-initialized output ports.
+            calyx_frontend::Direction::Input => {
+                writeln!(
+                    f,
+                    "{}{} is invalid ; invalidate all output ports.",
+                    SPACING.repeat(2),
+                    port.name
+                )?;
+                dst_set.insert(port.canonical());
+            }
+            _ => {}
+        }
     }
 
     // Add a COMPONENT START: <name> anchor before any code in the component
@@ -118,7 +139,6 @@ fn emit_component<F: io::Write>(
         }
     }
 
-    let mut dst_set: HashSet<ir::Canonical> = HashSet::new();
     // Emit assignments
     for asgn in &comp.continuous_assignments {
         match asgn.guard.as_ref() {

--- a/calyx-backend/src/firrtl.rs
+++ b/calyx-backend/src/firrtl.rs
@@ -105,6 +105,7 @@ fn emit_component<F: io::Write>(
                 SPACING.repeat(2),
                 port.name
             )?;
+            writeln!(f, "{}{} <= UInt(0)", SPACING.repeat(2), port.name)?;
             dst_set.insert(port.canonical());
         }
     }

--- a/tests/backend/firrtl/and-or-not-guard.expect
+++ b/tests/backend/firrtl/and-or-not-guard.expect
@@ -9,10 +9,12 @@ circuit main:
         input clk: Clock
         input reset: UInt<1>
         output done: UInt<1>
-        ; COMPONENT START: main
-        done <= UInt(1)
         out is invalid ; default initialization
         out <= UInt(0)
+        done is invalid ; default initialization
+        done <= UInt(0)
+        ; COMPONENT START: main
+        done <= UInt(1)
         when and(or(not(cond), cond2), cond3):
             out <= in
         ; COMPONENT END: main

--- a/tests/backend/firrtl/basic-cell.expect
+++ b/tests/backend/firrtl/basic-cell.expect
@@ -12,6 +12,10 @@ circuit main:
         input clk: Clock
         input reset: UInt<1>
         output done: UInt<1>
+        out is invalid ; default initialization
+        out <= UInt(0)
+        done is invalid ; default initialization
+        done <= UInt(0)
         ; COMPONENT START: identity
         done <= UInt(1)
         out <= in
@@ -22,12 +26,12 @@ circuit main:
         input clk: Clock
         input reset: UInt<1>
         output done: UInt<1>
+        done is invalid ; default initialization
+        done <= UInt(0)
         ; COMPONENT START: main
         inst id of identity
         inst invoke0_go of std_wire_1
         inst invoke0_done of std_wire_1
-        done is invalid ; default initialization
-        done <= UInt(0)
         when invoke0_done.out:
             done <= UInt(1)
         id.clk <= clk

--- a/tests/backend/firrtl/basic-guard.expect
+++ b/tests/backend/firrtl/basic-guard.expect
@@ -7,10 +7,12 @@ circuit main:
         input clk: Clock
         input reset: UInt<1>
         output done: UInt<1>
-        ; COMPONENT START: main
-        done <= UInt(1)
         out is invalid ; default initialization
         out <= UInt(0)
+        done is invalid ; default initialization
+        done <= UInt(0)
+        ; COMPONENT START: main
+        done <= UInt(1)
         when cond:
             out <= in
         ; COMPONENT END: main

--- a/tests/backend/firrtl/basic-program.expect
+++ b/tests/backend/firrtl/basic-program.expect
@@ -6,6 +6,10 @@ circuit main:
         input clk: Clock
         input reset: UInt<1>
         output done: UInt<1>
+        out is invalid ; default initialization
+        out <= UInt(0)
+        done is invalid ; default initialization
+        done <= UInt(0)
         ; COMPONENT START: main
         done <= UInt(1)
         out <= in

--- a/tests/backend/firrtl/comparison-guard.expect
+++ b/tests/backend/firrtl/comparison-guard.expect
@@ -9,10 +9,12 @@ circuit main:
         input clk: Clock
         input reset: UInt<1>
         output done: UInt<1>
-        ; COMPONENT START: main
-        done <= UInt(1)
         out is invalid ; default initialization
         out <= UInt(0)
+        done is invalid ; default initialization
+        done <= UInt(0)
+        ; COMPONENT START: main
+        done <= UInt(1)
         when and(leq(var, var2), cond3):
             out <= in
         ; COMPONENT END: main

--- a/tests/backend/firrtl/or-guard.expect
+++ b/tests/backend/firrtl/or-guard.expect
@@ -8,10 +8,12 @@ circuit main:
         input clk: Clock
         input reset: UInt<1>
         output done: UInt<1>
-        ; COMPONENT START: main
-        done <= UInt(1)
         out is invalid ; default initialization
         out <= UInt(0)
+        done is invalid ; default initialization
+        done <= UInt(0)
+        ; COMPONENT START: main
+        done <= UInt(1)
         when or(cond, cond2):
             out <= in
         ; COMPONENT END: main

--- a/tests/backend/firrtl/primitive-cells.expect
+++ b/tests/backend/firrtl/primitive-cells.expect
@@ -19,6 +19,10 @@ circuit main:
         input clk: Clock
         input reset: UInt<1>
         output done: UInt<1>
+        out is invalid ; default initialization
+        out <= UInt(0)
+        done is invalid ; default initialization
+        done <= UInt(0)
         ; COMPONENT START: plus_one
         inst add of std_add_32
         done <= UInt(1)
@@ -32,12 +36,12 @@ circuit main:
         input clk: Clock
         input reset: UInt<1>
         output done: UInt<1>
+        done is invalid ; default initialization
+        done <= UInt(0)
         ; COMPONENT START: main
         inst po of plus_one
         inst invoke0_go of std_wire_1
         inst invoke0_done of std_wire_1
-        done is invalid ; default initialization
-        done <= UInt(0)
         when invoke0_done.out:
             done <= UInt(1)
         invoke0_go.in <= go

--- a/tests/backend/firrtl/two-or-guards.expect
+++ b/tests/backend/firrtl/two-or-guards.expect
@@ -10,10 +10,12 @@ circuit main:
         input clk: Clock
         input reset: UInt<1>
         output done: UInt<1>
-        ; COMPONENT START: main
-        done <= UInt(1)
         out is invalid ; default initialization
         out <= UInt(0)
+        done is invalid ; default initialization
+        done <= UInt(0)
+        ; COMPONENT START: main
+        done <= UInt(1)
         when or(cond, cond2):
             out <= in
         when or(cond2, cond3):


### PR DESCRIPTION
This should hopefully be a small PR! It contains changes to `firrtl.rs` and associated tests so that output ports are initialized to invalid and 0. (I ran into Calyx programs where externalized memories would never get written, causing the FIRRTL-to-Verilog compiler to complain that output ports that wrote to those memories were never initialized)

Please let me know if there's anything I can improve/fix here!