### PR TITLE
Update Runt version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ ADD . calyx
 WORKDIR /home/calyx
 RUN cargo build --all && \
     cargo install vcdump && \
-    cargo install runt --version 0.4.0
+    cargo install runt --version 0.4.1
 
 # Install fud
 WORKDIR /home/calyx/fud

--- a/frontends/mrxl/test/runt.toml
+++ b/frontends/mrxl/test/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.4.0"
+ver = "0.4.1"
 
 [[tests]]
 name = "interpret"

--- a/interp/runt.toml
+++ b/interp/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.4.0"
+ver = "0.4.1"
 
 # Check basic functionality of the interpreter
 [[tests]]

--- a/runt.toml
+++ b/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.4.0"
+ver = "0.4.1"
 
 ##### Compilation Tests ######
 ## Test each pass in isolation. Gets the pass flags from a comment on the first line of the file

--- a/tests/xilinx/runt.toml
+++ b/tests/xilinx/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.4.0"
+ver = "0.4.1"
 
 # Run Vivado/Vitis to produce an xclbin binary.
 # This command needs to output to a temporary file and delete it because fud

--- a/tools/data_gen/runt.toml
+++ b/tools/data_gen/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.4.0"
+ver = "0.4.1"
 [[tests]]
 name = "data gen tests"
 paths = [


### PR DESCRIPTION
`cargo install runt` provides `v0.4.1`, yet the configuration is requesting `0.4.0`.