### PR TITLE
Add some signed primitives

### DIFF
--- a/primitives/core.futil
+++ b/primitives/core.futil
@@ -4,6 +4,7 @@ extern "core.sv" {
   /// Primitives
   comb primitive std_slice<"share"=1>[IN_WIDTH, OUT_WIDTH](@data in: IN_WIDTH) -> (out: OUT_WIDTH);
   comb primitive std_pad<"share"=1>[IN_WIDTH, OUT_WIDTH](@data in: IN_WIDTH) -> (out: OUT_WIDTH);
+  comb primitive std_sign_extend<"share"=1>[IN_WIDTH, OUT_WIDTH](@data in: IN_WIDTH) -> (out: OUT_WIDTH);
   comb primitive std_cat<"share"=1>[LEFT_WIDTH, RIGHT_WIDTH, OUT_WIDTH](@data left: LEFT_WIDTH, @data right: RIGHT_WIDTH) -> (out: OUT_WIDTH);
   comb primitive std_bit_slice<"share"=1>[IN_WIDTH, START_IDX, END_IDX, OUT_WIDTH](@data in: IN_WIDTH) -> (out: OUT_WIDTH);
 
@@ -23,5 +24,6 @@ extern "core.sv" {
   comb primitive std_ge<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: 1);
   comb primitive std_le<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: 1);
   comb primitive std_rsh<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: WIDTH);
+  comb primitive std_signed_rsh<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: WIDTH);
   comb primitive std_mux<"share"=1>[WIDTH](@data cond: 1, @data tru: WIDTH, @data fal: WIDTH) -> (out: WIDTH);
 }

--- a/primitives/core.sv
+++ b/primitives/core.sv
@@ -50,6 +50,28 @@ module std_pad #(
   `endif
 endmodule
 
+module std_sign_extend #(
+    parameter IN_WIDTH  = 32,
+    parameter OUT_WIDTH = 32
+) (
+   input wire logic [IN_WIDTH-1:0]  in,
+   output logic     [OUT_WIDTH-1:0] out
+);
+   localparam EXTEND = OUT_WIDTH - IN_WIDTH;
+   assign out = { {EXTEND {in[IN_WIDTH-1]}}, in };
+
+  `ifdef VERILATOR
+    always_comb begin
+      if (IN_WIDTH > OUT_WIDTH)
+        $error(
+          "std_sign_extend: Output width less than input width\n",
+          "IN_WIDTH: %0d", IN_WIDTH,
+          "OUT_WIDTH: %0d", OUT_WIDTH
+        );
+    end
+  `endif
+endmodule
+
 module std_cat #(
   parameter LEFT_WIDTH  = 32,
   parameter RIGHT_WIDTH = 32,
@@ -191,6 +213,16 @@ module std_rsh #(
    output logic [WIDTH-1:0] out
 );
   assign out = left >> right;
+endmodule
+
+module std_signed_rsh #(
+    parameter WIDTH = 32
+) (
+   input wire               signed [WIDTH-1:0] left,
+   input wire               logic  [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+  assign out = left >>> right;
 endmodule
 
 /// this primitive is intended to be used

--- a/tests/backend/verilog/memory-with-external-attribute.expect
+++ b/tests/backend/verilog/memory-with-external-attribute.expect
@@ -288,6 +288,28 @@ module std_pad #(
   `endif
 endmodule
 
+module std_sign_extend #(
+    parameter IN_WIDTH  = 32,
+    parameter OUT_WIDTH = 32
+) (
+   input wire logic [IN_WIDTH-1:0]  in,
+   output logic     [OUT_WIDTH-1:0] out
+);
+   localparam EXTEND = OUT_WIDTH - IN_WIDTH;
+   assign out = { {EXTEND {in[IN_WIDTH-1]}}, in };
+
+  `ifdef VERILATOR
+    always_comb begin
+      if (IN_WIDTH > OUT_WIDTH)
+        $error(
+          "std_sign_extend: Output width less than input width\n",
+          "IN_WIDTH: %0d", IN_WIDTH,
+          "OUT_WIDTH: %0d", OUT_WIDTH
+        );
+    end
+  `endif
+endmodule
+
 module std_cat #(
   parameter LEFT_WIDTH  = 32,
   parameter RIGHT_WIDTH = 32,
@@ -429,6 +451,16 @@ module std_rsh #(
    output logic [WIDTH-1:0] out
 );
   assign out = left >> right;
+endmodule
+
+module std_signed_rsh #(
+    parameter WIDTH = 32
+) (
+   input wire               signed [WIDTH-1:0] left,
+   input wire               logic  [WIDTH-1:0] right,
+   output logic [WIDTH-1:0] out
+);
+  assign out = left >>> right;
 endmodule
 
 /// this primitive is intended to be used

--- a/tests/import/a.expect
+++ b/tests/import/a.expect
@@ -13,6 +13,7 @@ extern "<ROOT>/calyx/primitives/memories/comb.sv" {
 extern "<ROOT>/calyx/primitives/core.sv" {
   comb primitive std_slice<"share"=1>[IN_WIDTH, OUT_WIDTH](@data in: IN_WIDTH) -> (out: OUT_WIDTH);
   comb primitive std_pad<"share"=1>[IN_WIDTH, OUT_WIDTH](@data in: IN_WIDTH) -> (out: OUT_WIDTH);
+  comb primitive std_sign_extend<"share"=1>[IN_WIDTH, OUT_WIDTH](@data in: IN_WIDTH) -> (out: OUT_WIDTH);
   comb primitive std_cat<"share"=1>[LEFT_WIDTH, RIGHT_WIDTH, OUT_WIDTH](@data left: LEFT_WIDTH, @data right: RIGHT_WIDTH) -> (out: OUT_WIDTH);
   comb primitive std_bit_slice<"share"=1>[IN_WIDTH, START_IDX, END_IDX, OUT_WIDTH](@data in: IN_WIDTH) -> (out: OUT_WIDTH);
   comb primitive std_not<"share"=1>[WIDTH](@data in: WIDTH) -> (out: WIDTH);
@@ -27,6 +28,7 @@ extern "<ROOT>/calyx/primitives/core.sv" {
   comb primitive std_ge<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: 1);
   comb primitive std_le<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: 1);
   comb primitive std_rsh<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: WIDTH);
+  comb primitive std_signed_rsh<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: WIDTH);
   comb primitive std_mux<"share"=1>[WIDTH](@data cond: 1, @data tru: WIDTH, @data fal: WIDTH) -> (out: WIDTH);
 }
 primitive undef<"share"=1>[WIDTH]() -> (out: WIDTH) {


### PR DESCRIPTION
- Add a `std_sign_extend` primitive that increases the bitwidth of a number by sign-extending, rather than just padding with zeros.
- Add a `std_signed_rsh` primitive that shifts right while maintaining the sign of the number