### PR TITLE
[fud2] Several more tests

### DIFF
--- a/fud2/tests/snapshots/tests__emit@calyx_debug.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_debug.snap
@@ -1,0 +1,48 @@
+---
+source: fud2/tests/tests.rs
+description: emit calyx -> debug
+---
+build-tool = fud2
+rule get-rsrc
+  command = $build-tool get-rsrc $out
+
+# RTL simulation
+python = python3
+build json-dat.py: get-rsrc
+rule hex-data
+  command = $python json-dat.py --from-json $in $out
+rule json-data
+  command = $python json-dat.py --to-json $out $in
+build tb.sv: get-rsrc
+sim_data = /test/data.json
+datadir = sim_data
+build $datadir: hex-data $sim_data | json-dat.py
+rule sim-run
+  command = ./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle-limit $args > $out
+cycle-limit = 500000000
+
+# Calyx compiler
+calyx-base = /test/calyx
+calyx-exe = $calyx-base/target/debug/calyx
+rule calyx
+  command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
+
+# Cider interpreter
+cider-exe = $calyx-base/target/debug/cider
+rule cider
+  command = $cider-exe -l $calyx-base --raw --data data.json $in > $out
+rule cider-debug
+  command = $cider-exe -l $calyx-base --data data.json $in debug || true
+  pool = console
+build interp-dat.py: get-rsrc
+python = python3
+rule dat-to-interp
+  command = $python interp-dat.py --to-interp $in
+rule interp-to-dat
+  command = $python interp-dat.py --from-interp $in $sim_data > $out
+build data.json: dat-to-interp $sim_data | interp-dat.py
+
+# build targets
+build _pseudo_debug: cider-debug stdin | data.json
+
+default _pseudo_debug

--- a/fud2/tests/snapshots/tests__emit@calyx_icarus_dat.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_icarus_dat.snap
@@ -1,0 +1,45 @@
+---
+source: fud2/tests/tests.rs
+description: emit calyx -> dat through icarus
+---
+build-tool = fud2
+rule get-rsrc
+  command = $build-tool get-rsrc $out
+
+# Calyx compiler
+calyx-base = /test/calyx
+calyx-exe = $calyx-base/target/debug/calyx
+rule calyx
+  command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
+
+# RTL simulation
+python = python3
+build json-dat.py: get-rsrc
+rule hex-data
+  command = $python json-dat.py --from-json $in $out
+rule json-data
+  command = $python json-dat.py --to-json $out $in
+build tb.sv: get-rsrc
+sim_data = /test/data.json
+datadir = sim_data
+build $datadir: hex-data $sim_data | json-dat.py
+rule sim-run
+  command = ./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle-limit $args > $out
+cycle-limit = 500000000
+
+# Icarus Verilog
+iverilog = iverilog
+rule icarus-compile
+  command = $iverilog -g2012 -o $out tb.sv $in
+
+# build targets
+build stdin.sv: calyx stdin
+  backend = verilog
+  args = --disable-verify
+build stdin.exe: icarus-compile stdin.sv | tb.sv
+build sim.log: sim-run stdin.exe $datadir
+  bin = stdin.exe
+  args = +NOTRACE=1
+build stdin.json: json-data $datadir sim.log | json-dat.py
+
+default stdin.json

--- a/fud2/tests/snapshots/tests__emit@calyx_icarus_vcd.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_icarus_vcd.snap
@@ -1,0 +1,44 @@
+---
+source: fud2/tests/tests.rs
+description: emit calyx -> vcd through icarus
+---
+build-tool = fud2
+rule get-rsrc
+  command = $build-tool get-rsrc $out
+
+# Calyx compiler
+calyx-base = /test/calyx
+calyx-exe = $calyx-base/target/debug/calyx
+rule calyx
+  command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
+
+# RTL simulation
+python = python3
+build json-dat.py: get-rsrc
+rule hex-data
+  command = $python json-dat.py --from-json $in $out
+rule json-data
+  command = $python json-dat.py --to-json $out $in
+build tb.sv: get-rsrc
+sim_data = /test/data.json
+datadir = sim_data
+build $datadir: hex-data $sim_data | json-dat.py
+rule sim-run
+  command = ./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle-limit $args > $out
+cycle-limit = 500000000
+
+# Icarus Verilog
+iverilog = iverilog
+rule icarus-compile
+  command = $iverilog -g2012 -o $out tb.sv $in
+
+# build targets
+build stdin.sv: calyx stdin
+  backend = verilog
+  args = --disable-verify
+build stdin.exe: icarus-compile stdin.sv | tb.sv
+build sim.log stdin.vcd: sim-run stdin.exe $datadir
+  bin = stdin.exe
+  args = +NOTRACE=0 +OUT=stdin.vcd
+
+default stdin.vcd

--- a/fud2/tests/snapshots/tests__emit@calyx_interp_dat.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_interp_dat.snap
@@ -1,0 +1,49 @@
+---
+source: fud2/tests/tests.rs
+description: emit calyx -> dat through interp
+---
+build-tool = fud2
+rule get-rsrc
+  command = $build-tool get-rsrc $out
+
+# RTL simulation
+python = python3
+build json-dat.py: get-rsrc
+rule hex-data
+  command = $python json-dat.py --from-json $in $out
+rule json-data
+  command = $python json-dat.py --to-json $out $in
+build tb.sv: get-rsrc
+sim_data = /test/data.json
+datadir = sim_data
+build $datadir: hex-data $sim_data | json-dat.py
+rule sim-run
+  command = ./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle-limit $args > $out
+cycle-limit = 500000000
+
+# Calyx compiler
+calyx-base = /test/calyx
+calyx-exe = $calyx-base/target/debug/calyx
+rule calyx
+  command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
+
+# Cider interpreter
+cider-exe = $calyx-base/target/debug/cider
+rule cider
+  command = $cider-exe -l $calyx-base --raw --data data.json $in > $out
+rule cider-debug
+  command = $cider-exe -l $calyx-base --data data.json $in debug || true
+  pool = console
+build interp-dat.py: get-rsrc
+python = python3
+rule dat-to-interp
+  command = $python interp-dat.py --to-interp $in
+rule interp-to-dat
+  command = $python interp-dat.py --from-interp $in $sim_data > $out
+build data.json: dat-to-interp $sim_data | interp-dat.py
+
+# build targets
+build interp_out.json: cider stdin | data.json
+build stdin.json: interp-to-dat interp_out.json | $sim_data interp-dat.py
+
+default stdin.json

--- a/fud2/tests/snapshots/tests__emit@calyx_verilator_dat.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_verilator_dat.snap
@@ -1,0 +1,49 @@
+---
+source: fud2/tests/tests.rs
+description: emit calyx -> dat through verilator
+---
+build-tool = fud2
+rule get-rsrc
+  command = $build-tool get-rsrc $out
+
+# Calyx compiler
+calyx-base = /test/calyx
+calyx-exe = $calyx-base/target/debug/calyx
+rule calyx
+  command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
+
+# RTL simulation
+python = python3
+build json-dat.py: get-rsrc
+rule hex-data
+  command = $python json-dat.py --from-json $in $out
+rule json-data
+  command = $python json-dat.py --to-json $out $in
+build tb.sv: get-rsrc
+sim_data = /test/data.json
+datadir = sim_data
+build $datadir: hex-data $sim_data | json-dat.py
+rule sim-run
+  command = ./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle-limit $args > $out
+cycle-limit = 500000000
+
+# Verilator
+verilator = verilator
+cycle-limit = 500000000
+rule verilator-compile
+  command = $verilator $in tb.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir
+rule cp
+  command = cp $in $out
+
+# build targets
+build stdin.sv: calyx stdin
+  backend = verilog
+build verilator-out/VTOP: verilator-compile stdin.sv | tb.sv
+  out-dir = verilator-out
+build stdin.exe: cp verilator-out/VTOP
+build sim.log: sim-run stdin.exe $datadir
+  bin = stdin.exe
+  args = +NOTRACE=1
+build stdin.json: json-data $datadir sim.log | json-dat.py
+
+default stdin.json

--- a/fud2/tests/snapshots/tests__emit@calyx_verilator_vcd.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_verilator_vcd.snap
@@ -1,0 +1,48 @@
+---
+source: fud2/tests/tests.rs
+description: emit calyx -> vcd through verilator
+---
+build-tool = fud2
+rule get-rsrc
+  command = $build-tool get-rsrc $out
+
+# Calyx compiler
+calyx-base = /test/calyx
+calyx-exe = $calyx-base/target/debug/calyx
+rule calyx
+  command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
+
+# RTL simulation
+python = python3
+build json-dat.py: get-rsrc
+rule hex-data
+  command = $python json-dat.py --from-json $in $out
+rule json-data
+  command = $python json-dat.py --to-json $out $in
+build tb.sv: get-rsrc
+sim_data = /test/data.json
+datadir = sim_data
+build $datadir: hex-data $sim_data | json-dat.py
+rule sim-run
+  command = ./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle-limit $args > $out
+cycle-limit = 500000000
+
+# Verilator
+verilator = verilator
+cycle-limit = 500000000
+rule verilator-compile
+  command = $verilator $in tb.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir
+rule cp
+  command = cp $in $out
+
+# build targets
+build stdin.sv: calyx stdin
+  backend = verilog
+build verilator-out/VTOP: verilator-compile stdin.sv | tb.sv
+  out-dir = verilator-out
+build stdin.exe: cp verilator-out/VTOP
+build sim.log stdin.vcd: sim-run stdin.exe $datadir
+  bin = stdin.exe
+  args = +NOTRACE=0 +OUT=stdin.vcd
+
+default stdin.vcd

--- a/fud2/tests/snapshots/tests__emit@calyx_xrt-trace_vcd.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_xrt-trace_vcd.snap
@@ -1,0 +1,74 @@
+---
+source: fud2/tests/tests.rs
+description: emit calyx -> vcd through xrt-trace
+---
+build-tool = fud2
+rule get-rsrc
+  command = $build-tool get-rsrc $out
+
+# Calyx compiler
+calyx-base = /test/calyx
+calyx-exe = $calyx-base/target/debug/calyx
+rule calyx
+  command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
+
+# Xilinx tools
+vivado-dir = /test/xilinx/vivado
+vitis-dir = /test/xilinx/vitis
+build gen_xo.tcl: get-rsrc
+build get-ports.py: get-rsrc
+python = python3
+rule gen-xo
+  command = $vivado-dir/bin/vivado -mode batch -source gen_xo.tcl -tclargs $out `$python get-ports.py kernel.xml`
+  pool = console
+xilinx-mode = hw_emu
+platform = xilinx_u50_gen3x16_xdma_201920_3
+rule compile-xclbin
+  command = $vitis-dir/bin/v++ -g -t $xilinx-mode --platform $platform --save-temps --profile.data all:all:all --profile.exec all:all:all -lo $out $in
+  pool = console
+
+# RTL simulation
+python = python3
+build json-dat.py: get-rsrc
+rule hex-data
+  command = $python json-dat.py --from-json $in $out
+rule json-data
+  command = $python json-dat.py --to-json $out $in
+build tb.sv: get-rsrc
+sim_data = /test/data.json
+datadir = sim_data
+build $datadir: hex-data $sim_data | json-dat.py
+rule sim-run
+  command = ./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle-limit $args > $out
+cycle-limit = 500000000
+
+# Xilinx execution via XRT
+rule emconfig
+  command = $vitis-dir/bin/emconfigutil --platform $platform
+build emconfig.json: emconfig
+xrt-dir = /test/xilinx/xrt
+rule xclrun
+  command = bash -c 'source $vitis-dir/settings64.sh ; source $xrt-dir/setup.sh ; XRT_INI_PATH=$xrt_ini EMCONFIG_PATH=. XCL_EMULATION_MODE=$xilinx-mode $python -m fud.xclrun --out $out $in'
+  pool = console
+rule echo
+  command = echo $contents > $out
+build pre_sim.tcl: echo  | 
+  contents = open_vcd\\nlog_vcd *\\n
+build post_sim.tcl: echo  | 
+  contents = close_vcd\\n
+
+# build targets
+build main.sv: calyx stdin
+  backend = verilog
+  args = --synthesis -p external
+build toplevel.v: calyx stdin
+  backend = xilinx
+build kernel.xml: calyx stdin
+  backend = xilinx-xml
+build stdin.xo: gen-xo | main.sv toplevel.v kernel.xml gen_xo.tcl get-ports.py
+build stdin.xclbin: compile-xclbin stdin.xo
+build xrt_trace.ini: get-rsrc
+build stdin.vcd: xclrun stdin.xclbin $sim_data | emconfig.json pre_sim.tcl post_sim.tcl xrt_trace.ini
+  xrt_ini = xrt_trace.ini
+
+default stdin.vcd

--- a/fud2/tests/snapshots/tests__emit@calyx_xrt_dat.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_xrt_dat.snap
@@ -1,0 +1,74 @@
+---
+source: fud2/tests/tests.rs
+description: emit calyx -> dat through xrt
+---
+build-tool = fud2
+rule get-rsrc
+  command = $build-tool get-rsrc $out
+
+# Calyx compiler
+calyx-base = /test/calyx
+calyx-exe = $calyx-base/target/debug/calyx
+rule calyx
+  command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
+
+# Xilinx tools
+vivado-dir = /test/xilinx/vivado
+vitis-dir = /test/xilinx/vitis
+build gen_xo.tcl: get-rsrc
+build get-ports.py: get-rsrc
+python = python3
+rule gen-xo
+  command = $vivado-dir/bin/vivado -mode batch -source gen_xo.tcl -tclargs $out `$python get-ports.py kernel.xml`
+  pool = console
+xilinx-mode = hw_emu
+platform = xilinx_u50_gen3x16_xdma_201920_3
+rule compile-xclbin
+  command = $vitis-dir/bin/v++ -g -t $xilinx-mode --platform $platform --save-temps --profile.data all:all:all --profile.exec all:all:all -lo $out $in
+  pool = console
+
+# RTL simulation
+python = python3
+build json-dat.py: get-rsrc
+rule hex-data
+  command = $python json-dat.py --from-json $in $out
+rule json-data
+  command = $python json-dat.py --to-json $out $in
+build tb.sv: get-rsrc
+sim_data = /test/data.json
+datadir = sim_data
+build $datadir: hex-data $sim_data | json-dat.py
+rule sim-run
+  command = ./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle-limit $args > $out
+cycle-limit = 500000000
+
+# Xilinx execution via XRT
+rule emconfig
+  command = $vitis-dir/bin/emconfigutil --platform $platform
+build emconfig.json: emconfig
+xrt-dir = /test/xilinx/xrt
+rule xclrun
+  command = bash -c 'source $vitis-dir/settings64.sh ; source $xrt-dir/setup.sh ; XRT_INI_PATH=$xrt_ini EMCONFIG_PATH=. XCL_EMULATION_MODE=$xilinx-mode $python -m fud.xclrun --out $out $in'
+  pool = console
+rule echo
+  command = echo $contents > $out
+build pre_sim.tcl: echo  | 
+  contents = open_vcd\\nlog_vcd *\\n
+build post_sim.tcl: echo  | 
+  contents = close_vcd\\n
+
+# build targets
+build main.sv: calyx stdin
+  backend = verilog
+  args = --synthesis -p external
+build toplevel.v: calyx stdin
+  backend = xilinx
+build kernel.xml: calyx stdin
+  backend = xilinx-xml
+build stdin.xo: gen-xo | main.sv toplevel.v kernel.xml gen_xo.tcl get-ports.py
+build stdin.xclbin: compile-xclbin stdin.xo
+build xrt.ini: get-rsrc
+build stdin.json: xclrun stdin.xclbin $sim_data | emconfig.json xrt.ini
+  xrt_ini = xrt.ini
+
+default stdin.json

--- a/fud2/tests/snapshots/tests__emit@dahlia_calyx.snap
+++ b/fud2/tests/snapshots/tests__emit@dahlia_calyx.snap
@@ -1,0 +1,17 @@
+---
+source: fud2/tests/tests.rs
+description: emit dahlia -> calyx
+---
+build-tool = fud2
+rule get-rsrc
+  command = $build-tool get-rsrc $out
+
+# Dahlia compiler
+dahlia-exe = /test/bin/dahlia
+rule dahlia-to-calyx
+  command = $dahlia-exe -b calyx --lower -l error $in -o $out
+
+# build targets
+build stdin.futil: dahlia-to-calyx stdin
+
+default stdin.futil

--- a/fud2/tests/snapshots/tests__emit@mrxl_calyx.snap
+++ b/fud2/tests/snapshots/tests__emit@mrxl_calyx.snap
@@ -1,0 +1,17 @@
+---
+source: fud2/tests/tests.rs
+description: emit mrxl -> calyx
+---
+build-tool = fud2
+rule get-rsrc
+  command = $build-tool get-rsrc $out
+
+# MrXL compiler
+mrxl-exe = mrxl
+rule mrxl-to-calyx
+  command = $mrxl-exe $in > $out
+
+# build targets
+build stdin.futil: mrxl-to-calyx stdin
+
+default stdin.futil

--- a/fud2/tests/tests.rs
+++ b/fud2/tests/tests.rs
@@ -82,15 +82,13 @@ fn test_emit(driver: &Driver, req: Request) {
 #[test]
 fn calyx_to_verilog() {
     let driver = test_driver();
-    let req = request(&driver, "calyx", "verilog", &[]);
-    test_emit(&driver, req);
+    test_emit(&driver, request(&driver, "calyx", "verilog", &[]));
 }
 
 #[test]
 fn calyx_via_firrtl() {
     let driver = test_driver();
-    let req = request(&driver, "calyx", "verilog", &["firrtl"]);
-    test_emit(&driver, req);
+    test_emit(&driver, request(&driver, "calyx", "verilog", &["firrtl"]));
 }
 
 #[test]
@@ -98,8 +96,7 @@ fn sim_tests() {
     let driver = test_driver();
     for dest in &["dat", "vcd"] {
         for sim in &["icarus", "verilator"] {
-            let req = request(&driver, "calyx", dest, &[sim]);
-            test_emit(&driver, req);
+            test_emit(&driver, request(&driver, "calyx", dest, &[sim]));
         }
     }
 }

--- a/fud2/tests/tests.rs
+++ b/fud2/tests/tests.rs
@@ -31,7 +31,11 @@ fn emit_ninja(driver: &Driver, req: Request) -> String {
         .merge(("exe", "fud2"))
         .merge(("calyx.base", "/test/calyx"))
         .merge(("firrtl.exe", "/test/bin/firrtl"))
-        .merge(("sim.data", "/test/data.json"));
+        .merge(("sim.data", "/test/data.json"))
+        .merge(("xilinx.vivado", "/test/xilinx/vivado"))
+        .merge(("xilinx.vitis", "/test/xilinx/vitis"))
+        .merge(("xilinx.xrt", "/test/xilinx/xrt"))
+        .merge(("dahlia", "/test/bin/dahlia"));
     let run = Run::with_config(driver, plan, config);
     let mut buf = vec![];
     run.emit(&mut buf).unwrap();
@@ -98,5 +102,27 @@ fn sim_tests() {
         for sim in &["icarus", "verilator"] {
             test_emit(&driver, request(&driver, "calyx", dest, &[sim]));
         }
+    }
+}
+
+#[test]
+fn cider_tests() {
+    let driver = test_driver();
+    test_emit(&driver, request(&driver, "calyx", "dat", &["interp"]));
+    test_emit(&driver, request(&driver, "calyx", "debug", &[]));
+}
+
+#[test]
+fn xrt_tests() {
+    let driver = test_driver();
+    test_emit(&driver, request(&driver, "calyx", "dat", &["xrt"]));
+    test_emit(&driver, request(&driver, "calyx", "vcd", &["xrt-trace"]));
+}
+
+#[test]
+fn frontend_tests() {
+    let driver = test_driver();
+    for frontend in &["dahlia", "mrxl"] {
+        test_emit(&driver, request(&driver, frontend, "calyx", &[]));
     }
 }


### PR DESCRIPTION
A follow-up to #1954. And part of #1878.

Just adds a bunch more tests to fud2 using the setup I created recently. Now every op in fud2 is covered except for `primitive-uses`; this should probably be covered once we have a more complete FIRRTL pipeline in here that depends on it.

(Incidentally, I had to look around for code coverage tools for Rust. I found I liked [llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) more than the more popular [tarpaulin](https://github.com/xd009642/tarpaulin). The main problem I had with the latter is that I couldn't filter out all the rest of the source files—so there was this giant list of source files with 0% coverage from the rest of the entire Calyx workspace. Surely there is a flag to just focus on one crate/subdirectory, but I couldn't find it? Anyway, llvm-cov did the right thing by default.)