### PR TITLE
Add a combinational constant multiplication primitive

### DIFF
--- a/primitives/binary_operators.futil
+++ b/primitives/binary_operators.futil
@@ -145,4 +145,5 @@ extern "binary_operators.sv" {
   comb primitive std_slsh<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: WIDTH);
   comb primitive std_srsh<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: WIDTH);
   comb primitive std_signext<"share"=1>[IN_WIDTH, OUT_WIDTH](@data in: IN_WIDTH) -> (out: OUT_WIDTH);
+  comb primitive std_mult<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: WIDTH);
 }

--- a/primitives/binary_operators.futil
+++ b/primitives/binary_operators.futil
@@ -145,5 +145,5 @@ extern "binary_operators.sv" {
   comb primitive std_slsh<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: WIDTH);
   comb primitive std_srsh<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: WIDTH);
   comb primitive std_signext<"share"=1>[IN_WIDTH, OUT_WIDTH](@data in: IN_WIDTH) -> (out: OUT_WIDTH);
-  comb primitive std_mult<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: WIDTH);
+  comb primitive std_const_mult<"share"=1>[WIDTH, VALUE](@data in: WIDTH) -> (out: WIDTH);
 }

--- a/primitives/binary_operators.sv
+++ b/primitives/binary_operators.sv
@@ -764,12 +764,12 @@ module std_signext #(
   `endif
 endmodule
 
-module std_mult #(
-    parameter WIDTH = 32
+module std_const_mult #(
+    parameter WIDTH = 32,
+    parameter VALUE = 1
 ) (
-    input  signed [WIDTH-1:0] left,
-    input  signed [WIDTH-1:0] right,
+    input  signed [WIDTH-1:0] in,
     output signed [WIDTH-1:0] out
 );
-  assign out = left * right;
+  assign out = in * VALUE;
 endmodule

--- a/primitives/binary_operators.sv
+++ b/primitives/binary_operators.sv
@@ -763,3 +763,13 @@ module std_signext #(
     end
   `endif
 endmodule
+
+module std_mult #(
+    parameter WIDTH = 32
+) (
+    input  signed [WIDTH-1:0] left,
+    input  signed [WIDTH-1:0] right,
+    output signed [WIDTH-1:0] out
+);
+  assign out = left * right;
+endmodule


### PR DESCRIPTION
Library primitive that takes a constant value as a parameter. The input is multiplied by the constant value. Useful for translating between memory ports with different dimensions.