### PR TITLE
[fud2] Make plugins optional

### DIFF
--- a/fud2/fud-core/Cargo.toml
+++ b/fud2/fud-core/Cargo.toml
@@ -19,6 +19,6 @@ camino = "1.1.6"
 anyhow.workspace = true
 log.workspace = true
 env_logger.workspace = true
-rhai = { version = "1.18.0" }
+rhai = "1.18.0"
 once_cell = "1.19.0"
 ariadne = "0.4.1"

--- a/fud2/fud-core/src/script/plugin.rs
+++ b/fud2/fud-core/src/script/plugin.rs
@@ -47,8 +47,14 @@ impl LoadPlugins for DriverBuilder {
     fn load_plugins(self) -> Self {
         // get list of plugins
         let config = config::load_config(&self.name);
-        let plugin_files =
-            config.extract_inner::<Vec<PathBuf>>("plugins").unwrap();
+        let plugin_files = match config.extract_inner::<Vec<PathBuf>>("plugins")
+        {
+            Ok(v) => v,
+            Err(_) => {
+                // No plugins to load.
+                return self;
+            }
+        };
 
         // wrap driver in a ref cell, so that we can call it from a
         // Rhai context


### PR DESCRIPTION
Very minor fix: #2078 added plugins, controlled by a `plugins` key in `fud2.toml`. However, it inadvertently made this option required, i.e., fud2 would crash if this option was not present. Now it's optional! So we just silently proceed with no plugins if none are configured.

Just tagging @sgpthomas for visibility, but I'll auto-merge this one.