### PR TITLE
Docs: correct path in MrXL page

### DIFF
--- a/docs/frontends/mrxl.md
+++ b/docs/frontends/mrxl.md
@@ -20,7 +20,7 @@ First, install the [calyx-py](../calyx-py.md) library.
 
 The MrXL implementation is in Python and uses [Flit][].
 Install Flit (`pip install flit` or similar), and then type the
-following after changing your directory to `frontend/mrxl`:
+following after changing your directory to `frontends/mrxl`:
 
     flit install --symlink
 
@@ -29,7 +29,7 @@ This creates a symbolic link to the present directory and installs the `mrxl` co
 By default, [fud](../running-calyx/fud) looks for the `mrxl` executable to enable
 the `mrxl` compilation stage.
 Type `fud check` to make sure `fud` reports that the `mrxl` compiler has been
-found. If it does not, run the following while still in `frontend/mrxl`.
+found. If it does not, run the following while still in `frontends/mrxl`.
 
     fud register mrxl -p fud/mrxl.py
 


### PR DESCRIPTION
The path to MrXL was listed as `frontend/mrxl` while it should be `frontends/mrxl`.