### PR TITLE
[Fud2] Forward the verbose flag to ninja and otherwise use the quiet flag

### DIFF
--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -220,6 +220,13 @@ impl<'a> Run<'a> {
         // Run `ninja` in the working directory.
         let mut cmd = Command::new(&self.global_config.ninja);
         cmd.current_dir(&dir.path);
+
+        if !self.global_config.verbose {
+            cmd.arg("--quiet");
+        } else {
+            cmd.arg("--verbose");
+        }
+
         cmd.stdout(std::io::stderr()); // Send Ninja's stdout to our stderr.
         let status = cmd.status()?;
 


### PR DESCRIPTION
A simple patch to fix use with our snapshot testing tools. Opted to forward the verbose flag as well for maximum verbosity.