### PR TITLE
Add combinational multiplier primitive

### DIFF
--- a/primitives/binary_operators.futil
+++ b/primitives/binary_operators.futil
@@ -145,4 +145,5 @@ extern "binary_operators.sv" {
   comb primitive std_slsh<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: WIDTH);
   comb primitive std_srsh<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: WIDTH);
   comb primitive std_signext<"share"=1>[IN_WIDTH, OUT_WIDTH](@data in: IN_WIDTH) -> (out: OUT_WIDTH);
+  comb primitive std_mult<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: WIDTH);
 }

--- a/primitives/binary_operators.sv
+++ b/primitives/binary_operators.sv
@@ -763,3 +763,13 @@ module std_signext #(
     end
   `endif
 endmodule
+
+module std_mult #(
+    parameter WIDTH = 32
+) (
+    input  signed [WIDTH-1:0] left,
+    input  signed [WIDTH-1:0] right,
+    output signed [WIDTH-1:0] out
+);
+  assign out = left * right;
+endmodule


### PR DESCRIPTION
This primitive is necessary for translating between memory ports of different dimensions, but it should be used carefully. It will destroy the max frequency unless it is 1) not chained with anything else (aka inputs come directly from registers and output is directly the input to a register) or 2) one of the inputs is a constant.