### PR TITLE
Add playground config validation script and CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validate-playground-config:
+    name: Validate playground config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+            toolchain: stable
+      - name: Build calyx dev
+        run: cargo build
+      - name: Check calyx build
+        run: ./target/debug/calyx --version
+      - name: validate playground config
+        run: node web/validate-data.js 
+
   # Get the hash of the Dockerfile
   hash:
     name: Get Docker Hash

--- a/web/data/config.json
+++ b/web/data/config.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "Invoke (call)",
-      "file": "tests/passes/compile-invoke.futil",
+      "file": "tests/passes/compile-invoke/compile-invoke.futil",
       "root": "/",
       "passes": [
         "compile-invoke"
@@ -52,37 +52,18 @@
       ]
     },
     {
-      "name": "Infer Static Timing",
-      "file": "tests/passes/infer-static/component.futil",
-      "root": "/",
-      "passes": [
-        "infer-static-timing"
-      ]
-    },
-    {
       "name": "Minimize Regs Simple",
-      "file": "tests/passes/minimize-regs/simple-liveness.futil",
+      "file": "tests/passes/cell-share/simple-liveness.futil",
       "root": "/",
       "passes": [
-        "minimize-regs",
         "dead-cell-removal"
       ]
     },
     {
       "name": "Minimize Regs (Nested Par)",
-      "file": "tests/passes/minimize-regs/nested-par.futil",
+      "file": "tests/passes/cell-share/nested-par.futil",
       "root": "/",
       "passes": [
-        "minimize-regs",
-        "dead-cell-removal"
-      ]
-    },
-    {
-      "name": "Resource Sharing",
-      "file": "tests/passes/resource-sharing/share.futil",
-      "root": "/",
-      "passes": [
-        "resource-sharing",
         "dead-cell-removal"
       ]
     }

--- a/web/data/passes.json
+++ b/web/data/passes.json
@@ -26,26 +26,6 @@
             "description": "collapse-control"
         },
         {
-            "name": "infer-static-timing",
-            "title": "Infer Static Timing",
-            "description": "infer-static-timing"
-        },
-        {
-            "name": "resource-sharing",
-            "title": "Resource Sharing",
-            "description": "resource-sharing"
-        },
-        {
-            "name": "minimize-regs",
-            "title": "Minimize Regs",
-            "description": "minimize-regs"
-        },
-        {
-            "name": "compile-empty",
-            "title": "Compile Empty",
-            "description": "compile-empty"
-        },
-        {
             "name": "simplify-with-control",
             "title": "Remove combinational groups",
             "description": "tdcc"
@@ -69,11 +49,6 @@
             "name": "go-insertion",
             "title": "Go Insertion",
             "description": "go-insertion"
-        },
-        {
-            "name": "component-interface-inserter",
-            "title": "Component Interface Inserter",
-            "description": "component-interface-inserter"
         },
         {
             "name": "hole-inliner",

--- a/web/validate-data.js
+++ b/web/validate-data.js
@@ -5,19 +5,19 @@ const config = require("./data/config.json");
 const passes = require("./data/passes.json").passes.map((p) => p.name);
 const examples = config.examples;
 
-const PASS_OUTPUT_PREFIX = "- all:";
-
 // we assume that we have a debug build of calyx ready
 const _spawned = childProcess.spawnSync(
   path.join(__dirname, "..", "target/debug/calyx"),
   ["pass-help"],
 );
 const op = new String(_spawned.stdout);
-const compileAliases = op.split("Aliases:\n")[1];
-const allPasses = compileAliases
+const passList = op.split("Aliases:\n")[0];
+const allPasses = passList
   .split("\n")
-  .filter((s) => s.startsWith(PASS_OUTPUT_PREFIX))[0]
-  .replace(PASS_OUTPUT_PREFIX, "");
+  .filter((s) => s.startsWith("-")) // each pass in the list starts with - , eg: - tdcc: something-about-tdcc
+  .map((s)=>s.split(":")[0]) // split by : to get the pass name and skip desc, eg : - tdcc
+  .map((s)=>s.replace("-","").trim()) // replcae the initial -  and trim. Note this will not replace - from pass names, only the leading one
+  .join(",");
 
 const errors = [];
 

--- a/web/validate-data.js
+++ b/web/validate-data.js
@@ -1,0 +1,46 @@
+const fs = require("fs");
+const path = require("path");
+const childProcess = require("child_process");
+const config = require("./data/config.json");
+const passes = require("./data/passes.json").passes.map((p) => p.name);
+const examples = config.examples;
+
+const PASS_OUTPUT_PREFIX = "- all:";
+
+// we assume that we have a debug build of calyx ready
+const _spawned = childProcess.spawnSync(
+  path.join(__dirname, "..", "target/debug/calyx"),
+  ["pass-help"],
+);
+const op = new String(_spawned.stdout);
+const compileAliases = op.split("Aliases:\n")[1];
+const allPasses = compileAliases
+  .split("\n")
+  .filter((s) => s.startsWith(PASS_OUTPUT_PREFIX))[0]
+  .replace(PASS_OUTPUT_PREFIX, "");
+
+const errors = [];
+
+for (const pass of passes) {
+  if (!allPasses.includes(pass)) {
+    errors.push(`pass ${pass} is not valid`);
+  }
+}
+
+const validPasses = passes.filter((p) => allPasses.includes(p));
+
+for (const eg of examples) {
+  const filepath = path.join(__dirname, "..", eg.file);
+  if (!fs.existsSync(filepath)) {
+    errors.push(`file ${eg.file} does not exist`);
+  }
+  for (const pass of eg.passes) {
+    if (!validPasses.includes(pass)) {
+      errors.push(`pass ${pass} for example ${eg.name} is invalid`);
+    }
+  }
+}
+if (errors.length > 0) {
+  console.error(errors);
+  process.exit(1);
+}


### PR DESCRIPTION
closes #1737 
ref : https://github.com/calyxir/calyx/issues/1737#issuecomment-1986905609

Sorry it took a bit of time to get this up, got busy in other things...

This adds a node script which will validate that 
1. All passes listed in the passes.json are valid (cross checking with calyx pass-help o/p)
2. all example files that are in config.json are actually present

Currently parked the CI in rust.yaml, as I figured it would be better to run on each push, can move to other yaml as per suggestions.

Also instead of checking with master, the files are checked at local level, so that addition of new file or removal of existing file is correctly detected. I can also add a step to post a comment on PR if the validation fails, but might be overkill.

Once suggested changes are added, will remove the non existent passes and example files so the CI passes. Example of failing CI https://github.com/YJDoc2/calyx/actions/runs/8331868876/job/22799692081

@sampsyo please take a look, thanks :)