### PR TITLE
Docs: document `calyx-py` installation step more clearly

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -83,16 +83,19 @@ tests.
 
 [The Calyx driver](./running-calyx/fud) wraps the various compiler frontends and
 backends to simplify running Calyx programs.
-
-`fud` currently has a dependency on [calyx-py](builder/calyx-py.md), which you need to install first.
-
+Start at the root of the repository.
 
 Install [Flit][]:
 ```
 pip3 install flit
 ```
 
-Install `fud` (from the root of the repository):
+Install [`calyx-py`](builder/calyx-py.md):
+```
+cd calyx-py && flit install -s && cd -
+```
+
+Install `fud`:
 ```
 flit -f fud/pyproject.toml install -s --deps production
 ```


### PR DESCRIPTION
Fud depends on calyx-py, and this fact is documented [here](https://docs.calyxir.org/#installing-the-command-line-driver). It is maybe a little terse and confusing.
> fud currently has a dependency on [calyx-py](https://docs.calyxir.org/builder/calyx-py.html), which you need to install first.

Someone who is quickly working through this page and copy-pasting every code block will miss it. This PR inlines the instructions to make the section more foolproof.