### PR TITLE
place compile-invoke after static-promotion

### DIFF
--- a/calyx-opt/src/analysis/promotion_analysis.rs
+++ b/calyx-opt/src/analysis/promotion_analysis.rs
@@ -86,10 +86,6 @@ impl PromotionAnalysis {
         &mut self,
         s: &mut ir::Invoke,
     ) -> ir::StaticControl {
-        assert!(
-            s.comb_group.is_none(),
-            "Shouldn't Promote to Static if there is a Comb Group",
-        );
         let latency = s.attributes.get(ir::NumAttr::Promotable).unwrap();
         s.attributes.remove(ir::NumAttr::Promotable);
         let s_inv = ir::StaticInvoke {

--- a/calyx-opt/src/analysis/read_write_set.rs
+++ b/calyx-opt/src/analysis/read_write_set.rs
@@ -1,6 +1,4 @@
 use calyx_ir::{self as ir, RRC};
-use itertools::Itertools;
-use std::{collections::HashMap, iter, rc::Rc};
 
 #[derive(Clone)]
 pub struct AssignmentIterator<'a, T: 'a, I>
@@ -235,6 +233,7 @@ impl ReadWriteSet {
                 comp,
                 ..
             }) => {
+                println!("we are here");
                 let mut inps: Vec<RRC<ir::Port>> =
                     inputs.iter().map(|(_, p)| p).cloned().collect();
                 let mut outs: Vec<RRC<ir::Port>> =
@@ -326,6 +325,7 @@ impl ReadWriteSet {
                 comp,
                 ..
             }) => {
+                println!("we are here2");
                 // XXX(Caleb): Maybe check that there is one @go port.
                 let inps = inputs.iter().map(|(_, p)| p).cloned();
                 let outs = outputs.iter().map(|(_, p)| p).cloned();
@@ -443,6 +443,13 @@ impl ReadWriteSet {
     ) -> (Vec<RRC<ir::Cell>>, Vec<RRC<ir::Cell>>) {
         let (port_reads, port_writes) =
             Self::control_port_read_write_set::<INCLUDE_HOLE_ASSIGNS>(con);
+        for p in &port_reads {
+            println!("{}", p.borrow().parent.borrow());
+        }
+        for p in &port_writes {
+            println!("{}", p.borrow().name);
+        }
+
         (
             port_reads
                 .into_iter()

--- a/calyx-opt/src/analysis/read_write_set.rs
+++ b/calyx-opt/src/analysis/read_write_set.rs
@@ -1,4 +1,6 @@
 use calyx_ir::{self as ir, RRC};
+use itertools::Itertools;
+use std::{collections::HashMap, iter, rc::Rc};
 
 #[derive(Clone)]
 pub struct AssignmentIterator<'a, T: 'a, I>
@@ -233,13 +235,12 @@ impl ReadWriteSet {
                 comp,
                 ..
             }) => {
-                println!("we are here");
                 let mut inps: Vec<RRC<ir::Port>> =
                     inputs.iter().map(|(_, p)| p).cloned().collect();
                 let mut outs: Vec<RRC<ir::Port>> =
                     outputs.iter().map(|(_, p)| p).cloned().collect();
                 // Adding comp.go to input ports
-                inps.push(
+                outs.push(
                     comp.borrow()
                         .find_all_with_attr(ir::NumAttr::Go)
                         .next()
@@ -325,7 +326,6 @@ impl ReadWriteSet {
                 comp,
                 ..
             }) => {
-                println!("we are here2");
                 // XXX(Caleb): Maybe check that there is one @go port.
                 let inps = inputs.iter().map(|(_, p)| p).cloned();
                 let outs = outputs.iter().map(|(_, p)| p).cloned();
@@ -443,12 +443,6 @@ impl ReadWriteSet {
     ) -> (Vec<RRC<ir::Cell>>, Vec<RRC<ir::Cell>>) {
         let (port_reads, port_writes) =
             Self::control_port_read_write_set::<INCLUDE_HOLE_ASSIGNS>(con);
-        for p in &port_reads {
-            println!("{}", p.borrow().parent.borrow());
-        }
-        for p in &port_writes {
-            println!("{}", p.borrow().name);
-        }
 
         (
             port_reads

--- a/calyx-opt/src/default_passes.rs
+++ b/calyx-opt/src/default_passes.rs
@@ -95,10 +95,10 @@ impl PassManager {
                 SimplifyWithControl, // Must run before compile-invoke
                 StaticInference,
                 StaticPromotion,
-                CompileInvoke, // creates dead comb groups
-                CompileRepeat,
-                DeadGroupRemoval, // Since previous passes potentially create dead groups
-                CollapseControl,
+                // CompileInvoke, // creates dead comb groups
+                // CompileRepeat,
+                // DeadGroupRemoval, // Since previous passes potentially create dead groups
+                // CollapseControl,
             ]
         );
         register_alias!(

--- a/calyx-opt/src/default_passes.rs
+++ b/calyx-opt/src/default_passes.rs
@@ -93,9 +93,9 @@ impl PassManager {
                 DeadCellRemoval, // Clean up dead wires left by CombProp
                 CellShare,       // LiveRangeAnalaysis should handle comb groups
                 SimplifyWithControl, // Must run before compile-invoke
-                CompileInvoke,   // creates dead comb groups
                 StaticInference,
                 StaticPromotion,
+                CompileInvoke, // creates dead comb groups
                 CompileRepeat,
                 DeadGroupRemoval, // Since previous passes potentially create dead groups
                 CollapseControl,


### PR DESCRIPTION
place `compile-invoke` after `static-promotion`.

This would possibly lead to a few performance drops. Hence this pr aims to investigate into the reasons for the performance drops and try to fix them.