### PR TITLE
Docs: correct command to list passes

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -10,7 +10,7 @@ executes.
 To get a complete list of all passes, run the following:
 
 ```
-calyx --list-passes
+cargo run -- pass-help
 ```
 
 This generates results of the form:

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -7,11 +7,10 @@ various passes and backends.
 
 The compiler is organized as a sequence of passes that are run when the compiler
 executes.
-To get a complete list of all passes, run the following from the repository
-root:
+To get a complete list of all passes, run the following:
 
 ```
-cargo run -- --list-passes
+calyx --list-passes
 ```
 
 This generates results of the form:


### PR DESCRIPTION
The [docs](https://docs.calyxir.org/compiler.html#controlling-passes) tell you to run 
```
cargo run -- --list-passes
```
from the root of the repository in order to see a list of Calyx passes. In reality I have found the command is 
```
calyx --list-passes
```
and it does not need to be run from the root. 

This PR changes the docs to reflect this. Please let me know if I've somehow gotten it wrong, or if additional context is needed at that point in the docs.