### PR TITLE
Probably fix #2016: Sort ports when compiling refs

### DIFF
--- a/calyx-opt/src/passes/compile_invoke.rs
+++ b/calyx-opt/src/passes/compile_invoke.rs
@@ -75,9 +75,12 @@ impl RefPortMap {
     /// Get all of the newly added ports associated with a component that had
     /// ref cells
     fn get_ports(&self, comp_name: &ir::Id) -> Option<Vec<RRC<ir::Port>>> {
-        self.0
-            .get(comp_name)
-            .map(|map| map.values().cloned().collect())
+        self.0.get(comp_name).map(|map| {
+            map.values()
+                .cloned()
+                .sorted_by(|a, b| a.borrow().name.cmp(&b.borrow().name))
+                .collect()
+        })
     }
 }
 


### PR DESCRIPTION
This is a really tiny change to force an ordering on the "inlined" ports when compiling `ref` cells, to address #2016.

Recall that compiling `ref` cells (which happens in `compile-invoke`, despite the name) involves creating ports in the "host" component to mirror those in the `ref` cell it contains. Those ports are created by an `ir::Rewriter`, which produces a `HashMap`, which is of course nondeterministic. The strategy here is to just take those randomly-ordered ports and sort them before we add them to the "host" component, yielding deterministic IR from this pass.

I don't know if this is the best way, but it is at least a way.