### PR TITLE
[Cider 2] Misc fixes + fud2 integration

### DIFF
--- a/fud2/src/lib.rs
+++ b/fud2/src/lib.rs
@@ -323,7 +323,7 @@ pub fn build_driver(bld: &mut DriverBuilder) {
         )?;
 
         e.rule("dump-to-interp", "$cider-converter --to cider $in > $out")?;
-        e.rule("interp-to-dump", "$cider-converter --to json $in")?;
+        e.rule("interp-to-dump", "$cider-converter --to json $in > $out")?;
         e.build_cmd(
             &["data.dump"],
             "dump-to-interp",

--- a/fud2/tests/snapshots/tests__emit@calyx_debug.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_debug.snap
@@ -31,6 +31,7 @@ rule calyx-pass
 
 # Cider interpreter
 cider-exe = $calyx-base/target/debug/cider
+cider-converter = $calyx-base/target/debug/cider-data-converter
 rule cider
   command = $cider-exe -l $calyx-base --raw --data data.json $in > $out
 rule cider-debug
@@ -43,6 +44,13 @@ rule dat-to-interp
 rule interp-to-dat
   command = $python interp-dat.py --from-interp $in $sim_data > $out
 build data.json: dat-to-interp $sim_data | interp-dat.py
+rule cider2
+  command = $cider-exe -l $calyx-base --data data.dump $in flat > $out
+rule dump-to-interp
+  command = $cider-converter --to cider $in > $out
+rule interp-to-dump
+  command = $cider-converter --to json $in > $out
+build data.dump: dump-to-interp $sim_data | $cider-converter
 
 # build targets
 build _pseudo_debug: cider-debug stdin | data.json

--- a/fud2/tests/snapshots/tests__emit@calyx_interp_dat.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_interp_dat.snap
@@ -31,6 +31,7 @@ rule calyx-pass
 
 # Cider interpreter
 cider-exe = $calyx-base/target/debug/cider
+cider-converter = $calyx-base/target/debug/cider-data-converter
 rule cider
   command = $cider-exe -l $calyx-base --raw --data data.json $in > $out
 rule cider-debug
@@ -43,6 +44,13 @@ rule dat-to-interp
 rule interp-to-dat
   command = $python interp-dat.py --from-interp $in $sim_data > $out
 build data.json: dat-to-interp $sim_data | interp-dat.py
+rule cider2
+  command = $cider-exe -l $calyx-base --data data.dump $in flat > $out
+rule dump-to-interp
+  command = $cider-converter --to cider $in > $out
+rule interp-to-dump
+  command = $cider-converter --to json $in > $out
+build data.dump: dump-to-interp $sim_data | $cider-converter
 
 # build targets
 build interp_out.json: cider stdin | data.json

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -3,7 +3,7 @@ name = "interp"
 version = "0.1.1"
 authors = ["The Calyx authors"]
 edition = "2021"
-rust-version.workspace = true
+rust-version = "1.73"
 
 [lib]
 doctest = false # Don't run doc tests

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -485,6 +485,10 @@ impl<'a> Simulator<'a> {
         &self.env.ports[port_idx]
     }
 
+    pub(crate) fn get_root_component(&self) -> &ComponentLedger {
+        self.env.cells.first().unwrap().as_comp().unwrap()
+    }
+
     /// Attempt to find the parent cell for a port. If no such cell exists (i.e.
     /// it is a hole port, then it returns None)
     fn _get_parent_cell(
@@ -940,7 +944,7 @@ impl<'a> Simulator<'a> {
             ctx.secondary[entrypoint_secondary.name].clone(),
         );
 
-        let root = self.env.cells.first().unwrap().as_comp().unwrap();
+        let root = self.get_root_component();
 
         for (offset, idx) in entrypoint_secondary.cell_offset_map.iter() {
             let cell_info = &ctx.secondary[*idx];

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -158,12 +158,16 @@ impl CellLedger {
     }
 
     #[must_use]
-    pub(crate) fn as_primitive(&self) -> Option<&dyn Primitive> {
-        if let Self::Primitive { cell_dyn } = self {
-            Some(&**cell_dyn)
-        } else {
-            None
+    pub fn as_primitive(&self) -> Option<&dyn Primitive> {
+        match self {
+            Self::Primitive { cell_dyn } => Some(&**cell_dyn),
+            _ => None,
         }
+    }
+
+    pub fn unwrap_primitive(&self) -> &dyn Primitive {
+        self.as_primitive()
+            .expect("Unwrapped cell ledger as primitive but received component")
     }
 }
 
@@ -959,8 +963,7 @@ impl<'a> Simulator<'a> {
                     dims.size(),
                     dims.as_serializing_dim(),
                     self.env.cells[cell_index]
-                        .as_primitive()
-                        .unwrap()
+                        .unwrap_primitive()
                         .dump_memory_state()
                         .unwrap(),
                 )

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -578,10 +578,10 @@ impl<'a> Simulator<'a> {
         // program counter as the size
         let mut leaf_nodes = vec![];
 
-        let mut par_map = std::mem::take(self.env.pc.par_map_mut());
         let mut new_nodes = vec![];
+        let (vecs, par_map) = self.env.pc.mut_refs();
 
-        self.env.pc.vec_mut().retain_mut(|node| {
+        vecs.retain_mut(|node| {
             // just considering a single node case for the moment
             match &self.env.ctx.primary[node.control_node_idx] {
                 ControlNode::Seq(seq) => {
@@ -702,8 +702,6 @@ impl<'a> Simulator<'a> {
 
         // insert all the new nodes from the par into the program counter
         self.env.pc.vec_mut().extend(new_nodes);
-        // return the par map to the program counter
-        *self.env.pc.par_map_mut() = par_map;
 
         self.undef_all_ports();
 

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -941,7 +941,7 @@ impl<'a> Simulator<'a> {
         let entrypoint_secondary = &ctx.secondary[ctx.entry_point];
 
         let mut dump = DataDump::new_empty_with_top_level(
-            ctx.secondary[entrypoint_secondary.name].clone(),
+            ctx.lookup_string(entrypoint_secondary.name).clone(),
         );
 
         let root = self.get_root_component();

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -949,7 +949,7 @@ impl<'a> Simulator<'a> {
         for (offset, idx) in entrypoint_secondary.cell_offset_map.iter() {
             let cell_info = &ctx.secondary[*idx];
             let cell_index = &root.index_bases + offset;
-            let name = ctx.secondary[cell_info.name].clone();
+            let name = ctx.lookup_string(cell_info.name).clone();
             if let CellPrototype::Memory { width, dims, .. } =
                 &cell_info.prototype
             {

--- a/interp/src/flatten/structures/environment/program_counter.rs
+++ b/interp/src/flatten/structures/environment/program_counter.rs
@@ -369,12 +369,23 @@ impl ProgramCounter {
         &mut self.vec
     }
 
-    pub fn par_map_mut(&mut self) -> &mut HashMap<ControlPoint, ChildCount> {
+    pub fn _par_map_mut(&mut self) -> &mut HashMap<ControlPoint, ChildCount> {
         &mut self.par_map
     }
 
     pub fn _par_map(&self) -> &HashMap<ControlPoint, ChildCount> {
         &self.par_map
+    }
+
+    /// returns mutable references to both vec and par_map.
+    /// This is useful for when you need to mutate both at the same time.
+    pub fn mut_refs(
+        &mut self,
+    ) -> (
+        &mut Vec<ControlPoint>,
+        &mut HashMap<ControlPoint, ChildCount>,
+    ) {
+        (&mut self.vec, &mut self.par_map)
     }
 }
 

--- a/tools/cider-data-converter/Cargo.toml
+++ b/tools/cider-data-converter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cider-data-converter"
 authors.workspace = true
-rust-version.workspace = true
+rust-version = "1.73"
 edition.workspace = true
 version = "0.1.0"
 


### PR DESCRIPTION
Part of #2044 which adds a basic fud2 flow for Cider 2, named `interp-flat`.

Also some minor tweaks to make the code a little nicer in a few places. I need to go implement `with` before I can get much of the test suite hooked up, since nearly all the test suite programs use it in some capacity