### PR TITLE
Generate or-and trees for guarded assignments

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check calyx build
         run: ./target/debug/calyx --version
       - name: validate playground config
-        run: node web/validate-data.js 
+        run: node web/validate-data.js
 
   # Get the hash of the Dockerfile
   hash:
@@ -105,8 +105,7 @@ jobs:
         git init
         git remote add origin https://github.com/${{ github.repository }}.git
         git fetch --all
-        git fetch origin $GITHUB_REF
-        git checkout -f $GITHUB_SHA
+        git checkout -f ${{ github.sha }}
         git clean -fd
 
     - name: Build

--- a/calyx-ir/src/context.rs
+++ b/calyx-ir/src/context.rs
@@ -13,6 +13,8 @@ pub struct BackendConf {
     pub enable_verification: bool,
     /// Use flat (ANF) assignments for guards instead of deep expression trees.
     pub flat_assign: bool,
+    /// Generate muxes in the backend:
+    pub emit_muxes: bool,
     /// [FIRRTL backend only] Emit extmodule declarations for primtives
     /// for use with SystemVerilog implementations
     pub emit_primitive_extmodules: bool,

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -58,36 +58,34 @@ pub struct Opts {
     #[argh(option, short = 'm', default = "CompileMode::default()")]
     pub compile_mode: CompileMode,
 
-    /// enable synthesis mode
+    // ========== Backend Options =========== //
+    /// select a backend
+    #[argh(option, short = 'b', default = "BackendOpt::default()")]
+    pub backend: BackendOpt,
+    /// disable generation of verification checks and `initial` and `final` blocks for memories. Implies `--disable-verify=0`
     #[argh(switch, long = "synthesis")]
     pub enable_synthesis: bool,
-
     /// disable verification checks emitted by backends
     #[argh(switch)]
     pub disable_verify: bool,
-
-    /// emit nested assignments (only relevant to the Verilog backend)
+    /// emit nested assignments (Verilog backend)
     #[argh(switch, long = "nested")]
     pub nested_assign: bool,
-
+    /// emit muxes instead of or trees (Verilog backend)
+    #[argh(switch, long = "emit-muxes")]
+    pub emit_muxes: bool,
     /// emit extmodules to use with SystemVerilog implementations
     /// of primitives (only relevant to the FIRRTL backend)
     #[argh(switch, long = "emit-primitive-extmodules")]
     pub emit_primitive_extmodules: bool,
 
-    /// select a backend
-    #[argh(option, short = 'b', default = "BackendOpt::default()")]
-    pub backend: BackendOpt,
-
     /// run this pass during execution
     #[argh(option, short = 'p')]
     pub pass: Vec<String>,
-
     /// disable pass during execution
     #[argh(option, short = 'd', long = "disable-pass")]
     pub disable_pass: Vec<String>,
-
-    /// extra options passed to the context
+    /// extra options for passes. Use `pass-help` to get more information
     #[argh(option, short = 'x', long = "extra-opt")]
     pub extra_opts: Vec<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ fn main() -> CalyxResult<()> {
         enable_verification: !opts.disable_verify,
         flat_assign: !opts.nested_assign,
         emit_primitive_extmodules: opts.emit_primitive_extmodules,
+        emit_muxes: opts.emit_muxes,
     };
     // Extra options for the passes
     ctx.extra_opts = opts.extra_opts.drain(..).collect();

--- a/tests/backend/verilog/data-instance.expect
+++ b/tests/backend/verilog/data-instance.expect
@@ -111,9 +111,9 @@ wire _guard4 = g;
 wire _guard5 = g;
 wire _guard6 = g;
 assign data_add_multi_left =
-  _guard1 ? 2'd2 :
-  _guard3 ? 2'd3 :
-  'x;
+  ({2{_guard1}} & 2'd2) |
+  ({2{_guard3}} & 2'd3) |
+  2'd0;
 always_comb begin
   if(~$onehot0({_guard3, _guard1})) begin
     $fatal(2, "Multiple assignment to port `data_add_multi.left'.");
@@ -121,11 +121,11 @@ end
 end
 assign done = 1'd1;
 assign con_add_left =
-  _guard4 ? 2'd2 :
+  ({2{_guard4}} & 2'd2) |
   2'd0;
 assign data_add_left = 2'd2;
 assign add_left =
-  _guard6 ? 2'd2 :
+  ({2{_guard6}} & 2'd2) |
   2'd0;
 // COMPONENT END: main
 endmodule


### PR DESCRIPTION
Instead of generating:
```
in = g0 ? o1 : 
       g1 ? o2 : 'x
```
This generates:
```
in = ({WIDTH{g0}} & o1) |
       ({WIDTH{g1}} & o2) | 0
```

Note that we have to generate `0` instead of `'x` because otherwise the `&`-`|` chain will produce an `'x` value.

The `--emit-mux` option simulates the old behavior.

I'm also noticing that a lot of optimizations around guards are now happening within the Verilog backend which is bad. We should move that logic into a pass if possible.