### PR TITLE
eDSL: Infer more widths, require fewer cell names

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -673,9 +673,9 @@ class ComponentBuilder:
         self,
         left,
         right,
+        ans_reg=None,
         cellname=None,
         width=None,
-        ans_reg=None,
         signed=False,
     ):
         """Inserts wiring into `self` to perform `reg := left + right`."""
@@ -687,9 +687,9 @@ class ComponentBuilder:
         self,
         left,
         right,
+        ans_reg=None,
         cellname=None,
         width=None,
-        ans_reg=None,
         signed=False,
     ):
         """Inserts wiring into `self` to perform `reg := left - right`."""
@@ -701,9 +701,9 @@ class ComponentBuilder:
         self,
         left,
         right,
+        ans_reg=None,
         cellname=None,
         width=None,
-        ans_reg=None,
         signed=False,
     ):
         """Inserts wiring into `self` to perform `reg := left == right`."""
@@ -715,9 +715,9 @@ class ComponentBuilder:
         self,
         left,
         right,
+        ans_reg=None,
         cellname=None,
         width=None,
-        ans_reg=None,
         signed=False,
     ):
         """Inserts wiring into `self` to perform `reg := left != right`."""

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -648,11 +648,18 @@ class ComponentBuilder:
             load_grp.done = ans.done
         return load_grp
 
-    def op_store_in_reg(self, op_cell, left, right, cellname, width=None, ans_reg=None):
+    def op_store_in_reg(
+        self,
+        op_cell,
+        left,
+        right,
+        cellname,
+        width,
+        ans_reg=None,
+    ):
         """Inserts wiring into `self` to perform `reg := left op right`,
         where `op_cell`, a Cell that performs some `op`, is provided.
         """
-        width = width or self.try_infer_width(width, left, right)
         ans_reg = ans_reg or self.reg(f"reg_{cellname}", width)
         with self.group(f"{cellname}_group") as op_group:
             op_cell.left = left
@@ -663,40 +670,60 @@ class ComponentBuilder:
         return op_group, ans_reg
 
     def add_store_in_reg(
-        self, left, right, cellname, width=None, ans_reg=None, signed=False
+        self,
+        left,
+        right,
+        cellname=None,
+        width=None,
+        ans_reg=None,
+        signed=False,
     ):
         """Inserts wiring into `self` to perform `reg := left + right`."""
         width = width or self.try_infer_width(width, left, right)
-        return self.op_store_in_reg(
-            self.add(width, cellname, signed), left, right, cellname, width, ans_reg
-        )
+        cell = self.add(width, cellname, signed)
+        return self.op_store_in_reg(cell, left, right, cell.name, width, ans_reg)
 
     def sub_store_in_reg(
-        self, left, right, cellname, width=None, ans_reg=None, signed=False
+        self,
+        left,
+        right,
+        cellname=None,
+        width=None,
+        ans_reg=None,
+        signed=False,
     ):
         """Inserts wiring into `self` to perform `reg := left - right`."""
         width = width or self.try_infer_width(width, left, right)
-        return self.op_store_in_reg(
-            self.sub(width, cellname, signed), left, right, cellname, width, ans_reg
-        )
+        cell = self.sub(width, cellname, signed)
+        return self.op_store_in_reg(cell, left, right, cell.name, width, ans_reg)
 
     def eq_store_in_reg(
-        self, left, right, cellname, width=None, ans_reg=None, signed=False
+        self,
+        left,
+        right,
+        cellname=None,
+        width=None,
+        ans_reg=None,
+        signed=False,
     ):
         """Inserts wiring into `self` to perform `reg := left == right`."""
         width = width or self.try_infer_width(width, left, right)
-        return self.op_store_in_reg(
-            self.eq(width, cellname, signed), left, right, cellname, 1, ans_reg
-        )
+        cell = self.eq(width, cellname, signed)
+        return self.op_store_in_reg(cell, left, right, cell.name, 1, ans_reg)
 
     def neq_store_in_reg(
-        self, left, right, cellname, width=None, ans_reg=None, signed=False
+        self,
+        left,
+        right,
+        cellname=None,
+        width=None,
+        ans_reg=None,
+        signed=False,
     ):
         """Inserts wiring into `self` to perform `reg := left != right`."""
         width = width or self.try_infer_width(width, left, right)
-        return self.op_store_in_reg(
-            self.neq(width, cellname, signed), left, right, cellname, 1, ans_reg
-        )
+        cell = self.neq(width, cellname, signed)
+        return self.op_store_in_reg(cell, left, right, cell.name, 1, ans_reg)
 
     def infer_width(self, expr) -> int:
         """Infer the width of an expression."""

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -76,7 +76,7 @@ class ComponentBuilder:
         self.prog = prog
         self.component: ast.Component = ast.Component(
             name,
-            attributes = [],
+            attributes=[],
             inputs=[],
             outputs=[],
             structs=cells,
@@ -114,8 +114,7 @@ class ComponentBuilder:
         return self.this()[name]
 
     def attribute(self, name: str, value: int) -> None:
-        """Declare an attribute on the component.
-        """
+        """Declare an attribute on the component."""
         self.component.attributes.append(ast.CompAttribute(name, value))
 
     def this(self) -> ThisBuilder:
@@ -649,10 +648,11 @@ class ComponentBuilder:
             load_grp.done = ans.done
         return load_grp
 
-    def op_store_in_reg(self, op_cell, left, right, cellname, width, ans_reg=None):
+    def op_store_in_reg(self, op_cell, left, right, cellname, width=None, ans_reg=None):
         """Inserts wiring into `self` to perform `reg := left op right`,
         where `op_cell`, a Cell that performs some `op`, is provided.
         """
+        width = width or self.try_infer_width(width, left, right)
         ans_reg = ans_reg or self.reg(f"reg_{cellname}", width)
         with self.group(f"{cellname}_group") as op_group:
             op_cell.left = left
@@ -663,31 +663,37 @@ class ComponentBuilder:
         return op_group, ans_reg
 
     def add_store_in_reg(
-        self, left, right, cellname, width, ans_reg=None, signed=False
+        self, left, right, cellname, width=None, ans_reg=None, signed=False
     ):
         """Inserts wiring into `self` to perform `reg := left + right`."""
+        width = width or self.try_infer_width(width, left, right)
         return self.op_store_in_reg(
             self.add(width, cellname, signed), left, right, cellname, width, ans_reg
         )
 
     def sub_store_in_reg(
-        self, left, right, cellname, width, ans_reg=None, signed=False
+        self, left, right, cellname, width=None, ans_reg=None, signed=False
     ):
         """Inserts wiring into `self` to perform `reg := left - right`."""
+        width = width or self.try_infer_width(width, left, right)
         return self.op_store_in_reg(
             self.sub(width, cellname, signed), left, right, cellname, width, ans_reg
         )
 
-    def eq_store_in_reg(self, left, right, cellname, width, ans_reg=None, signed=False):
+    def eq_store_in_reg(
+        self, left, right, cellname, width=None, ans_reg=None, signed=False
+    ):
         """Inserts wiring into `self` to perform `reg := left == right`."""
+        width = width or self.try_infer_width(width, left, right)
         return self.op_store_in_reg(
             self.eq(width, cellname, signed), left, right, cellname, 1, ans_reg
         )
 
     def neq_store_in_reg(
-        self, left, right, cellname, width, ans_reg=None, signed=False
+        self, left, right, cellname, width=None, ans_reg=None, signed=False
     ):
         """Inserts wiring into `self` to perform `reg := left != right`."""
+        width = width or self.try_infer_width(width, left, right)
         return self.op_store_in_reg(
             self.neq(width, cellname, signed), left, right, cellname, 1, ans_reg
         )

--- a/calyx-py/calyx/queue_call.py
+++ b/calyx-py/calyx/queue_call.py
@@ -83,7 +83,7 @@ def insert_runner(prog, queue, name, stats_component=None):
 
     # Wiring that raises `err` iff `i = MAX_CMDS`.
     check_if_out_of_cmds, _ = runner.eq_store_in_reg(
-        i.out, cb.const(32, queue_util.MAX_CMDS), ans_reg=err
+        i.out, cb.const(32, queue_util.MAX_CMDS), err
     )
 
     runner.control += [

--- a/calyx-py/calyx/queue_call.py
+++ b/calyx-py/calyx/queue_call.py
@@ -83,7 +83,7 @@ def insert_runner(prog, queue, name, stats_component=None):
 
     # Wiring that raises `err` iff `i = MAX_CMDS`.
     check_if_out_of_cmds, _ = runner.eq_store_in_reg(
-        i.out, cb.const(32, queue_util.MAX_CMDS), "i_eq_MAX_CMDS", ans_reg=err
+        i.out, cb.const(32, queue_util.MAX_CMDS), ans_reg=err
     )
 
     runner.control += [

--- a/calyx-py/calyx/queue_call.py
+++ b/calyx-py/calyx/queue_call.py
@@ -82,9 +82,7 @@ def insert_runner(prog, queue, name, stats_component=None):
     not_err = runner.not_use(err.out)
 
     # Wiring that raises `err` iff `i = MAX_CMDS`.
-    check_if_out_of_cmds, _ = runner.eq_store_in_reg(
-        i.out, cb.const(32, queue_util.MAX_CMDS), err
-    )
+    check_if_out_of_cmds, _ = runner.eq_store_in_reg(i.out, queue_util.MAX_CMDS, err)
 
     runner.control += [
         read_cmd,

--- a/calyx-py/calyx/queue_call.py
+++ b/calyx-py/calyx/queue_call.py
@@ -83,7 +83,7 @@ def insert_runner(prog, queue, name, stats_component=None):
 
     # Wiring that raises `err` iff `i = MAX_CMDS`.
     check_if_out_of_cmds, _ = runner.eq_store_in_reg(
-        i.out, cb.const(32, queue_util.MAX_CMDS), "i_eq_MAX_CMDS", 32, err
+        i.out, cb.const(32, queue_util.MAX_CMDS), "i_eq_MAX_CMDS", ans_reg=err
     )
 
     runner.control += [
@@ -91,21 +91,23 @@ def insert_runner(prog, queue, name, stats_component=None):
         write_cmd_to_reg,  # `cmd := commands[i]`
         read_value,
         write_value_to_reg,  # `value := values[i]`
-        cb.invoke(  # Invoke the queue.
-            queue,
-            in_cmd=cmd.out,
-            in_value=value.out,
-            ref_ans=ans,
-            ref_err=err,
-            ref_stats=stats,
-        )
-        if stats_component
-        else cb.invoke(  # Invoke the queue.
-            queue,
-            in_cmd=cmd.out,
-            in_value=value.out,
-            ref_ans=ans,
-            ref_err=err,
+        (
+            cb.invoke(  # Invoke the queue.
+                queue,
+                in_cmd=cmd.out,
+                in_value=value.out,
+                ref_ans=ans,
+                ref_err=err,
+                ref_stats=stats,
+            )
+            if stats_component
+            else cb.invoke(  # Invoke the queue.
+                queue,
+                in_cmd=cmd.out,
+                in_value=value.out,
+                ref_ans=ans,
+                ref_err=err,
+            )
         ),
         # We're back from the invoke, and it's time for some post-mortem analysis.
         cb.if_with(
@@ -162,23 +164,25 @@ def insert_main(prog, queue, controller=None, stats_component=None):
         not_err,  # While the dataplane component has not errored out.
         [
             lower_has_ans,  # Lower the has-ans flag.
-            cb.invoke(  # Invoke the dataplane component.
-                dataplane,
-                ref_commands=commands,
-                ref_values=values,
-                ref_has_ans=has_ans,
-                ref_component_ans=dataplane_ans,
-                ref_component_err=dataplane_err,
-                ref_stats_runner=stats,
-            )
-            if stats_component
-            else cb.invoke(  # Invoke the dataplane component.
-                dataplane,
-                ref_commands=commands,
-                ref_values=values,
-                ref_has_ans=has_ans,
-                ref_component_ans=dataplane_ans,
-                ref_component_err=dataplane_err,
+            (
+                cb.invoke(  # Invoke the dataplane component.
+                    dataplane,
+                    ref_commands=commands,
+                    ref_values=values,
+                    ref_has_ans=has_ans,
+                    ref_component_ans=dataplane_ans,
+                    ref_component_err=dataplane_err,
+                    ref_stats_runner=stats,
+                )
+                if stats_component
+                else cb.invoke(  # Invoke the dataplane component.
+                    dataplane,
+                    ref_commands=commands,
+                    ref_values=values,
+                    ref_has_ans=has_ans,
+                    ref_component_ans=dataplane_ans,
+                    ref_component_err=dataplane_err,
+                )
             ),
             # If the dataplane component has a nonzero answer,
             # write it to the answer-list and increment the index `j`.
@@ -186,11 +190,13 @@ def insert_main(prog, queue, controller=None, stats_component=None):
                 has_ans.out,
                 cb.if_with(ans_neq_0, [write_ans, incr_j]),
             ),
-            cb.invoke(  # Invoke the controller component.
-                controller,
-                ref_stats_controller=stats,
-            )
-            if controller
-            else ast.Empty,
+            (
+                cb.invoke(  # Invoke the controller component.
+                    controller,
+                    ref_stats_controller=stats,
+                )
+                if controller
+                else ast.Empty
+            ),
         ],
     )

--- a/calyx-py/test/correctness/arbiter_6.py
+++ b/calyx-py/test/correctness/arbiter_6.py
@@ -38,8 +38,8 @@ def add_wrap2(prog):
     unchanged = wrap.reg_store(j_mod_4, j, "j_unchanged")
 
     # Wiring to perform j-4 and j-8. Either of these will store the result in `j_mod_4`.
-    j_minus_4, j_mod_4 = wrap.sub_store_in_reg(j, 4, "j_minus_4", ans_reg=j_mod_4)
-    j_minus_8, j_mod_4 = wrap.sub_store_in_reg(j, 8, "j_minus_8", ans_reg=j_mod_4)
+    j_minus_4, j_mod_4 = wrap.sub_store_in_reg(j, 4, ans_reg=j_mod_4)
+    j_minus_8, j_mod_4 = wrap.sub_store_in_reg(j, 8, ans_reg=j_mod_4)
 
     load_from_mems = [
         # Add wiring to load the value `j_mod_4` from all of the memory cells.
@@ -121,7 +121,7 @@ def add_wrap3(prog):
     unchanged = wrap.reg_store(j_mod_4, j, "j_unchanged")
 
     # Wiring to perform j-4 and store the result in `j_mod_4`.
-    subcell, j_mod_4 = wrap.sub_store_in_reg(j, 4, "j_minus_4", ans_reg=j_mod_4)
+    subcell, j_mod_4 = wrap.sub_store_in_reg(j, 4, ans_reg=j_mod_4)
 
     emit_from_mems = [
         wrap.mem_load_to_mem(mems[i], j_mod_4.out, ans, 0, f"load_from_mem{i}")

--- a/calyx-py/test/correctness/arbiter_6.py
+++ b/calyx-py/test/correctness/arbiter_6.py
@@ -38,8 +38,8 @@ def add_wrap2(prog):
     unchanged = wrap.reg_store(j_mod_4, j, "j_unchanged")
 
     # Wiring to perform j-4 and j-8. Either of these will store the result in `j_mod_4`.
-    j_minus_4, j_mod_4 = wrap.sub_store_in_reg(j, 4, "j_minus_4", 32, j_mod_4)
-    j_minus_8, j_mod_4 = wrap.sub_store_in_reg(j, 8, "j_minus_8", 32, j_mod_4)
+    j_minus_4, j_mod_4 = wrap.sub_store_in_reg(j, 4, "j_minus_4", ans_reg=j_mod_4)
+    j_minus_8, j_mod_4 = wrap.sub_store_in_reg(j, 8, "j_minus_8", ans_reg=j_mod_4)
 
     load_from_mems = [
         # Add wiring to load the value `j_mod_4` from all of the memory cells.
@@ -121,7 +121,7 @@ def add_wrap3(prog):
     unchanged = wrap.reg_store(j_mod_4, j, "j_unchanged")
 
     # Wiring to perform j-4 and store the result in `j_mod_4`.
-    subcell, j_mod_4 = wrap.sub_store_in_reg(j, 4, "j_minus_4", 32, j_mod_4)
+    subcell, j_mod_4 = wrap.sub_store_in_reg(j, 4, "j_minus_4", ans_reg=j_mod_4)
 
     emit_from_mems = [
         wrap.mem_load_to_mem(mems[i], j_mod_4.out, ans, 0, f"load_from_mem{i}")

--- a/calyx-py/test/correctness/arbiter_6.py
+++ b/calyx-py/test/correctness/arbiter_6.py
@@ -38,8 +38,8 @@ def add_wrap2(prog):
     unchanged = wrap.reg_store(j_mod_4, j, "j_unchanged")
 
     # Wiring to perform j-4 and j-8. Either of these will store the result in `j_mod_4`.
-    j_minus_4, j_mod_4 = wrap.sub_store_in_reg(j, 4, ans_reg=j_mod_4)
-    j_minus_8, j_mod_4 = wrap.sub_store_in_reg(j, 8, ans_reg=j_mod_4)
+    j_minus_4, j_mod_4 = wrap.sub_store_in_reg(j, 4, j_mod_4)
+    j_minus_8, j_mod_4 = wrap.sub_store_in_reg(j, 8, j_mod_4)
 
     load_from_mems = [
         # Add wiring to load the value `j_mod_4` from all of the memory cells.
@@ -121,7 +121,7 @@ def add_wrap3(prog):
     unchanged = wrap.reg_store(j_mod_4, j, "j_unchanged")
 
     # Wiring to perform j-4 and store the result in `j_mod_4`.
-    subcell, j_mod_4 = wrap.sub_store_in_reg(j, 4, ans_reg=j_mod_4)
+    subcell, j_mod_4 = wrap.sub_store_in_reg(j, 4, j_mod_4)
 
     emit_from_mems = [
         wrap.mem_load_to_mem(mems[i], j_mod_4.out, ans, 0, f"load_from_mem{i}")

--- a/calyx-py/test/correctness/reduction_tree.py
+++ b/calyx-py/test/correctness/reduction_tree.py
@@ -23,9 +23,9 @@ def add_tree(prog):
     # Into the component `tree`, add the wiring for three adder groups that will
     # use the tree to perform their additions.
     # These need to be orchestrated in the control below.
-    add_l0_l1, left = tree.add_store_in_reg(leaf0, leaf1, "add_l0_l1")
-    add_l2_l3, right = tree.add_store_in_reg(leaf2, leaf3, "add_l2_l3")
-    add_l_r_nodes, root = tree.add_store_in_reg(left.out, right.out, "add_l_r")
+    add_l0_l1, left = tree.add_store_in_reg(leaf0, leaf1)
+    add_l2_l3, right = tree.add_store_in_reg(leaf2, leaf3)
+    add_l_r_nodes, root = tree.add_store_in_reg(left.out, right.out)
 
     # Continuously output the value of the root register.
     # It is the invoker's responsibility to ensure that the tree is done

--- a/calyx-py/test/correctness/reduction_tree.py
+++ b/calyx-py/test/correctness/reduction_tree.py
@@ -23,9 +23,9 @@ def add_tree(prog):
     # Into the component `tree`, add the wiring for three adder groups that will
     # use the tree to perform their additions.
     # These need to be orchestrated in the control below.
-    add_l0_l1, left = tree.add_store_in_reg(leaf0, leaf1, "add_l0_l1", 32)
-    add_l2_l3, right = tree.add_store_in_reg(leaf2, leaf3, "add_l2_l3", 32)
-    add_l_r_nodes, root = tree.add_store_in_reg(left.out, right.out, "add_l_r", 32)
+    add_l0_l1, left = tree.add_store_in_reg(leaf0, leaf1, "add_l0_l1")
+    add_l2_l3, right = tree.add_store_in_reg(leaf2, leaf3, "add_l2_l3")
+    add_l_r_nodes, root = tree.add_store_in_reg(left.out, right.out, "add_l_r")
 
     # Continuously output the value of the root register.
     # It is the invoker's responsibility to ensure that the tree is done


### PR DESCRIPTION
Just spotted a few instances where we were requiring users to provide names for cells when they could easily be generated, and were requiring users to provide bitwidths when they could easily be inferred.