### PR TITLE
eDSL: Fix method names

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -269,7 +269,9 @@ class ComponentBuilder:
         if name:
             assert isinstance(name, str), f"name {name} is not a string"
         if is_ref and not name:
-            raise ValueError("A register that will be passed by reference must have a name.")
+            raise ValueError(
+                "A register that will be passed by reference must have a name."
+            )
         name = name or self.generate_name("reg")
         return self.cell(name, ast.Stdlib.register(size), False, is_ref)
 
@@ -576,9 +578,9 @@ class ComponentBuilder:
             reg_grp.done = reg.done
         return reg_grp
 
-    def mem_load_std_d1(self, mem, i, reg, groupname=None):
+    def mem_load_comb_mem_d1(self, mem, i, reg, groupname=None):
         """Inserts wiring into `self` to perform `reg := mem[i]`,
-        where `mem` is a std_d1 memory.
+        where `mem` is a comb_mem_d1 memory.
         """
         assert mem.is_comb_mem_d1()
         groupname = groupname or f"{mem.name()}_load_to_reg"
@@ -589,9 +591,9 @@ class ComponentBuilder:
             load_grp.done = reg.done
         return load_grp
 
-    def mem_store_std_d1(self, mem, i, val, groupname=None):
+    def mem_store_comb_mem_d1(self, mem, i, val, groupname=None):
         """Inserts wiring into `self` to perform `mem[i] := val`,
-        where `mem` is a std_d1 memory."""
+        where `mem` is a comb_mem_d1 memory."""
         assert mem.is_comb_mem_d1()
         groupname = groupname or f"store_into_{mem.name()}"
         with self.group(groupname) as store_grp:
@@ -642,7 +644,7 @@ class ComponentBuilder:
 
     def mem_load_to_mem(self, mem, i, ans, j, groupname=None):
         """Inserts wiring into `self` to perform `ans[j] := mem[i]`,
-        where `mem` and `ans` are both std_d1 memories.
+        where `mem` and `ans` are both comb_mem_d1 memories.
         """
         assert mem.is_comb_mem_d1() and ans.is_comb_mem_d1()
         groupname = groupname or f"{mem.name()}_load_to_mem"

--- a/calyx-py/calyx/gen_exp.py
+++ b/calyx-py/calyx/gen_exp.py
@@ -700,9 +700,9 @@ def build_base_not_e(degree, width, int_width, is_signed) -> Program:
     ret = main.comb_mem_d1("ret", width, 1, 1, is_external=True)
     f = main.comp_instance("f", "fp_pow_full")
 
-    read_base = main.mem_load_std_d1(b, 0, base_reg, "read_base")
-    read_exp = main.mem_load_std_d1(x, 0, exp_reg, "read_exp")
-    write_to_memory = main.mem_store_std_d1(ret, 0, f.out, "write_to_memory")
+    read_base = main.mem_load_comb_mem_d1(b, 0, base_reg, "read_base")
+    read_exp = main.mem_load_comb_mem_d1(x, 0, exp_reg, "read_exp")
+    write_to_memory = main.mem_store_comb_mem_d1(ret, 0, f.out, "write_to_memory")
 
     main.control += [
         read_base,
@@ -741,7 +741,7 @@ def build_base_is_e(degree, width, int_width, is_signed) -> Program:
         t.write_en = 1
         init.done = t.done
 
-    write_to_memory = main.mem_store_std_d1(ret, 0, e.out, "write_to_memory")
+    write_to_memory = main.mem_store_comb_mem_d1(ret, 0, e.out, "write_to_memory")
 
     main.control += [
         init,


### PR DESCRIPTION
Some methods were calling themselves "std_d1" when they were in fact expecting comb_mem_d1. This is a quick fix for that.