### PR TITLE
Update docs to note `fud` dependency on `calyx-py`

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -84,6 +84,9 @@ tests.
 [The Calyx driver](./running-calyx/fud) wraps the various compiler frontends and
 backends to simplify running Calyx programs.
 
+`fud` currently has a dependency on [calyx-py](builder/calyx-py.md), which you need to install first.
+
+
 Install [Flit][]:
 ```
 pip3 install flit

--- a/docs/running-calyx/fud/index.md
+++ b/docs/running-calyx/fud/index.md
@@ -15,6 +15,8 @@ The source for fud is [here](https://github.com/calyxir/calyx/tree/master/fud).
 ## Installation
 > Fud requires Python 3.9 or higher to work correctly.
 
+`fud` currently has a dependency on [calyx-py](builder/calyx-py.md), which you need to install first.
+
 You need [Flit](https://flit.readthedocs.io/en/latest/) to install `fud`. Install it with `pip3 install flit`.
 
 You can then install `fud` with


### PR DESCRIPTION
#1719 makes `fud` depend on `calyx-py` (there used to be a dependency the other way, that PR switches the dependency). 

Either way, in the meantime we should update the docs to reflect this. 