### PR TITLE
[Cider2] Continuous assigns + `with`

### DIFF
--- a/interp/src/flatten/primitives/builder.rs
+++ b/interp/src/flatten/primitives/builder.rs
@@ -130,8 +130,8 @@ pub fn build_primitive(
             }
         }
 
-        CellPrototype::Unknown(_, _) => {
-            todo!()
+        CellPrototype::Unknown(s, _) => {
+            todo!("Primitives {s} not yet implemented")
         }
     }
 }

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -598,7 +598,7 @@ impl<'a> Simulator<'a> {
         let mut leaf_nodes = vec![];
 
         let mut new_nodes = vec![];
-        let (vecs, par_map) = self.env.pc.mut_refs();
+        let (vecs, par_map, with_map) = self.env.pc.mut_refs();
 
         vecs.retain_mut(|node| {
             // just considering a single node case for the moment
@@ -745,7 +745,9 @@ impl<'a> Simulator<'a> {
             }
         }
 
-        self.simulate_combinational(&leaf_nodes)?;
+        let assigns_bundle = self.get_assignments(&leaf_nodes);
+
+        self.simulate_combinational(&assigns_bundle)?;
 
         for cell in self.env.cells.values_mut() {
             match cell {
@@ -830,9 +832,8 @@ impl<'a> Simulator<'a> {
 
     fn simulate_combinational(
         &mut self,
-        control_points: &[ControlPoint],
+        assigns_bundle: &[ScheduledAssignments],
     ) -> InterpreterResult<()> {
-        let assigns_bundle = self.get_assignments(control_points);
         let mut has_changed = true;
 
         // TODO griffin: rewrite this so that someone can actually read it

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -585,6 +585,10 @@ impl<'a> Simulator<'a> {
                     ScheduledAssignments::new(x.comp, x.assigns, None)
                 }),
             )
+            .chain(self.env.pc.with_map().iter().map(|(ctrl_pt, comb_grp)| {
+                let assigns = self.ctx().primary[*comb_grp].assignments;
+                ScheduledAssignments::new(ctrl_pt.comp, assigns, None)
+            }))
             .collect()
     }
 

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -251,6 +251,12 @@ impl<'a> Environment<'a> {
             .expect("Called layout component with a non-component cell.");
         let comp_aux = &self.ctx.secondary[*comp_id];
 
+        // Insert the component's continuous assignments into the program counter, if non-empty
+        let cont_assigns = self.ctx.primary[*comp_id].continuous_assignments;
+        if !cont_assigns.is_empty() {
+            self.pc.push_continuous_assigns(comp, cont_assigns);
+        }
+
         // first layout the signature
         for sig_port in comp_aux.signature.iter() {
             let idx = self.ports.push(PortValue::new_undef());
@@ -574,6 +580,11 @@ impl<'a> Simulator<'a> {
                     }
                 }
             })
+            .chain(
+                self.env.pc.continuous_assigns().iter().map(|x| {
+                    ScheduledAssignments::new(x.comp, x.assigns, None)
+                }),
+            )
             .collect()
     }
 

--- a/interp/src/flatten/structures/environment/program_counter.rs
+++ b/interp/src/flatten/structures/environment/program_counter.rs
@@ -395,18 +395,6 @@ impl ProgramCounter {
         &self.par_map
     }
 
-    /// returns mutable references to both vec and par_map.
-    /// This is useful for when you need to mutate both at the same time.
-    pub fn mut_refs(
-        &mut self,
-    ) -> (
-        &mut Vec<ControlPoint>,
-        &mut HashMap<ControlPoint, ChildCount>,
-        &mut HashMap<ControlPoint, CombGroupIdx>,
-    ) {
-        (&mut self.vec, &mut self.par_map, &mut self.with_map)
-    }
-
     pub fn take_fields(
         &mut self,
     ) -> (

--- a/interp/src/flatten/structures/environment/program_counter.rs
+++ b/interp/src/flatten/structures/environment/program_counter.rs
@@ -432,6 +432,10 @@ impl ProgramCounter {
     pub(crate) fn continuous_assigns(&self) -> &[ContinuousAssignments] {
         &self.continuous_assigns
     }
+
+    pub(crate) fn with_map(&self) -> &HashMap<ControlPoint, CombGroupIdx> {
+        &self.with_map
+    }
 }
 
 impl<'a> IntoIterator for &'a ProgramCounter {

--- a/interp/src/flatten/structures/environment/program_counter.rs
+++ b/interp/src/flatten/structures/environment/program_counter.rs
@@ -5,7 +5,8 @@ use ahash::{HashMap, HashMapExt};
 use super::super::context::Context;
 use crate::flatten::{
     flat_ir::prelude::{
-        AssignmentIdx, ControlIdx, ControlMap, ControlNode, GlobalCellIdx,
+        AssignmentIdx, CombGroupIdx, ControlIdx, ControlMap, ControlNode,
+        GlobalCellIdx,
     },
     structures::index_trait::{impl_index_nonzero, IndexRange, IndexRef},
 };
@@ -332,6 +333,7 @@ pub(crate) struct ProgramCounter {
     vec: Vec<ControlPoint>,
     par_map: HashMap<ControlPoint, ChildCount>,
     continuous_assigns: Vec<ContinuousAssignments>,
+    with_map: HashMap<ControlPoint, CombGroupIdx>,
 }
 
 // we need a few things from the program counter
@@ -360,6 +362,7 @@ impl ProgramCounter {
             vec,
             par_map: HashMap::new(),
             continuous_assigns: Vec::new(),
+            with_map: HashMap::new(),
         }
     }
 
@@ -394,8 +397,9 @@ impl ProgramCounter {
     ) -> (
         &mut Vec<ControlPoint>,
         &mut HashMap<ControlPoint, ChildCount>,
+        &mut HashMap<ControlPoint, CombGroupIdx>,
     ) {
-        (&mut self.vec, &mut self.par_map)
+        (&mut self.vec, &mut self.par_map, &mut self.with_map)
     }
 
     pub(crate) fn push_continuous_assigns(

--- a/interp/src/serialization/data_dump.rs
+++ b/interp/src/serialization/data_dump.rs
@@ -149,6 +149,7 @@ impl DataDump {
         write!(writer, "{}", header_str).unwrap();
 
         let written = writer.write(&self.data)?;
+        writer.flush()?;
         assert_eq!(written, self.data.len());
         Ok(())
     }


### PR DESCRIPTION
Part of #1913.

This modifies the program counter to add support for `with` groups and continuous assignments. Nothing super fancy here.  The only annoying thing of note is that I had to reintroduce a `take`-style method to deal with the existing structure and mutability. Might be worth revisiting in the future