### PR TITLE
[fud2] Always send Ninja's stdout to our stderr

### DIFF
--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -219,10 +219,7 @@ impl<'a> Run<'a> {
         // Run `ninja` in the working directory.
         let mut cmd = Command::new(&self.global_config.ninja);
         cmd.current_dir(dir);
-        if self.plan.stdout && !self.global_config.verbose {
-            // When we're printing to stdout, suppress Ninja's output by default.
-            cmd.stdout(std::process::Stdio::null());
-        }
+        cmd.stdout(std::io::stderr()); // Send Ninja's stdout to our stderr.
         let status = cmd.status()?;
 
         // Emit stdout, only when Ninja succeeded.


### PR DESCRIPTION
This solves a confusing problem, encountered by both @sgpthomas and @EclecticGriffin in short order, where using fud2 in "stdout mode" (i.e., without `-o`) would suppress errors from the underlying commands by default (i.e., unless you *also* remember to use `-v`). We don't want Ninja printing stuff to stdout, but we also don't like hiding the error messages, so a sensible solution is to just unconditionally make Ninja's progress messages go to stderr. Seems reasonable to me, semantically: all of fud2's output other than the actual content of a "stdout mode" output should go to stderr.

To be super clear about it, there are 4 conditions that matter. Here are sample commands for each:

* Success, file-output mode. Example: `cat anything.futil | fud2 --from calyx --to verilog -o /dev/null`
  * This used to show Ninja progress, and it still does.
* Success, stdout mode. Example: `cat lti.futil | fud2 --from calyx --to verilog > /dev/null`
  * This used to show nothing at all. Now it prints Ninja progress messages (on stderr, not redirect to `/dev/null`). This is debatably better or worse.
* Error, file-output mode. Example: `echo 'component' | fud2 --from calyx --to verilog -o /dev/null`
  * This used to show a good error message, and it still does.
* Error, stdout mode. Example: `echo 'component' | fud2 --from calyx --to verilog > /dev/null`
  * This used to show nothing at all, and now it shows a useful error message from the underlying Calyx compiler invocation. **This is what this PR fixes.**

I also tried "buffering up" the stderr and printing it only when there's an error. This leads to marginally "cleaner" output in "stdout mode" because we don't even see Ninja's progress messages. But it also means buffering and all the various conditions get quite messy... and we also lose colors in the errors because they don't think they are talking to a terminal anymore! I think this solution is a bit simpler and better overall.