### PR TITLE
Mark `pipelined_mult` inputs as `@data`

### DIFF
--- a/primitives/pipelined.futil
+++ b/primitives/pipelined.futil
@@ -2,8 +2,8 @@ extern "pipelined.sv" {
     // A latency-sensitive multiplier that takes 4 cycles to compute its result.
     static<4> primitive pipelined_mult[WIDTH] (
         @clk clk: 1,
-        left: WIDTH,
-        right: WIDTH
+        @data left: WIDTH,
+        @data right: WIDTH
     ) -> (
         out: WIDTH
     );
@@ -14,8 +14,8 @@ extern "pipelined.sv" {
     ] (
         @clk clk: 1,
         @reset reset: 1,
-        left: WIDTH,
-        right: WIDTH
+        @data left: WIDTH,
+        @data right: WIDTH
     ) -> (
         out: WIDTH
     );


### PR DESCRIPTION
This should prevent default zero generations and help frequency significantly.