### PR TITLE
Only trigger push event on main

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,7 +1,8 @@
 name: Format
 
 on:
-  push: # allow for all branches, so forks can also validate on their own
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/fud2.yml
+++ b/.github/workflows/fud2.yml
@@ -2,6 +2,7 @@ name: fud2 tests
 
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check calyx build
         run: ./target/debug/calyx --version
       - name: validate playground config
-        run: node web/validate-data.js 
+        run: node web/validate-data.js
 
   # Get the hash of the Dockerfile
   hash:
@@ -106,8 +106,7 @@ jobs:
         git init
         git remote add origin https://github.com/${{ github.repository }}.git
         git fetch --all
-        git fetch origin $GITHUB_REF
-        git checkout -f $GITHUB_SHA
+        git checkout -f ${{ github.sha }}
         git clean -fd
 
     - name: Build
@@ -158,8 +157,7 @@ jobs:
         git init
         git remote add origin https://github.com/${{ github.repository }}.git
         git fetch --all
-        git fetch origin $GITHUB_REF
-        git checkout -f $GITHUB_SHA
+        git checkout -f ${{ github.sha }}
         git clean -fd
 
     - name: Install calyx-py & MrXL
@@ -218,8 +216,7 @@ jobs:
         git init
         git remote add origin https://github.com/${{ github.repository }}.git
         git fetch --all
-        git fetch origin $GITHUB_REF
-        git checkout -f $GITHUB_SHA
+        git checkout -f ${{ github.sha }}
         git clean -fd
 
     - name: Build


### PR DESCRIPTION
CI events are duplicated when a pull request is opened because both `push` and `pull_request` events are triggered. This makes `push` only trigger on the `main` branch. The downside is that branches won't get to see CI results till a PR is opened.