### PR TITLE
Update CI to run on fork-based PRs and use proper repo when checking out

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     name: Docs website
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,6 +1,9 @@
 name: Format
 
-on: [push]
+on:
+  push: # allow for all branches, so forks can also validate on their own
+  pull_request:
+    branches: [main]
 
 jobs:
   format:
@@ -8,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install stable
       uses: actions-rs/toolchain@v1
       with:
@@ -37,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Fud Formatting check
         uses: psf/black@stable
         with:

--- a/.github/workflows/fud2.yml
+++ b/.github/workflows/fud2.yml
@@ -2,7 +2,6 @@ name: fud2 tests
 
 on:
   push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,9 @@
 name: Test
 
-on: [push]
+on:
+  push:
+  pull_request:
+    branches: [main]
 
 # Ensures that only the latest commit of a PR can execute the actions.
 # Useful for cancelling job when a sequence of commits are quickly added.
@@ -18,7 +21,7 @@ jobs:
       exists: ${{ steps.exists.outputs.exists }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: calyxir/calyx
           ref: ${{ github.sha }}
@@ -83,7 +86,7 @@ jobs:
       working-directory: /home/calyx
       run: |
         git init
-        git remote add origin https://github.com/calyxir/calyx.git
+        git remote add origin https://github.com/${{ github.repository }}.git
         git fetch --all
         git checkout -f $GITHUB_SHA
         git clean -fd
@@ -134,7 +137,7 @@ jobs:
       working-directory: /home/calyx
       run: |
         git init
-        git remote add origin https://github.com/calyxir/calyx.git
+        git remote add origin https://github.com/${{ github.repository }}.git
         git fetch --all
         git checkout -f $GITHUB_SHA
         git clean -fd
@@ -193,7 +196,7 @@ jobs:
       working-directory: /home/calyx
       run: |
         git init
-        git remote add origin https://github.com/calyxir/calyx.git
+        git remote add origin https://github.com/${{ github.repository }}.git
         git fetch --all
         git checkout -f $GITHUB_SHA
         git clean -fd

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,6 +88,7 @@ jobs:
         git init
         git remote add origin https://github.com/${{ github.repository }}.git
         git fetch --all
+        git fetch origin $GITHUB_REF
         git checkout -f $GITHUB_SHA
         git clean -fd
 
@@ -139,6 +140,7 @@ jobs:
         git init
         git remote add origin https://github.com/${{ github.repository }}.git
         git fetch --all
+        git fetch origin $GITHUB_REF
         git checkout -f $GITHUB_SHA
         git clean -fd
 
@@ -198,6 +200,7 @@ jobs:
         git init
         git remote add origin https://github.com/${{ github.repository }}.git
         git fetch --all
+        git fetch origin $GITHUB_REF
         git checkout -f $GITHUB_SHA
         git clean -fd
 

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -19,7 +19,7 @@ jobs:
     container: ghcr.io/cucapra/calyx:latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Get bwrap for opam
       run: |
         apt-get update -y


### PR DESCRIPTION
ref : https://github.com/calyxir/calyx/pull/1976#issuecomment-2005781427

As of now, most of CI workflows (expect fud2 tests) only work on push event, which is triggered in the context of repo where the branch is. So when I make any changes in my fork, and open a PR, it does not correctly run CI on PR, and the the  status checks that are required are always pending. see https://github.com/calyxir/calyx/pull/1976

This PR does following changes :
1. change most CI events to push and pull_request , so that PRs from fork  can have their CI properly run
2. use correct URL in the container based tests, so that when they run on forks, the checkout doesn't fail. As of now, it is hard-coded to this repo, but that fails when run on forks, as the commit done there is not present here, hence it fails.
3. Update actions/checkout to v4 , as v2 and v3 are old 

There is some security concerns regarding the `pull_request` v/s `pull_request_target` events, with latter being more "dangerous" . The main point of concern here is pushing docker image,  but I think the push tagging/url is set correctly, and the `pull_request` is the correct event here ; but someone else should also verify this.

On a side note, in the interpreter tests, [see run here](https://github.com/YJDoc2/calyx/actions/runs/8345605970/job/22840930020) ,  there are a lot of warnings in `source code tests` of 
```
WARN Computation under/overflowed (5475150119556378183249983036156166840 -> 2429530781374366392), source: 
```
 Are these expected ?