### PR TITLE
[Cider 2] Barebones Par

### DIFF
--- a/interp/src/flatten/structures/environment/program_counter.rs
+++ b/interp/src/flatten/structures/environment/program_counter.rs
@@ -145,7 +145,7 @@ impl SearchPath {
                         // par's child count should be decremented. The latter
                         // seems more promising but I need to think on it more
 
-                        todo!("need to deal with par")
+                        return Some(*node);
                     }
                     ControlNode::If(_) => {
                         // there is nothing to do when ascending to an if as it
@@ -322,7 +322,7 @@ pub type ChildCount = u16;
 #[derive(Debug, Default)]
 pub(crate) struct ProgramCounter {
     vec: Vec<ControlPoint>,
-    _par_map: HashMap<ControlPoint, ChildCount>,
+    par_map: HashMap<ControlPoint, ChildCount>,
 }
 
 // we need a few things from the program counter
@@ -349,7 +349,7 @@ impl ProgramCounter {
 
         Self {
             vec,
-            _par_map: HashMap::new(),
+            par_map: HashMap::new(),
         }
     }
 
@@ -365,8 +365,16 @@ impl ProgramCounter {
         self.vec.iter_mut()
     }
 
-    pub(crate) fn vec_mut(&mut self) -> &mut Vec<ControlPoint> {
+    pub fn vec_mut(&mut self) -> &mut Vec<ControlPoint> {
         &mut self.vec
+    }
+
+    pub fn par_map_mut(&mut self) -> &mut HashMap<ControlPoint, ChildCount> {
+        &mut self.par_map
+    }
+
+    pub fn _par_map(&self) -> &HashMap<ControlPoint, ChildCount> {
+        &self.par_map
     }
 }
 


### PR DESCRIPTION
Part of #1913.

Adds a simple lockstep version of par functionality via the auxiliary child-count map. The `step` function ends up being responsible for updates to the par state, rather than the program tree traversal. As a side effect, a node in the PC pointing to a par has two different meanings based on the state of the auxiliary map. If there is no entry in the map, then it means we are about to enter this par node. If there is an entry, it means that one of the threads of the par is about to exit. In this latter case, there may be multiple simultaneous copies of the entry if par threads exit simultaneously. I think this is a fine first approach though I worry it may cause some confusion in understanding the PC down the line for users of the debugger. If so, some fancier printing may resolve it.

The current implementation also necessitates use of `std::mem::take` which I don't love, though this should be avoidable with some changes to the PC "api"