### PR TITLE
Another change to pipelined_mult to improve QoR

### DIFF
--- a/primitives/pipelined.futil
+++ b/primitives/pipelined.futil
@@ -2,7 +2,6 @@ extern "pipelined.sv" {
     // A latency-sensitive multiplier that takes 4 cycles to compute its result.
     static<4> primitive pipelined_mult[WIDTH] (
         @clk clk: 1,
-        @reset reset: 1,
         left: WIDTH,
         right: WIDTH
     ) -> (

--- a/primitives/pipelined.sv
+++ b/primitives/pipelined.sv
@@ -5,7 +5,6 @@ module pipelined_mult #(
     parameter WIDTH = 32
 ) (
     input wire clk,
-    input wire reset,
     // inputs
     input wire [WIDTH-1:0] left,
     input wire [WIDTH-1:0] right,

--- a/primitives/pipelined.sv
+++ b/primitives/pipelined.sv
@@ -19,19 +19,11 @@ assign out = buff2;
 assign tmp_prod = tmp_left * tmp_right;
 
 always_ff @(posedge clk) begin
-    if (reset) begin
-        buff0 <= 0;
-        buff1 <= 0;
-        buff2 <= 0;
-        tmp_left <= 0;
-        tmp_right <= 0;
-    end else begin
-        tmp_left <= left;
-        tmp_right <= right;
-        buff0 <= tmp_prod;
-        buff1 <= buff0;
-        buff2 <= buff1;
-    end
+    tmp_left <= left;
+    tmp_right <= right;
+    buff0 <= tmp_prod;
+    buff1 <= buff0;
+    buff2 <= buff1;
 end
 
 endmodule 


### PR DESCRIPTION
Initializing these registers changes what DSP structure this gets mapped to which harms frequency. This change should be fine because no program should rely on the output of the multiplier until 4 cycles after the first set of inputs is given.