### PR TITLE
[fud2] Plugins with Starlark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +61,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocative"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082af274fd02beef17b7f0725a49ecafe6c075ef56cac9d6363eb3916a9817ae"
+dependencies = [
+ "allocative_derive",
+ "bumpalo",
+ "ctor",
+ "hashbrown 0.14.3",
+ "num-bigint",
+]
+
+[[package]]
+name = "allocative_derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe233a377643e0fc1a56421d7c90acdec45c291b30345eb9f08e8d0ddce5a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +103,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -157,6 +206,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +288,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bindgen"
@@ -345,6 +409,12 @@ name = "bytemuck"
 version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -649,6 +719,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmp_any"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +751,12 @@ dependencies = [
  "cfg-if",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "copy_dir"
@@ -777,6 +859,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +893,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -923,6 +1021,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugserver-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf6834a70ed14e8e4e41882df27190bea150f1f6ecf461f1033f8739cd8af4a"
+dependencies = [
+ "schemafy",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +1040,36 @@ dependencies = [
  "powerfmt",
  "serde",
 ]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -984,10 +1123,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "display_container"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a110a75c96bedec8e65823dea00a1d710288b7a369d95fd8a0f5127639466fa"
+dependencies = [
+ "either",
+ "indenter",
+]
+
+[[package]]
+name = "dupe"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73b0ec8a0206a0aa8cfd70f10adae48bdfe4b01663a5a5a37e2e48fa16a2705"
+dependencies = [
+ "dupe_derive",
+]
+
+[[package]]
+name = "dupe_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e7d0f888ea556a80f971cda6c897ce90ae0e7673fc1602eb2e9b86734e68768"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1017,6 +1195,15 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "errno"
@@ -1105,11 +1292,14 @@ dependencies = [
 name = "fud"
 version = "0.0.2"
 dependencies = [
+ "allocative",
  "anyhow",
+ "derive_more",
  "fud-core",
  "include_dir",
  "insta",
  "manifest-dir-macros",
+ "starlark",
 ]
 
 [[package]]
@@ -1211,6 +1401,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,6 +1471,10 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash 0.8.10",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1387,6 +1590,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,7 +1654,7 @@ dependencies = [
  "pest_derive",
  "petgraph",
  "proptest",
- "rustyline",
+ "rustyline 10.0.0",
  "serde",
  "serde_json",
  "serde_with 1.14.0",
@@ -1455,6 +1664,12 @@ dependencies = [
  "smallvec",
  "thiserror",
 ]
+
+[[package]]
+name = "inventory"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "is-terminal"
@@ -1498,6 +1713,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "diff",
+ "ena",
+ "is-terminal",
+ "itertools 0.10.5",
+ "lalrpop-util",
+ "petgraph",
+ "regex",
+ "regex-syntax 0.6.29",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -1574,6 +1820,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "logos"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
+dependencies = [
+ "beef",
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.6.29",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "lsp-types"
 version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,10 +1868,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -1631,6 +1915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,6 +1934,17 @@ name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -1809,6 +2110,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +2131,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -1920,6 +2237,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,6 +2318,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "pretty"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,7 +2368,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.2",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -2171,7 +2503,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2182,8 +2514,14 @@ checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.2",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2211,6 +2549,15 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2257,7 +2604,30 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.24.3",
+ "radix_trie",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
+
+[[package]]
+name = "rustyline"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "clipboard-win",
+ "dirs-next",
+ "fd-lock",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.26.4",
  "radix_trie",
  "scopeguard",
  "unicode-segmentation",
@@ -2282,10 +2652,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemafy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aea5ba40287dae331f2c48b64dbc8138541f5e97ee8793caa7948c1f31d86d5"
+dependencies = [
+ "Inflector",
+ "schemafy_core",
+ "schemafy_lib",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "schemafy_core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41781ae092f4fd52c9287efb74456aea0d3b90032d2ecad272bd14dbbcb0511b"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemafy_lib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e953db32579999ca98c451d80801b6f6a7ecba6127196c5387ec0774c528befa"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "schemafy_core",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -2443,6 +2861,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,6 +2926,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "starlark"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419b088f6fe8393b8b2525d57f32e240ff07ab49e39f0afe3c8a5372bb94a823"
+dependencies = [
+ "allocative",
+ "anyhow",
+ "bumpalo",
+ "cmp_any",
+ "debugserver-types",
+ "derivative",
+ "derive_more",
+ "display_container",
+ "dupe",
+ "either",
+ "erased-serde",
+ "hashbrown 0.14.3",
+ "inventory",
+ "itertools 0.10.5",
+ "maplit",
+ "memoffset",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "regex",
+ "rustyline 11.0.0",
+ "serde",
+ "serde_json",
+ "starlark_derive",
+ "starlark_map",
+ "starlark_syntax",
+ "static_assertions",
+ "strsim",
+ "textwrap",
+ "thiserror",
+]
+
+[[package]]
+name = "starlark_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8407ca86174f600acfc8b7e0576058bb866a19521b92f9590fa2bcf1c8c807"
+dependencies = [
+ "dupe",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "starlark_map"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e03678553f5f0ce473a7a9064fc7bf2c1fa5013eb605c95d09896e3eacbacc5"
+dependencies = [
+ "allocative",
+ "dupe",
+ "equivalent",
+ "fxhash",
+ "hashbrown 0.14.3",
+ "serde",
+]
+
+[[package]]
+name = "starlark_syntax"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ae4c126dbc9702fae89fb2460f06b0f562e7de1351ab545591a27e9528afa2f"
+dependencies = [
+ "allocative",
+ "annotate-snippets",
+ "anyhow",
+ "derivative",
+ "derive_more",
+ "dupe",
+ "lalrpop",
+ "lalrpop-util",
+ "logos",
+ "lsp-types",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "starlark_map",
+ "thiserror",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,6 +3035,19 @@ dependencies = [
  "cfg-if",
  "hashbrown 0.11.2",
  "serde",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
 ]
 
 [[package]]
@@ -2694,6 +3220,15 @@ checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2989,6 +3524,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "url"

--- a/fud2/Cargo.toml
+++ b/fud2/Cargo.toml
@@ -17,6 +17,9 @@ fud-core = { path = "fud-core", version = "0.0.2" }
 anyhow.workspace = true
 manifest-dir-macros = "0.1"
 include_dir = "0.7"
+starlark = "0.12.0"
+allocative = "0.3.3"
+derive_more = "0.99.17"
 
 [lib]
 name = "fud2"

--- a/fud2/fud-core/src/exec/driver.rs
+++ b/fud2/fud-core/src/exec/driver.rs
@@ -252,6 +252,13 @@ impl DriverBuilder {
         })
     }
 
+    pub fn find_state(&self, needle: &str) -> Option<StateRef> {
+        self.states
+            .iter()
+            .find(|(_, State { name, .. })| needle == name)
+            .map(|(state_ref, _)| state_ref)
+    }
+
     fn add_op<T: run::EmitBuild + 'static>(
         &mut self,
         name: &str,

--- a/fud2/src/main.rs
+++ b/fud2/src/main.rs
@@ -1,9 +1,20 @@
+mod plugins;
+
+use std::path::PathBuf;
+
 use fud2::build_driver;
 use fud_core::{cli, DriverBuilder};
+use plugins::build_plugins;
 
 fn main() -> anyhow::Result<()> {
+    // let bld: DbWrap = DbWrap::new("fud2");
     let mut bld = DriverBuilder::new("fud2");
+
+    // build rust stages and operations
     build_driver(&mut bld);
+
+    // build plugin states and operations
+    bld = build_plugins(bld, &[PathBuf::from("test.star")]);
 
     // In debug mode, get resources from the source directory.
     #[cfg(debug_assertions)]

--- a/fud2/src/plugins.rs
+++ b/fud2/src/plugins.rs
@@ -1,0 +1,242 @@
+use std::{cell::RefCell, path::PathBuf, sync::RwLock};
+
+use allocative::Allocative;
+use anyhow::anyhow;
+use fud_core::{
+    exec::{OpRef, StateRef},
+    run::{EmitResult, EmitSetup, Emitter},
+    DriverBuilder,
+};
+use starlark::{
+    environment::{
+        GlobalsBuilder, LibraryExtension, Methods, MethodsBuilder,
+        MethodsStatic, Module,
+    },
+    eval::Evaluator,
+    starlark_module,
+    syntax::{AstModule, Dialect},
+    values::{
+        list::UnpackList, none::NoneType, starlark_value, AllocValue,
+        NoSerialize, ProvidesStaticType, StarlarkValue, UnpackValue, Value,
+    },
+};
+
+#[derive(ProvidesStaticType)]
+struct DbWrap(RefCell<DriverBuilder>);
+
+impl DbWrap {
+    fn new(driver_builder: DriverBuilder) -> Self {
+        Self(RefCell::new(driver_builder))
+    }
+}
+
+#[derive(Debug, ProvidesStaticType, Allocative, Clone)]
+enum Stmt {
+    ConfigVar(String, String),
+    Rule(String, String),
+}
+
+impl Stmt {
+    fn exec(&self, e: &mut Emitter) -> EmitResult {
+        match self {
+            Stmt::ConfigVar(name, key) => Ok(e.config_var(name, key)?),
+            Stmt::Rule(name, command) => Ok(e.rule(name, command)?),
+        }
+    }
+}
+
+#[derive(Debug, ProvidesStaticType, Default, Allocative, Clone)]
+struct EmitterStmts(Vec<Stmt>);
+
+impl EmitterStmts {
+    fn push(&mut self, item: Stmt) {
+        self.0.push(item);
+    }
+}
+
+impl EmitSetup for EmitterStmts {
+    fn setup(&self, e: &mut Emitter) -> EmitResult {
+        self.0.iter().try_fold((), |_, it| it.exec(e))
+    }
+}
+
+#[derive(
+    Debug, derive_more::Display, Allocative, NoSerialize, ProvidesStaticType,
+)]
+struct StarlarkStateRef(#[allocative(skip)] StateRef);
+#[starlark_value(type = "StateRef", UnpackValue, StarlarkTypeRepr)]
+impl<'v> StarlarkValue<'v> for StarlarkStateRef {}
+impl<'v> AllocValue<'v> for StarlarkStateRef {
+    fn alloc_value(self, heap: &'v starlark::values::Heap) -> Value<'v> {
+        heap.alloc_simple(self)
+    }
+}
+
+#[derive(
+    Debug, derive_more::Display, Allocative, NoSerialize, ProvidesStaticType,
+)]
+struct StarlarkOpRef(#[allocative(skip)] OpRef);
+#[starlark_value(type = "OpRef", UnpackValue, StarlarkTypeRepr)]
+impl<'v> StarlarkValue<'v> for StarlarkOpRef {}
+impl<'v> AllocValue<'v> for StarlarkOpRef {
+    fn alloc_value(self, heap: &'v starlark::values::Heap) -> Value<'v> {
+        heap.alloc_simple(self)
+    }
+}
+
+#[derive(
+    Debug,
+    ProvidesStaticType,
+    Default,
+    Allocative,
+    NoSerialize,
+    derive_more::Display,
+)]
+#[display(fmt = "EmitedStore({:?})", _0)]
+struct EmitterStore(RwLock<EmitterStmts>);
+
+#[starlark_module]
+fn emit_methods(builder: &mut MethodsBuilder) {
+    fn config_var(
+        this: &EmitterStore,
+        name: &str,
+        key: &str,
+    ) -> anyhow::Result<NoneType> {
+        this.0
+            .write()
+            .unwrap()
+            .push(Stmt::ConfigVar(name.to_string(), key.to_string()));
+        Ok(NoneType)
+    }
+
+    fn rule(
+        this: &EmitterStore,
+        name: &str,
+        command: &str,
+    ) -> anyhow::Result<NoneType> {
+        this.0
+            .write()
+            .unwrap()
+            .push(Stmt::Rule(name.to_string(), command.to_string()));
+        Ok(NoneType)
+    }
+}
+
+/// This is how we inject methods onto the `EmitterStore` struct
+#[starlark_value(type = "EmitterStore", UnpackValue, StarlarkTypeRepr)]
+impl<'v> StarlarkValue<'v> for EmitterStore {
+    fn get_methods() -> Option<&'static Methods> {
+        static RES: MethodsStatic = MethodsStatic::new();
+        RES.methods(emit_methods)
+    }
+}
+
+#[starlark_module]
+fn global_dfns(builder: &mut GlobalsBuilder) {
+    fn state(
+        name: &str,
+        extensions: UnpackList<&str>,
+        eval: &mut Evaluator,
+    ) -> anyhow::Result<StarlarkStateRef> {
+        let mut db_ref = eval
+            .extra
+            .unwrap()
+            .downcast_ref::<DbWrap>()
+            .unwrap()
+            .0
+            .borrow_mut();
+        Ok(StarlarkStateRef(db_ref.state(name, &extensions.items)))
+    }
+
+    fn get_state(
+        name: &str,
+        eval: &mut Evaluator,
+    ) -> anyhow::Result<StarlarkStateRef> {
+        let db_ref = eval
+            .extra
+            .unwrap()
+            .downcast_ref::<DbWrap>()
+            .unwrap()
+            .0
+            .borrow();
+
+        db_ref
+            .find_state(name)
+            .map(StarlarkStateRef)
+            .ok_or(anyhow!("Unknown state: {name}"))
+    }
+
+    fn rule<'v>(
+        setups: UnpackList<Value<'v>>,
+        input: &StarlarkStateRef,
+        output: &StarlarkStateRef,
+        rule_name: &str,
+        eval: &mut Evaluator<'v, '_>,
+    ) -> anyhow::Result<StarlarkOpRef> {
+        let mut db_ref = eval
+            .extra
+            .unwrap()
+            .downcast_ref::<DbWrap>()
+            .unwrap()
+            .0
+            .borrow_mut();
+
+        // get setuprefs for starlark functions
+        let heap = eval.heap();
+        let mut stores = vec![];
+        for setup in setups {
+            let store: &EmitterStore =
+                <&EmitterStore as UnpackValue>::unpack_value(
+                    eval.eval_function(
+                        setup,
+                        &[heap.alloc_simple(EmitterStore::default())],
+                        &[],
+                    )
+                    .unwrap(),
+                )
+                .unwrap();
+            let store_ref = store.0.read().unwrap();
+            stores.push(store_ref.clone());
+        }
+
+        let setup_refs = stores
+            .into_iter()
+            .map(|s| db_ref.add_setup("test", s))
+            .collect::<Vec<_>>();
+
+        Ok(StarlarkOpRef(db_ref.rule(
+            &setup_refs,
+            input.0,
+            output.0,
+            rule_name,
+        )))
+    }
+}
+
+// todo: would like to change this to just take a &mut DriverBuilder. I'll play around with that later
+pub fn build_plugins(bld: DriverBuilder, paths: &[PathBuf]) -> DriverBuilder {
+    let dbwrap = DbWrap::new(bld);
+
+    let globals = GlobalsBuilder::extended_by(&[LibraryExtension::Print])
+        .with(global_dfns)
+        .build();
+    let module = Module::new();
+    let mut eval = Evaluator::new(&module);
+
+    // we have to use unsafe here to construct a reference to `bld`
+    // this is because `Evaluator` forces the lifetime of the reference
+    // passed in for `eval.extra` to live as long as `bld`. This makes
+    // it impossible to use `bld` again, because the reference might
+    // still be alive. There might be another way around this, but this
+    // is what I could find
+    let bld_ref: *const DbWrap = &dbwrap as *const _;
+    eval.extra = Some(unsafe { bld_ref.as_ref().unwrap() });
+
+    for p in paths {
+        let ast = AstModule::parse_file(&p, &Dialect::Standard).unwrap();
+        eval.eval_module(ast, &globals).unwrap();
+    }
+
+    // extract the driver builder out of the refcell
+    dbwrap.0.into_inner()
+}

--- a/fud2/test.star
+++ b/fud2/test.star
@@ -1,0 +1,12 @@
+# define the dahlia state
+dahlia = state(
+    name = "dahlia2",
+    extensions = ["fuse"]
+)
+
+def dahlia_setup(e):
+    e.config_var("dahlia-exe", "dahlia")
+    e.rule("dahlia-to-calyx", "$dahlia-exe -b calyx --lower -l error $in -o $out")
+    return e
+
+rule([dahlia_setup], dahlia, get_state("calyx"), "dahlia2-to-calyx")


### PR DESCRIPTION
This is a prototype implementation to help decide if this is the right path to bring back the extensibility of the original fud.

I think theoretically there are two main approaches to defining a plugin API for fud. The first is defining a static configuration language (in `json` or something similar), that we then parse and "interpret" into operations and stages. The second is exposing the Rust API for constructing these things. This implementation explores the second path; which means wherever possible (and easy), I expose Starlark methods that just call Rust functions directly.

The main upside for the first approach is simplicity. We don't have to pull in a whole interpreter, and can more easily enforce the philosophy of all work is done by commands that you can run. This falls apart if we want to support operations that do more complicated things. I'm not totally sure what those complicated things are, but they might exist. I think in the worst case, we end up basically implementing our own adhoc language.

For the second approach, we get a more capable language for defining ops, at the cost of complexity in the plugin framework layer. With Starlark, we are also relying on an externally maintained (and relatively niche) thing. We wouldn't have this with the dlopen route, but I think I prefer Starlark. It makes adding ops easier by not requiring compiling a plugin into a shared library.

I guess this decision comes down to whether we think having a richer configuration language is a worthwhile trade-off for more implementation complexity. Not totally sure where I land on this.

## Implementation Woes
I feel like I'm making a big deal about "implementation complexity." This comes from the experience of figuring out how to use Starlark. While it is decently well-documented, I had to do a lot of digging around to figure out how to do the things that I wanted. I do not think that maintaining and improving this part of the code-base will be a trivial task. But maybe it's a small enough thing that it will not be a big deal.

I had to do some `unsafe` wackiness to get the implementation to work. Particularly passing the `DriverBuilder` into the evaluator. Unsafe is not necessarily bad, but does make the plugin framework code more complicated and harder to read (and thus maintain). (note: I will also note that I don't think that it should be necessary. I think the Starlark Evaluator enforces unnecessarily strict lifetime constraints on the `eval.extra` field. I'll look more into this when I get the chance, and maybe it's a thing we can fix upstream.)

## Questions / Implementation details
### Should this layer live in `fud_core` or the `fud2` frontend?
At the moment, I have implemented this in the `fud2` frontend. I did this to match the pattern of the frontend defining all of the operations. However, this makes it challenging to define a frontend to add new plugins in the cli, because the cli is defined in `fud_core`. This means that we either should move the plugin infrastructure into `fud_core` or bring the cli up into the frontend (or maybe do both things). I lean towards including the plugin stuff with `fud_core` because it doesn't rely on anything Calyx specific, and so makes sense to include in the "generic compiler driver" library.

