### PR TITLE
`gen_msb`: Tidying using modern eDSL

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -585,6 +585,18 @@ class ComponentBuilder:
             lsh_group.done = ans.done
         return lsh_group
 
+    def rsh_use(self, input, ans, val=1):
+        """Inserts wiring into `self` to perform `ans := input >> val`."""
+        width = ans.infer_width_reg()
+        cell = self.rsh(width)
+        with self.group(f"{cell.name}_group") as rsh_group:
+            cell.left = input
+            cell.right = const(width, val)
+            ans.write_en = 1
+            ans.in_ = cell.out
+            rsh_group.done = ans.done
+        return rsh_group
+
     def reg_store(self, reg, val, groupname=None):
         """Inserts wiring into `self` to perform `reg := val`."""
         groupname = groupname or f"{reg.name}_store_to_reg"

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -573,15 +573,16 @@ class ComponentBuilder:
             decr_group.done = reg.done
         return decr_group
 
-    def lsh_use(self, ref, val=1):
-        """Inserts wiring into `self` to perform `ref := ref << val`."""
-        cell = self.lsh(ref.infer_width_reg())
+    def lsh_use(self, input, ans, val=1):
+        """Inserts wiring into `self` to perform `ans := input << val`."""
+        width = ans.infer_width_reg()
+        cell = self.lsh(width)
         with self.group(f"{cell.name}_group") as lsh_group:
-            cell.left = ref.out
-            cell.right = const(ref.infer_width_reg(), val)
-            ref.write_en = 1
-            ref.in_ = cell.out
-            lsh_group.done = ref.done
+            cell.left = input
+            cell.right = const(width, val)
+            ans.write_en = 1
+            ans.in_ = cell.out
+            lsh_group.done = ans.done
         return lsh_group
 
     def reg_store(self, reg, val, groupname=None):

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -573,6 +573,17 @@ class ComponentBuilder:
             decr_group.done = reg.done
         return decr_group
 
+    def lsh_use(self, ref, val=1):
+        """Inserts wiring into `self` to perform `ref := ref << val`."""
+        cell = self.lsh(ref.infer_width_reg())
+        with self.group(f"{cell.name}_group") as lsh_group:
+            cell.left = ref.out
+            cell.right = const(ref.infer_width_reg(), val)
+            ref.write_en = 1
+            ref.in_ = cell.out
+            lsh_group.done = ref.done
+        return lsh_group
+
     def reg_store(self, reg, val, groupname=None):
         """Inserts wiring into `self` to perform `reg := val`."""
         groupname = groupname or f"{reg.name}_store_to_reg"

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -372,6 +372,10 @@ class ComponentBuilder:
         """Generate a StdRsh cell."""
         return self.binary("rsh", size, name, signed)
 
+    def lsh(self, size: int, name: str = None, signed: bool = False) -> CellBuilder:
+        """Generate a StdLsh cell."""
+        return self.binary("lsh", size, name, signed)
+
     def logic(self, operation, size: int, name: str = None) -> CellBuilder:
         """Generate a logical operator cell, of the flavor specified in `operation`."""
         name = name or self.generate_name(operation)

--- a/calyx-py/calyx/gen_msb.py
+++ b/calyx-py/calyx/gen_msb.py
@@ -1,11 +1,6 @@
 from typing import List
-from calyx.py_ast import (
-    Component,
-)
-from calyx.builder import (
-    Builder,
-    while_with,
-)
+from calyx.py_ast import Component
+from calyx.builder import Builder, while_with
 
 
 def gen_msb_calc(width: int, int_width: int) -> List[Component]:

--- a/calyx-py/calyx/gen_msb.py
+++ b/calyx-py/calyx/gen_msb.py
@@ -34,9 +34,7 @@ def gen_msb_calc(width: int, int_width: int) -> List[Component]:
     val_ans = comp.reg(width, "val_ans")
     val_build = comp.reg(width, "val_build")
     rsh = comp.rsh(width)
-    sub = comp.sub(width)
     neq = comp.neq(width)
-    lsh = comp.lsh(width)
 
     with comp.group("wr_cur_val") as wr_cur_val:
         rsh.left = in_
@@ -59,6 +57,7 @@ def gen_msb_calc(width: int, int_width: int) -> List[Component]:
         neq.right = counter.out
 
     incr_count = comp.incr(counter)
+    decr_count = comp.decr(counter)
 
     with comp.group("shift_cur_val") as shift_cur_val:
         rsh.left = cur_val.out
@@ -68,27 +67,8 @@ def gen_msb_calc(width: int, int_width: int) -> List[Component]:
         shift_cur_val.done = cur_val.done
 
     shift_val_build = comp.lsh_use(val_build.out, val_build)
-
-    with comp.group("decr_count") as decr_count:
-        sub.left = counter.out
-        sub.right = const(width, 1)
-        counter.in_ = sub.out
-        counter.write_en = HI
-        decr_count.done = counter.done
-
-    with comp.group("wr_count") as wr_count:
-        lsh.left = counter.out
-        lsh.right = const(width, width - int_width)
-        count_ans.in_ = lsh.out
-        count_ans.write_en = HI
-        wr_count.done = count_ans.done
-
-    with comp.group("wr_val") as wr_val:
-        lsh.left = val_build.out
-        lsh.right = const(width, width - int_width)
-        val_ans.in_ = lsh.out
-        val_ans.write_en = HI
-        wr_val.done = val_ans.done
+    wr_count = comp.lsh_use(counter.out, count_ans, width - int_width)
+    wr_val = comp.lsh_use(val_build.out, val_ans, width - int_width)
 
     with comp.continuous:
         comp.this().count = count_ans.out

--- a/calyx-py/calyx/gen_msb.py
+++ b/calyx-py/calyx/gen_msb.py
@@ -29,16 +29,16 @@ def gen_msb_calc(width: int, int_width: int) -> List[Component]:
     comp.output("count", width)
     comp.output("value", width)
 
-    rsh = comp.cell("rsh", Stdlib.op("rsh", width, signed=False))
     counter = comp.reg(width, "counter")
     cur_val = comp.reg(width, "cur_val")
-    add = comp.cell("add", Stdlib.op("add", width, signed=False))
-    sub = comp.cell("sub", Stdlib.op("sub", width, signed=False))
-    neq = comp.cell("neq", Stdlib.op("neq", width, signed=False))
-    lsh = comp.cell("lsh", Stdlib.op("lsh", width, signed=False))
     count_ans = comp.reg(width, "count_ans")
     val_ans = comp.reg(width, "val_ans")
     val_build = comp.reg(width, "val_build")
+    rsh = comp.rsh(width)
+    add = comp.add(width)
+    sub = comp.sub(width)
+    neq = comp.neq(width)
+    lsh = comp.lsh(width)
 
     with comp.group("wr_cur_val") as wr_cur_val:
         rsh.left = comp.this().in_
@@ -60,12 +60,7 @@ def gen_msb_calc(width: int, int_width: int) -> List[Component]:
         neq.left = const(width, 0)
         neq.right = counter.out
 
-    with comp.group("incr_count") as incr_count:
-        add.left = counter.out
-        add.right = const(width, 1)
-        counter.in_ = add.out
-        counter.write_en = HI
-        incr_count.done = counter.done
+    incr_count = comp.incr(counter)
 
     with comp.group("shift_cur_val") as shift_cur_val:
         rsh.left = cur_val.out

--- a/calyx-py/calyx/gen_msb.py
+++ b/calyx-py/calyx/gen_msb.py
@@ -67,12 +67,7 @@ def gen_msb_calc(width: int, int_width: int) -> List[Component]:
         cur_val.write_en = HI
         shift_cur_val.done = cur_val.done
 
-    with comp.group("shift_val_build") as shift_val_build:
-        lsh.left = val_build.out
-        lsh.right = const(width, 1)
-        val_build.in_ = lsh.out
-        val_build.write_en = HI
-        shift_val_build.done = val_build.done
+    shift_val_build = comp.lsh_use(val_build.out, val_build)
 
     with comp.group("decr_count") as decr_count:
         sub.left = counter.out

--- a/calyx-py/calyx/gen_msb.py
+++ b/calyx-py/calyx/gen_msb.py
@@ -4,9 +4,6 @@ from calyx.py_ast import (
 )
 from calyx.builder import (
     Builder,
-    CellAndGroup,
-    const,
-    HI,
     while_with,
 )
 
@@ -33,39 +30,15 @@ def gen_msb_calc(width: int, int_width: int) -> List[Component]:
     count_ans = comp.reg(width, "count_ans")
     val_ans = comp.reg(width, "val_ans")
     val_build = comp.reg(width, "val_build")
-    rsh = comp.rsh(width)
-    neq = comp.neq(width)
 
-    with comp.group("wr_cur_val") as wr_cur_val:
-        rsh.left = in_
-        rsh.right = const(width, int_width)
-        cur_val.in_ = rsh.out
-        cur_val.write_en = HI
-        wr_cur_val.done = cur_val.done
-
-    with comp.group("wr_val_build") as wr_val_build:
-        val_build.in_ = const(32, 1)
-        val_build.write_en = HI
-        wr_val_build.done = val_build.done
-
-    with comp.comb_group("cur_val_cond") as cur_val_cond:
-        neq.left = const(width, 0)
-        neq.right = cur_val.out
-
-    with comp.comb_group("count_cond") as count_cond:
-        neq.left = const(width, 0)
-        neq.right = counter.out
-
+    wr_cur_val = comp.rsh_use(in_, cur_val, int_width)
+    wr_val_build = comp.reg_store(val_build, 1)
+    cur_val_cond = comp.neq_use(0, cur_val.out)
+    count_cond = comp.neq_use(0, counter.out)
     incr_count = comp.incr(counter)
     decr_count = comp.decr(counter)
 
-    with comp.group("shift_cur_val") as shift_cur_val:
-        rsh.left = cur_val.out
-        rsh.right = const(width, 1)
-        cur_val.in_ = rsh.out
-        cur_val.write_en = HI
-        shift_cur_val.done = cur_val.done
-
+    shift_cur_val = comp.rsh_use(cur_val.out, cur_val)
     shift_val_build = comp.lsh_use(val_build.out, val_build)
     wr_count = comp.lsh_use(counter.out, count_ans, width - int_width)
     wr_val = comp.lsh_use(val_build.out, val_ans, width - int_width)
@@ -77,14 +50,14 @@ def gen_msb_calc(width: int, int_width: int) -> List[Component]:
     comp.control += [
         wr_cur_val,
         while_with(
-            CellAndGroup(neq, cur_val_cond),
+            cur_val_cond,
             [incr_count, shift_cur_val],
         ),
         decr_count,
         wr_count,
         wr_val_build,
         while_with(
-            CellAndGroup(neq, count_cond),
+            count_cond,
             [decr_count, shift_val_build],
         ),
         wr_val,

--- a/calyx-py/calyx/gen_msb.py
+++ b/calyx-py/calyx/gen_msb.py
@@ -25,11 +25,11 @@ def gen_msb_calc(width: int, int_width: int) -> List[Component]:
     comp.output("count", width)
     comp.output("value", width)
 
-    counter = comp.reg(width, "counter")
-    cur_val = comp.reg(width, "cur_val")
-    count_ans = comp.reg(width, "count_ans")
-    val_ans = comp.reg(width, "val_ans")
-    val_build = comp.reg(width, "val_build")
+    counter = comp.reg(width)
+    cur_val = comp.reg(width)
+    count_ans = comp.reg(width)
+    val_ans = comp.reg(width)
+    val_build = comp.reg(width)
 
     wr_cur_val = comp.rsh_use(in_, cur_val, int_width)
     wr_val_build = comp.reg_store(val_build, 1)

--- a/calyx-py/calyx/gen_msb.py
+++ b/calyx-py/calyx/gen_msb.py
@@ -1,6 +1,5 @@
 from typing import List
 from calyx.py_ast import (
-    Stdlib,
     Component,
 )
 from calyx.builder import (
@@ -19,13 +18,13 @@ def gen_msb_calc(width: int, int_width: int) -> List[Component]:
     that 2^n <= x. Note that this is essentially finding the index of the most
     significant bit in x. count_ans is the value for `n`, and `value_ans` is the
     value for `2^n`.
-    Essentially, the component uses a while loop, a counter register, and shifts the input
+    The component uses a while loop, a counter register, and shifts the input
     1 bit to the right at each iteration until it equals 0.
     Important note: this component doesn't work when the input is 0.
     """
     builder = Builder()
     comp = builder.component("msb_calc")
-    comp.input("in", width)
+    in_ = comp.input("in", width)
     comp.output("count", width)
     comp.output("value", width)
 
@@ -35,13 +34,12 @@ def gen_msb_calc(width: int, int_width: int) -> List[Component]:
     val_ans = comp.reg(width, "val_ans")
     val_build = comp.reg(width, "val_build")
     rsh = comp.rsh(width)
-    add = comp.add(width)
     sub = comp.sub(width)
     neq = comp.neq(width)
     lsh = comp.lsh(width)
 
     with comp.group("wr_cur_val") as wr_cur_val:
-        rsh.left = comp.this().in_
+        rsh.left = in_
         rsh.right = const(width, int_width)
         cur_val.in_ = rsh.out
         cur_val.write_en = HI


### PR DESCRIPTION
Following on from the work of #2034 and #2036, this PR does some tidying on the single file `gen_msb.py`. The diff file will be very pleasing, as this file was really ripe for a little cleanup using modern eDSL features. We now pass as few strings as we can, infer as many widths as we can, and generally leave all group-creation to the builder library.

Closes #1673