### PR TITLE
`@data` carried over to external memories 

### DIFF
--- a/calyx-backend/src/verilog.rs
+++ b/calyx-backend/src/verilog.rs
@@ -499,7 +499,12 @@ fn is_data_port(pr: &RRC<ir::Port>) -> bool {
     if let ir::PortParent::Cell(cwr) = &port.parent {
         let cr = cwr.upgrade();
         let cell = cr.borrow();
-        if cell.attributes.has(ir::BoolAttr::Data) {
+        // For cell.is_this() ports that were externalized, we already checked
+        // that the parent cell had the `@data` attribute.
+        if cell.attributes.has(ir::BoolAttr::Data)
+            || (cell.is_this()
+                & port.attributes.has(ir::BoolAttr::Externalized))
+        {
             return true;
         }
     }

--- a/calyx-frontend/src/attribute.rs
+++ b/calyx-frontend/src/attribute.rs
@@ -64,6 +64,9 @@ pub enum BoolAttr {
     #[strum(serialize = "promoted")]
     /// denotes a static component or control promoted from dynamic
     Promoted,
+    #[strum(serialize = "externalized")]
+    /// Denotes a port that has been externalized (i.e., dumped into signature)
+    Externalized,
 }
 impl From<BoolAttr> for Attribute {
     fn from(attr: BoolAttr) -> Self {

--- a/calyx-opt/src/passes/dump_ports.rs
+++ b/calyx-opt/src/passes/dump_ports.rs
@@ -62,12 +62,17 @@ where
         for port_ref in ports_inline {
             let canon = port_ref.borrow().canonical();
             let port = port_ref.borrow();
+            // Have to remove @interval and @promotable since they will no longer
+            // be true.
+            let mut filtered_attributes = port.attributes.clone();
+            filtered_attributes.remove(ir::NumAttr::Interval);
+            filtered_attributes.remove(ir::NumAttr::Promotable);
             let new_port = ir::rrc(ir::Port {
                 name: component.generate_name(format_port_name(&canon)),
                 width: port.width,
                 direction: port.direction.clone(),
                 parent: ir::PortParent::Cell(WRC::from(&component.signature)),
-                attributes: port.attributes.clone(),
+                attributes: filtered_attributes,
             });
             component
                 .signature

--- a/calyx-opt/src/passes/dump_ports.rs
+++ b/calyx-opt/src/passes/dump_ports.rs
@@ -63,7 +63,7 @@ where
             let canon = port_ref.borrow().canonical();
             let port = port_ref.borrow();
             // Have to remove @interval and @promotable since they will no longer
-            // be true.
+            // be true. Same for @go, @done, @clk, and @reset.
             let mut filtered_attributes = port.attributes.clone();
             let non_transferrable_num_attributes = vec![
                 ir::NumAttr::Interval,

--- a/calyx-opt/src/passes/dump_ports.rs
+++ b/calyx-opt/src/passes/dump_ports.rs
@@ -67,7 +67,7 @@ where
                 width: port.width,
                 direction: port.direction.clone(),
                 parent: ir::PortParent::Cell(WRC::from(&component.signature)),
-                attributes: ir::Attributes::default(),
+                attributes: port.attributes.clone(),
             });
             component
                 .signature

--- a/calyx-opt/src/passes/dump_ports.rs
+++ b/calyx-opt/src/passes/dump_ports.rs
@@ -65,8 +65,20 @@ where
             // Have to remove @interval and @promotable since they will no longer
             // be true.
             let mut filtered_attributes = port.attributes.clone();
-            filtered_attributes.remove(ir::NumAttr::Interval);
-            filtered_attributes.remove(ir::NumAttr::Promotable);
+            let non_transferrable_num_attributes = vec![
+                ir::NumAttr::Interval,
+                ir::NumAttr::Promotable,
+                ir::NumAttr::Go,
+                ir::NumAttr::Done,
+            ];
+            let non_transferrable_bool_attributes =
+                vec![ir::BoolAttr::Clk, ir::BoolAttr::Reset];
+            for num_attr in non_transferrable_num_attributes {
+                filtered_attributes.remove(num_attr);
+            }
+            for bool_attr in non_transferrable_bool_attributes {
+                filtered_attributes.remove(bool_attr);
+            }
             let new_port = ir::rrc(ir::Port {
                 name: component.generate_name(format_port_name(&canon)),
                 width: port.width,

--- a/tests/passes/compile-invoke/invoke-ref.expect
+++ b/tests/passes/compile-invoke/invoke-ref.expect
@@ -1,5 +1,5 @@
 import "primitives/compile.futil";
-component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable r_out: 32, @done r_done: 1) -> (@done done: 1, @write_together @data r_in: 32, @write_together @go r_write_en: 1) {
+component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable r_out: 32, r_done: 1) -> (@done done: 1, @write_together @data r_in: 32, @write_together r_write_en: 1) {
   cells {
   }
   wires {

--- a/tests/passes/compile-invoke/invoke-ref.expect
+++ b/tests/passes/compile-invoke/invoke-ref.expect
@@ -1,5 +1,5 @@
 import "primitives/compile.futil";
-component foo(@go go: 1, @clk clk: 1, @reset reset: 1, r_out: 32, r_done: 1) -> (@done done: 1, r_in: 32, r_write_en: 1) {
+component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable r_out: 32, @done r_done: 1) -> (@done done: 1, @write_together @data r_in: 32, @write_together @interval @go r_write_en: 1) {
   cells {
   }
   wires {

--- a/tests/passes/compile-invoke/invoke-ref.expect
+++ b/tests/passes/compile-invoke/invoke-ref.expect
@@ -1,5 +1,5 @@
 import "primitives/compile.futil";
-component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable r_out: 32, r_done: 1) -> (@done done: 1, @write_together @data r_in: 32, @write_together r_write_en: 1) {
+component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @externalized r_out: 32, @externalized r_done: 1) -> (@done done: 1, @externalized r_in: 32, @externalized r_write_en: 1) {
   cells {
   }
   wires {

--- a/tests/passes/compile-invoke/invoke-ref.expect
+++ b/tests/passes/compile-invoke/invoke-ref.expect
@@ -1,5 +1,5 @@
 import "primitives/compile.futil";
-component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable r_out: 32, @done r_done: 1) -> (@done done: 1, @write_together @data r_in: 32, @write_together @interval @go r_write_en: 1) {
+component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable r_out: 32, @done r_done: 1) -> (@done done: 1, @write_together @data r_in: 32, @write_together @go r_write_en: 1) {
   cells {
   }
   wires {

--- a/tests/passes/compile-invoke/ref-chain.expect
+++ b/tests/passes/compile-invoke/ref-chain.expect
@@ -20,7 +20,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     }
   }
 }
-component incr(@go go: 1, @clk clk: 1, @reset reset: 1, value_out: 32, value_done: 1) -> (@done done: 1, value_in: 32, value_write_en: 1) {
+component incr(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, @done value_done: 1) -> (@done done: 1, @write_together @data value_in: 32, @write_together @interval @go value_write_en: 1) {
   cells {
     ih = incr_helper();
   }
@@ -40,7 +40,7 @@ component incr(@go go: 1, @clk clk: 1, @reset reset: 1, value_out: 32, value_don
     }
   }
 }
-component incr_helper(@go go: 1, @clk clk: 1, @reset reset: 1, value_out: 32, value_done: 1) -> (@done done: 1, value_in: 32, value_write_en: 1) {
+component incr_helper(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, @done value_done: 1) -> (@done done: 1, @write_together @data value_in: 32, @write_together @interval @go value_write_en: 1) {
   cells {
     incr_value = std_add(32);
   }

--- a/tests/passes/compile-invoke/ref-chain.expect
+++ b/tests/passes/compile-invoke/ref-chain.expect
@@ -20,7 +20,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     }
   }
 }
-component incr(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, value_done: 1) -> (@done done: 1, @write_together @data value_in: 32, @write_together value_write_en: 1) {
+component incr(@go go: 1, @clk clk: 1, @reset reset: 1, @externalized value_out: 32, @externalized value_done: 1) -> (@done done: 1, @externalized value_in: 32, @externalized value_write_en: 1) {
   cells {
     ih = incr_helper();
   }
@@ -40,7 +40,7 @@ component incr(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, v
     }
   }
 }
-component incr_helper(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, value_done: 1) -> (@done done: 1, @write_together @data value_in: 32, @write_together value_write_en: 1) {
+component incr_helper(@go go: 1, @clk clk: 1, @reset reset: 1, @externalized value_out: 32, @externalized value_done: 1) -> (@done done: 1, @externalized value_in: 32, @externalized value_write_en: 1) {
   cells {
     incr_value = std_add(32);
   }

--- a/tests/passes/compile-invoke/ref-chain.expect
+++ b/tests/passes/compile-invoke/ref-chain.expect
@@ -20,7 +20,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     }
   }
 }
-component incr(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, @done value_done: 1) -> (@done done: 1, @write_together @data value_in: 32, @write_together @interval @go value_write_en: 1) {
+component incr(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, @done value_done: 1) -> (@done done: 1, @write_together @data value_in: 32, @write_together @go value_write_en: 1) {
   cells {
     ih = incr_helper();
   }
@@ -40,7 +40,7 @@ component incr(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, @
     }
   }
 }
-component incr_helper(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, @done value_done: 1) -> (@done done: 1, @write_together @data value_in: 32, @write_together @interval @go value_write_en: 1) {
+component incr_helper(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, @done value_done: 1) -> (@done done: 1, @write_together @data value_in: 32, @write_together @go value_write_en: 1) {
   cells {
     incr_value = std_add(32);
   }

--- a/tests/passes/compile-invoke/ref-chain.expect
+++ b/tests/passes/compile-invoke/ref-chain.expect
@@ -20,7 +20,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     }
   }
 }
-component incr(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, @done value_done: 1) -> (@done done: 1, @write_together @data value_in: 32, @write_together @go value_write_en: 1) {
+component incr(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, value_done: 1) -> (@done done: 1, @write_together @data value_in: 32, @write_together value_write_en: 1) {
   cells {
     ih = incr_helper();
   }
@@ -40,7 +40,7 @@ component incr(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, @
     }
   }
 }
-component incr_helper(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, @done value_done: 1) -> (@done done: 1, @write_together @data value_in: 32, @write_together @go value_write_en: 1) {
+component incr_helper(@go go: 1, @clk clk: 1, @reset reset: 1, @stable value_out: 32, value_done: 1) -> (@done done: 1, @write_together @data value_in: 32, @write_together value_write_en: 1) {
   cells {
     incr_value = std_add(32);
   }

--- a/tests/passes/compile-invoke/ref-invoke.expect
+++ b/tests/passes/compile-invoke/ref-invoke.expect
@@ -1,5 +1,5 @@
 import "primitives/compile.futil";
-component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable m_out: 32, m_done: 1) -> (@done done: 1, @write_together @data m_in: 32, @write_together m_write_en: 1) {
+component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @externalized m_out: 32, @externalized m_done: 1) -> (@done done: 1, @externalized m_in: 32, @externalized m_write_en: 1) {
   cells {
     r = std_reg(32);
   }

--- a/tests/passes/compile-invoke/ref-invoke.expect
+++ b/tests/passes/compile-invoke/ref-invoke.expect
@@ -1,5 +1,5 @@
 import "primitives/compile.futil";
-component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable m_out: 32, @done m_done: 1) -> (@done done: 1, @write_together @data m_in: 32, @write_together @go m_write_en: 1) {
+component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable m_out: 32, m_done: 1) -> (@done done: 1, @write_together @data m_in: 32, @write_together m_write_en: 1) {
   cells {
     r = std_reg(32);
   }

--- a/tests/passes/compile-invoke/ref-invoke.expect
+++ b/tests/passes/compile-invoke/ref-invoke.expect
@@ -1,5 +1,5 @@
 import "primitives/compile.futil";
-component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable m_out: 32, @done m_done: 1) -> (@done done: 1, @write_together @data m_in: 32, @write_together @interval @go m_write_en: 1) {
+component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable m_out: 32, @done m_done: 1) -> (@done done: 1, @write_together @data m_in: 32, @write_together @go m_write_en: 1) {
   cells {
     r = std_reg(32);
   }

--- a/tests/passes/compile-invoke/ref-invoke.expect
+++ b/tests/passes/compile-invoke/ref-invoke.expect
@@ -1,5 +1,5 @@
 import "primitives/compile.futil";
-component foo(@go go: 1, @clk clk: 1, @reset reset: 1, m_out: 32, m_done: 1) -> (@done done: 1, m_in: 32, m_write_en: 1) {
+component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable m_out: 32, @done m_done: 1) -> (@done done: 1, @write_together @data m_in: 32, @write_together @interval @go m_write_en: 1) {
   cells {
     r = std_reg(32);
   }

--- a/tests/passes/compile-invoke/ref.expect
+++ b/tests/passes/compile-invoke/ref.expect
@@ -1,5 +1,5 @@
 import "primitives/compile.futil";
-component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable r_out: 32, @done r_done: 1) -> (@done done: 1, @write_together @data r_in: 32, @write_together @go r_write_en: 1) {
+component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable r_out: 32, r_done: 1) -> (@done done: 1, @write_together @data r_in: 32, @write_together r_write_en: 1) {
   cells {
   }
   wires {

--- a/tests/passes/compile-invoke/ref.expect
+++ b/tests/passes/compile-invoke/ref.expect
@@ -1,5 +1,5 @@
 import "primitives/compile.futil";
-component foo(@go go: 1, @clk clk: 1, @reset reset: 1, r_out: 32, r_done: 1) -> (@done done: 1, r_in: 32, r_write_en: 1) {
+component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable r_out: 32, @done r_done: 1) -> (@done done: 1, @write_together @data r_in: 32, @write_together @interval @go r_write_en: 1) {
   cells {
   }
   wires {

--- a/tests/passes/compile-invoke/ref.expect
+++ b/tests/passes/compile-invoke/ref.expect
@@ -1,5 +1,5 @@
 import "primitives/compile.futil";
-component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable r_out: 32, r_done: 1) -> (@done done: 1, @write_together @data r_in: 32, @write_together r_write_en: 1) {
+component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @externalized r_out: 32, @externalized r_done: 1) -> (@done done: 1, @externalized r_in: 32, @externalized r_write_en: 1) {
   cells {
   }
   wires {

--- a/tests/passes/compile-invoke/ref.expect
+++ b/tests/passes/compile-invoke/ref.expect
@@ -1,5 +1,5 @@
 import "primitives/compile.futil";
-component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable r_out: 32, @done r_done: 1) -> (@done done: 1, @write_together @data r_in: 32, @write_together @interval @go r_write_en: 1) {
+component foo(@go go: 1, @clk clk: 1, @reset reset: 1, @stable r_out: 32, @done r_done: 1) -> (@done done: 1, @write_together @data r_in: 32, @write_together @go r_write_en: 1) {
   cells {
   }
   wires {

--- a/tests/passes/compile-invoke/static-ref.expect
+++ b/tests/passes/compile-invoke/static-ref.expect
@@ -1,6 +1,6 @@
 import "primitives/core.futil";
 import "primitives/memories/comb.futil";
-static<2> component add_one(@go go: 1, @clk clk: 1, @reset reset: 1, @read_together out_read_data: 32, @done out_done: 1) -> (@done done: 1, @read_together out_addr0: 1, @write_together @data out_write_data: 32, @write_together @interval @go out_write_en: 1) {
+static<2> component add_one(@go go: 1, @clk clk: 1, @reset reset: 1, @read_together out_read_data: 32, @done out_done: 1) -> (@done done: 1, @read_together out_addr0: 1, @write_together @data out_write_data: 32, @write_together @go out_write_en: 1) {
   cells {
     add = std_add(32);
     r = std_reg(32);

--- a/tests/passes/compile-invoke/static-ref.expect
+++ b/tests/passes/compile-invoke/static-ref.expect
@@ -1,6 +1,6 @@
 import "primitives/core.futil";
 import "primitives/memories/comb.futil";
-static<2> component add_one(@go go: 1, @clk clk: 1, @reset reset: 1, @read_together out_read_data: 32, @done out_done: 1) -> (@done done: 1, @read_together out_addr0: 1, @write_together @data out_write_data: 32, @write_together @go out_write_en: 1) {
+static<2> component add_one(@go go: 1, @clk clk: 1, @reset reset: 1, @read_together out_read_data: 32, out_done: 1) -> (@done done: 1, @read_together out_addr0: 1, @write_together @data out_write_data: 32, @write_together out_write_en: 1) {
   cells {
     add = std_add(32);
     r = std_reg(32);

--- a/tests/passes/compile-invoke/static-ref.expect
+++ b/tests/passes/compile-invoke/static-ref.expect
@@ -1,6 +1,6 @@
 import "primitives/core.futil";
 import "primitives/memories/comb.futil";
-static<2> component add_one(@go go: 1, @clk clk: 1, @reset reset: 1, out_read_data: 32, out_done: 1) -> (@done done: 1, out_addr0: 1, out_write_data: 32, out_write_en: 1) {
+static<2> component add_one(@go go: 1, @clk clk: 1, @reset reset: 1, @read_together out_read_data: 32, @done out_done: 1) -> (@done done: 1, @read_together out_addr0: 1, @write_together @data out_write_data: 32, @write_together @interval @go out_write_en: 1) {
   cells {
     add = std_add(32);
     r = std_reg(32);

--- a/tests/passes/compile-invoke/static-ref.expect
+++ b/tests/passes/compile-invoke/static-ref.expect
@@ -1,6 +1,6 @@
 import "primitives/core.futil";
 import "primitives/memories/comb.futil";
-static<2> component add_one(@go go: 1, @clk clk: 1, @reset reset: 1, @read_together out_read_data: 32, out_done: 1) -> (@done done: 1, @read_together out_addr0: 1, @write_together @data out_write_data: 32, @write_together out_write_en: 1) {
+static<2> component add_one(@go go: 1, @clk clk: 1, @reset reset: 1, @externalized out_read_data: 32, @externalized out_done: 1) -> (@done done: 1, @externalized out_addr0: 1, @externalized out_write_data: 32, @externalized out_write_en: 1) {
   cells {
     add = std_add(32);
     r = std_reg(32);

--- a/tests/passes/externalize.expect
+++ b/tests/passes/externalize.expect
@@ -1,6 +1,6 @@
 import "primitives/core.futil";
 import "primitives/memories/comb.futil";
-component main(@go go: 1, @clk clk: 1, @reset reset: 1, @read_together A_read_data: 32, @done A_done: 1) -> (@done done: 1, @read_together A_addr0: 4, @write_together @data A_write_data: 32, @write_together @interval @go A_write_en: 1, @clk A_clk: 1, @reset A_reset: 1) {
+component main(@go go: 1, @clk clk: 1, @reset reset: 1, @read_together A_read_data: 32, @done A_done: 1) -> (@done done: 1, @read_together A_addr0: 4, @write_together @data A_write_data: 32, @write_together @go A_write_en: 1, @clk A_clk: 1, @reset A_reset: 1) {
   cells {
     B = comb_mem_d1(32, 16, 4);
     state = std_reg(32);

--- a/tests/passes/externalize.expect
+++ b/tests/passes/externalize.expect
@@ -1,6 +1,6 @@
 import "primitives/core.futil";
 import "primitives/memories/comb.futil";
-component main(@go go: 1, @clk clk: 1, @reset reset: 1, @read_together A_read_data: 32, @done A_done: 1) -> (@done done: 1, @read_together A_addr0: 4, @write_together @data A_write_data: 32, @write_together @go A_write_en: 1, @clk A_clk: 1, @reset A_reset: 1) {
+component main(@go go: 1, @clk clk: 1, @reset reset: 1, @read_together A_read_data: 32, A_done: 1) -> (@done done: 1, @read_together A_addr0: 4, @write_together @data A_write_data: 32, @write_together A_write_en: 1, A_clk: 1, A_reset: 1) {
   cells {
     B = comb_mem_d1(32, 16, 4);
     state = std_reg(32);

--- a/tests/passes/externalize.expect
+++ b/tests/passes/externalize.expect
@@ -1,6 +1,6 @@
 import "primitives/core.futil";
 import "primitives/memories/comb.futil";
-component main(@go go: 1, @clk clk: 1, @reset reset: 1, @read_together A_read_data: 32, A_done: 1) -> (@done done: 1, @read_together A_addr0: 4, @write_together @data A_write_data: 32, @write_together A_write_en: 1, A_clk: 1, A_reset: 1) {
+component main(@go go: 1, @clk clk: 1, @reset reset: 1, @externalized A_read_data: 32, @externalized A_done: 1) -> (@done done: 1, @externalized A_addr0: 4, @externalized A_write_data: 32, @externalized A_write_en: 1, @externalized A_clk: 1, @externalized A_reset: 1) {
   cells {
     B = comb_mem_d1(32, 16, 4);
     state = std_reg(32);

--- a/tests/passes/externalize.expect
+++ b/tests/passes/externalize.expect
@@ -1,6 +1,6 @@
 import "primitives/core.futil";
 import "primitives/memories/comb.futil";
-component main(@go go: 1, @clk clk: 1, @reset reset: 1, A_read_data: 32, A_done: 1) -> (@done done: 1, A_addr0: 4, A_write_data: 32, A_write_en: 1, A_clk: 1, A_reset: 1) {
+component main(@go go: 1, @clk clk: 1, @reset reset: 1, @read_together A_read_data: 32, @done A_done: 1) -> (@done done: 1, @read_together A_addr0: 4, @write_together @data A_write_data: 32, @write_together @interval @go A_write_en: 1, @clk A_clk: 1, @reset A_reset: 1) {
   cells {
     B = comb_mem_d1(32, 16, 4);
     state = std_reg(32);


### PR DESCRIPTION
@andrewb1999 does this solve #2012? Lmk if it doesn't. 

Here's why I think it wasn't working before: 
## The Problem 
The problem was that, in order to have "default-to-zero behavior" we needed the cell _and_ the port to be marked as`@data`. However, when we externalize it, we _change the parent cell_. 

```
component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
  cells {
    // out.write_data's parent is out, which is marked as @data
    @external @data out = seq_mem_d1(32, 1, 1);
    ...
} 
// out_write_data's parent is now main which is not marked as @data 
component main(...@data out_write_data: 32....) { ... }
``` 
 
## The Solution 
I made a pretty hacky solution: when we externalize a cell, we only add the `@data` attribute when the cell is `@data` as well. This way, when we're in the Verilog backend, if we detect the parent is `this_component`, then we don't have to check that it's parent is a `@data` cell-- we already checked that during the `externalize` pass. Also, we need to mark ports that we externalized with an `@externalize` attribute-- it's only these `@externalize` ports that we can "skip" the step of checking the parent. 