### PR TITLE
Add bypass register primitive

### DIFF
--- a/primitives/compile.futil
+++ b/primitives/compile.futil
@@ -41,3 +41,28 @@ primitive std_reg<"state_share"=1>[WIDTH](
     end else done <= 1'd0;
   end
 }
+
+
+primitive std_bypass_reg<"state_share"=1>[WIDTH](
+  @write_together(1) @data in: WIDTH,
+  @write_together(1) @interval(1) @go write_en: 1,
+  @clk clk: 1,
+  @reset reset: 1
+) -> (
+  @stable out: WIDTH,
+  @done done: 1
+)
+{
+  logic [WIDTH-1:0] val;
+  assign out = write_en? in : val;
+
+  always_ff @(posedge clk) begin
+    if (reset) begin
+       val <= 0;
+       done <= 0;
+    end else if (write_en) begin
+      val <= in;
+      done <= 1'd1;
+    end else done <= 1'd0;
+  end
+}


### PR DESCRIPTION
Having this primitive built into the Calyx library would be useful for the AMC memory flow.  The use case for this is I have an arbiter de-muxing data from a memory load interface, so I introduced my own inline primitive to latch the data without adding a cycle of latency.

Are there any test cases I should add, besides fixing the ones it broke? Either for parsing sake or an actual use-case? Should the stable attribute on the bypass register be removed?