### PR TITLE
Let calyx-ir build with `serialize` feature

### DIFF
--- a/calyx-ir/Cargo.toml
+++ b/calyx-ir/Cargo.toml
@@ -13,7 +13,7 @@ readme.workspace = true
 
 [features]
 default = []
-serialize = ["serde/derive", "dep:serde_with", "calyx-utils/serialize", "calyx-frontend/serialize", "smallvec/serde"]
+serialize = ["serde/derive", "dep:serde_with", "calyx-utils/serialize", "calyx-frontend/serialize", "smallvec/serde", "serde/rc"]
 
 [dependencies]
 log.workspace = true


### PR DESCRIPTION
Previously, running `cargo build --features serialize` from `calyx-ir` did not build properly. It would only build properly from the root directory. This PR lets the above command build successfully. I imagine this is what we want?

cc @rachitnigam @EclecticGriffin just to make sure this is right.