### PR TITLE
Fix hyperlinks to documentation for fud/frontends

### DIFF
--- a/docs/debug/cider.md
+++ b/docs/debug/cider.md
@@ -277,6 +277,6 @@ much of the execution is occurring in parallel at any given point.
 Use `help` to see all commands. Use `exit` to exit the debugger.
 
 
-[fud]: ../fud/index.md
+[fud]: ../running-calyx/fud/index.md
 [gdb]: https://sourceware.org/gdb/
 [interp]: ../interpreter.md

--- a/docs/debug/index.md
+++ b/docs/debug/index.md
@@ -9,7 +9,7 @@ Interpreter](../interpreter.md). If it produces the wrong values, your Calyx imp
 algorithm is incorrect. You can use the [Calyx Debugger](./cider.md) to debug these problems.
 
 If the interpreter produces the right values, try a different Verilog backed. We support both
-[Verilator](../fud/index.md#verilator) and [Icarus Verilog](../fud/index.md#icarus-verilog). If
+[Verilator](../running-calyx/fud/index.md#verilator) and [Icarus Verilog](../running-calyx/fud/index.md#icarus-verilog). If
 both produce the wrong answer *and* the interpreter produces the right answer then you likely have
 a compilation bug on your hands. Use the [debugging tips][tips] to narrow down the pass that causes
 the error.

--- a/docs/frontends/mrxl.md
+++ b/docs/frontends/mrxl.md
@@ -26,7 +26,7 @@ following after changing your directory to `frontend/mrxl`:
 
 This creates a symbolic link to the present directory and installs the `mrxl` command line tool.
 
-By default, [fud](../fud) looks for the `mrxl` executable to enable
+By default, [fud](../running-calyx/fud) looks for the `mrxl` executable to enable
 the `mrxl` compilation stage.
 Type `fud check` to make sure `fud` reports that the `mrxl` compiler has been
 found. If it does not, run the following while still in `frontend/mrxl`.

--- a/docs/frontends/ntt.md
+++ b/docs/frontends/ntt.md
@@ -31,7 +31,7 @@ during each stage of the pipeline. This requires installing PrettyTable:
 
 ## Fud Stage
 
-The NTT pipeline defines an [external fud stage][../fud/external.md] to
+The NTT pipeline defines an [external fud stage][../running-calyx/fud/external.md] to
 transform configuration files into Calyx programs.
 To install, run:
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -166,7 +166,7 @@ Congratulations! You've simulated your first hardware design with Calyx.
 [dahlia]: https://github.com/cucapra/dahlia
 [dahlia-install]: https://github.com/cucapra/dahlia#set-it-up
 [sbt]: https://www.scala-sbt.org/download.html
-[interpreter]: ./interpreter.md
+[interpreter]: ./running-calyx/interpreter.md
 [homebrew]: https://brew.sh
 [fud-icarus]: ./running-calyx/fud/index.md#icarus-verilog
 [fud-verilator]: ./running-calyx/fud/index.md#verilator

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -81,7 +81,7 @@ tests.
 
 ## Installing the Command-Line Driver
 
-[The Calyx driver](./fud) wraps the various compiler frontends and
+[The Calyx driver](./running-calyx/fud) wraps the various compiler frontends and
 backends to simplify running Calyx programs.
 
 Install [Flit][]:
@@ -146,8 +146,8 @@ Congratulations! You've simulated your first hardware design with Calyx.
 
 - [How can I setup syntax highlighting in my editor?](./tools/editor-highlighting.md)
 - [How does the language work?](./tutorial/language-tut.md)
-- [How do I install Calyx frontends?](./fud/index.html#dahlia-fronted)
-- [Where can I see further examples with `fud`?](./fud/examples.md)
+- [How do I install Calyx frontends?](./running-calyx/fud/index.html#dahlia-fronted)
+- [Where can I see further examples with `fud`?](./running-calyx/fud/examples.md)
 - [How do I write a frontend for Calyx?](./tutorial/frontend-tut.md)
 
 
@@ -168,8 +168,8 @@ Congratulations! You've simulated your first hardware design with Calyx.
 [sbt]: https://www.scala-sbt.org/download.html
 [interpreter]: ./interpreter.md
 [homebrew]: https://brew.sh
-[fud-icarus]: ./fud/index.md#icarus-verilog
-[fud-verilator]: ./fud/index.md#verilator
+[fud-icarus]: ./running-calyx/fud/index.md#icarus-verilog
+[fud-verilator]: ./running-calyx/fud/index.md#verilator
 [icarus-install-source]: https://iverilog.fandom.com/wiki/Installation_Guide#Installation_From_Source
 [calyx-crate]: https://crates.io/crates/calyx
 [core-lib]: https://github.com/calyxir/calyx/blob/master/primitives/core.futil

--- a/docs/lang/data-format.md
+++ b/docs/lang/data-format.md
@@ -81,8 +81,8 @@ Often times, it can be useful to automatically generate random values for a larg
 
 [toplevel-attr]: attributes.md#toplevel
 [ext-attr]: attributes.md#external
-[fud]: ../fud/index.md
+[fud]: ../running-calyx/fud/index.md
 [data-gen]: ../tools/data-gen.md
-[iv]: ../fud/index.md#icarus-verilog
-[verilator]: ../fud/index.md#verilator
+[iv]: ../running-calyx/fud/index.md#icarus-verilog
+[verilator]: ../running-calyx/fud/index.md#verilator
 [interpreter]: ../interpreter.md

--- a/docs/running-calyx/fud/axi-gen.md
+++ b/docs/running-calyx/fud/axi-gen.md
@@ -82,5 +82,5 @@ allow this.
 [bursting]: https://developer.arm.com/documentation/ihi0022/e/AMBA-AXI3-and-AXI4-Protocol-Specification/Single-Interface-Requirements/Transaction-structure/Address-structure?lang=en
 [access_protection]: https://developer.arm.com/documentation/ihi0022/e/AMBA-AXI3-and-AXI4-Protocol-Specification/Transaction-Attributes/Access-permissions?lang=en
 [toplevel]: https://docs.calyxir.org/lang/attributes.html?highlight=toplevel#toplevel
-[xilinx_how]: https://docs.calyxir.org/fud/xilinx.html?highlight=synthesis#how-it-works
+[xilinx_how]: https://docs.calyxir.org/running-calyx/fud/xilinx.html?highlight=synthesis#how-it-works
 [kernel_requirements]: https://docs.xilinx.com/r/en-US/ug1393-vitis-application-acceleration/Kernel-Interface-Requirements

--- a/docs/running-calyx/fud/circt.md
+++ b/docs/running-calyx/fud/circt.md
@@ -73,10 +73,10 @@ We provide `-x discover-external:default=<size>` which tells the pass that when 
 A limitation of this approach is that the pass does not support discovering interface memories with different sizes.
 If you desperately need this, please [open an issue][issue], and we'll try to prioritize it.
 
-[`fud`]: ../running-calyx/fud
+[`fud`]: ./index.md
 [cider]: ../interpreter.md
-[synth]: ../running-calyx/fud/xilinx.html#synthesis-only
-[axi-gen]: ../running-calyx/fud/axi-gen.html
+[synth]: ./xilinx.html#synthesis-only
+[axi-gen]: ./axi-gen.html
 [`@external`]: ../lang/attributes.html#external
 [issue]:https://github.com/calyxir/calyx/issues/new
 

--- a/docs/running-calyx/fud/circt.md
+++ b/docs/running-calyx/fud/circt.md
@@ -73,10 +73,10 @@ We provide `-x discover-external:default=<size>` which tells the pass that when 
 A limitation of this approach is that the pass does not support discovering interface memories with different sizes.
 If you desperately need this, please [open an issue][issue], and we'll try to prioritize it.
 
-[`fud`]: ../fud
+[`fud`]: ../running-calyx/fud
 [cider]: ../interpreter.md
-[synth]: ../fud/xilinx.html#synthesis-only
-[axi-gen]: ../fud/axi-gen.html
+[synth]: ../running-calyx/fud/xilinx.html#synthesis-only
+[axi-gen]: ../running-calyx/fud/axi-gen.html
 [`@external`]: ../lang/attributes.html#external
 [issue]:https://github.com/calyxir/calyx/issues/new
 

--- a/docs/running-calyx/fud/external.md
+++ b/docs/running-calyx/fud/external.md
@@ -47,4 +47,4 @@ The override order for stage configuration is:
 2. Configuration value in the fud config.
 3. Default value provided by `Stage.defaults()`
 
-[MrXL]: ../frontends/mrxl.md
+[MrXL]: ../../frontends/mrxl.md

--- a/docs/running-calyx/fud/index.md
+++ b/docs/running-calyx/fud/index.md
@@ -134,7 +134,7 @@ fud c stages.verilog.priority 1
 ## Dahlia Frontend
 
 In order to use the Dahlia frontend with Fud, first [install
-Dahlia](../frontends/dahlia.md).
+Dahlia](../../frontends/dahlia.md).
 Once Dahlia is compiled, point `fud` to the Dahlia compiler binary:
 ```bash
 fud config stages.dahlia.exec <full path to dahlia repo>/fuse
@@ -146,20 +146,20 @@ You need [flit][] to install our Python frontends.
 pip3 install flit
 ```
 
-Our Python [frontends](../frontends) use a Calyx ast library written in Python. Install with:
+Our Python [frontends](../../frontends) use a Calyx ast library written in Python. Install with:
 ```
 cd calyx-py && flit install -s
 ```
 
 Frontend specific instructions:
- - [Systolic array](../frontends/systolic-array.md): Nothing else needed.
- - [NTT](../frontends/ntt.md):
+ - [Systolic array](../../frontends/systolic-array.md): Nothing else needed.
+ - [NTT](../../frontends/ntt.md):
    - Install dependencies: `pip3 install prettytable`
    - Install external `fud` stage: `fud register ntt -p frontends/ntt-pipeline/fud/ntt.py`
- - [MrXL](../frontends/mrxl.md):
+ - [MrXL](../../frontends/mrxl.md):
    - Install `mrxl` binary: `cd frontends/mrxl && flit install -s`
    - Install `mrxl` [external stage][] for `fud`: `fud register mrxl -p frontends/mrxl/fud/mrxl.py`
- - [TVM Relay](../frontends/tvm-relay.md): See instructions.
+ - [TVM Relay](../../frontends/tvm-relay.md): See instructions.
 
 
 ## Adding Synthesis Backends
@@ -244,7 +244,7 @@ simulate                        0.161
 
 Lastly, the `-csv` flag will provide the profiling information in CSV format.
 
-[frontends]: ../frontends/index.md
+[frontends]: ../../frontends/index.md
 [calyx-py]: ./calyx-py.md
 [flit]: https://flit.readthedocs.io/en/latest/
 [verilator]: https://www.veripool.org/wiki/verilator

--- a/docs/running-calyx/fud2.md
+++ b/docs/running-calyx/fud2.md
@@ -7,7 +7,7 @@ fud2 is an experiment in building a new driver that works like fud that adds som
 Someday, fud2 may supplant fud, but it needs more work before it is ready to do that.
 Until then, fud remains your first choice for all your build-related needs.
 
-[fud]: ./fud/index.md
+[fud]: ./running-calyx/fud/index.md
 
 ## Set Up
 

--- a/docs/running-calyx/fud2.md
+++ b/docs/running-calyx/fud2.md
@@ -7,7 +7,7 @@ fud2 is an experiment in building a new driver that works like fud that adds som
 Someday, fud2 may supplant fud, but it needs more work before it is ready to do that.
 Until then, fud remains your first choice for all your build-related needs.
 
-[fud]: ./running-calyx/fud/index.md
+[fud]: ./fud/index.md
 
 ## Set Up
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -3,6 +3,6 @@
 Calyx uses an array of tools to simplify and streamline compiler testing,
 development, and usage.
 
-- [Fud: The Calyx Driver](../fud): Invoke various tools to compile, test, and simulation input programs.
+- [Fud: The Calyx Driver](../running-calyx/fud): Invoke various tools to compile, test, and simulation input programs.
 - [Runt: Run Tests](./runt.md): Parallel expectation testing framework.
 - [`exp` Generator](./exp-generator.md): Generates the necessary components to compute a fixed point `exp`.

--- a/docs/tutorial/frontend-tut.md
+++ b/docs/tutorial/frontend-tut.md
@@ -447,7 +447,7 @@ This transformation is achieved using a [`fud`][fud] pass that converts MrXL-nat
 
 [astcode]: https://github.com/calyxir/calyx/blob/mrxl/mrxl/mrxl/ast.py
 [mrxldocs-install]: https://docs.calyxir.org/frontends/mrxl.html#install
-[fud]: ../fud/index.md
+[fud]: ../running-calyx/fud/index.md
 [fud-data]: ../lang/data-format.md
 [json]: https://www.json.org/json-en.html
 [calyx-tut]: ./language-tut.md

--- a/docs/tutorial/language-tut.md
+++ b/docs/tutorial/language-tut.md
@@ -267,6 +267,6 @@ Take a look at the [full language reference][lang-ref] for details on the comple
 [verilator]: https://www.veripool.org/wiki/verilator
 [tutorial]: https://github.com/calyxir/calyx/tree/master/examples/tutorial
 [icarus verilog]: http://iverilog.icarus.com
-[fud]: ../fud/index.md
+[fud]: ../running-calyx/fud/index.md
 [data-format]: ../lang/data-format.md
 [lang-ref]: ../lang/ref.md


### PR DESCRIPTION
Some of the hyperlinks to documentation about fud and the compiler frontends for Calyx were broken - hoping that this fixes most of them. 

I'm not sure if there's a template engine for Calyx's documentation that would resolve these issues automatically - if so, feel free to disregard this PR :smile: 