### PR TITLE
Tdcc ohe

### DIFF
--- a/calyx-opt/src/passes/top_down_compile_control.rs
+++ b/calyx-opt/src/passes/top_down_compile_control.rs
@@ -222,8 +222,8 @@ struct Schedule<'b, 'a: 'b> {
     /// The component builder. The reference has a shorter lifetime than the builder itself
     /// to allow multiple schedules to use the same builder.
     pub builder: &'b mut ir::Builder<'a>,
-    /// Contains slicers that have already been queried
-    pub used_slicers: HashMap<u64, ir::RRC<ir::Cell>>,
+    // Contains slicers that have already been queried
+    // pub used_slicers: HashMap<u64, ir::RRC<ir::Cell>>,
 }
 
 impl<'b, 'a> From<&'b mut ir::Builder<'a>> for Schedule<'b, 'a> {
@@ -232,7 +232,7 @@ impl<'b, 'a> From<&'b mut ir::Builder<'a>> for Schedule<'b, 'a> {
             enables: HashMap::new(),
             transitions: Vec::new(),
             builder,
-            used_slicers: HashMap::new(),
+            // used_slicers: HashMap::new(),
         }
     }
 }
@@ -288,7 +288,7 @@ impl<'b, 'a> Schedule<'b, 'a> {
     /// Implement a given [Schedule] and return the name of the [ir::Group] that
     /// implements it.
     fn realize_schedule(
-        mut self,
+        self,
         dump_fsm: bool,
         one_hot_cutoff: u64,
     ) -> RRC<ir::Group> {
@@ -312,300 +312,226 @@ impl<'b, 'a> Schedule<'b, 'a> {
         };
 
         match encoding {
-            Encoding::Binary => {
-                let fsm_size = get_bit_width_from(
-                    final_state + 1, /* represent 0..final_state */
-                );
-
-                structure!(self.builder;
-                    let  fsm = prim std_reg(fsm_size);
-                    let  signal_on = constant(1, 1);
-                    let  last_state = constant(final_state, fsm_size);
-                    let  first_state = constant(0, fsm_size);
-                );
-
-                // Enable assignments
-                group.borrow_mut().assignments.extend(
-                    self.enables
-                        .into_iter()
-                        .sorted_by(|(k1, _), (k2, _)| k1.cmp(k2))
-                        .flat_map(|(state, mut assigns)| {
-                            let state_const =
-                                self.builder.add_constant(state, fsm_size);
-                            let state_guard =
-                                guard!(fsm["out"] == state_const["out"]);
-                            assigns.iter_mut().for_each(|asgn| {
-                                asgn.guard
-                                    .update(|g| g.and(state_guard.clone()))
-                            });
-                            assigns
-                        }),
-                );
-
-                // Transition assignments
-                group.borrow_mut().assignments.extend(
-                    self.transitions.into_iter().flat_map(|(s, e, guard)| {
-                        structure!(self.builder;
-                            let end_const = constant(e, fsm_size);
-                            let start_const = constant(s, fsm_size);
-                        );
-                        let ec_borrow = end_const.borrow();
-                        let trans_guard =
-                            guard!((fsm["out"] == start_const["out"]) & guard);
-
-                        vec![
-                            self.builder.build_assignment(
-                                fsm.borrow().get("in"),
-                                ec_borrow.get("out"),
-                                trans_guard.clone(),
-                            ),
-                            self.builder.build_assignment(
-                                fsm.borrow().get("write_en"),
-                                signal_on.borrow().get("out"),
-                                trans_guard,
-                            ),
-                        ]
-                    }),
-                );
-
-                // Done condition for group
-                let last_guard = guard!(fsm["out"] == last_state["out"]);
-                let done_assign = self.builder.build_assignment(
-                    group.borrow().get("done"),
-                    signal_on.borrow().get("out"),
-                    last_guard.clone(),
-                );
-                group.borrow_mut().assignments.push(done_assign);
-
-                // Cleanup: Add a transition from last state to the first state.
-                let reset_fsm = build_assignments!(self.builder;
-                    fsm["in"] = last_guard ? first_state["out"];
-                    fsm["write_en"] = last_guard ? signal_on["out"];
-                );
-                self.builder
-                    .component
-                    .continuous_assignments
-                    .extend(reset_fsm);
-
-                group
-            }
-
-            Encoding::OneHot => {
-                let fsm_size = final_state; /* represent 0..final_state */
-
-                structure!(self.builder;
-                    let fsm = prim std_reg(fsm_size);
-                    let signal_on = constant(1, 1);
-                    let signal_off = constant(0, fsm_size);
-                );
-
-                // Enable assignments
-                group.borrow_mut().assignments.extend(
-                    self.enables
-                        .into_iter()
-                        .sorted_by(|(k1, _), (k2, _)| k1.cmp(k2))
-                        .flat_map(|(state, mut assigns)| {
-
-                            // initial fsm state is 0, need full bit-by-bit comparison
-                            if state == 0 {
-                                let state_guard = guard!(fsm["out"] == signal_off["out"]);
+            // match encoding {
+                Encoding::Binary => {
+                    let fsm_size = get_bit_width_from(
+                        final_state + 1, /* represent 0..final_state */
+                    );
+    
+                    structure!(self.builder;
+                        let fsm = prim std_reg(fsm_size);
+                        let signal_on = constant(1, 1);
+                        let last_state = constant(final_state, fsm_size);
+                        let first_state = constant(0, fsm_size);
+                    );
+                    // Enable assignments
+                    group.borrow_mut().assignments.extend(
+                        self.enables
+                            .into_iter()
+                            .sorted_by(|(k1, _), (k2, _)| k1.cmp(k2))
+                            .flat_map(|(state, mut assigns)| {
+                                let state_const =
+                                    self.builder.add_constant(state, fsm_size);
+                                let state_guard =
+                                    guard!(fsm["out"] == state_const["out"]);
                                 assigns.iter_mut().for_each(|asgn| {
                                     asgn.guard
                                         .update(|g| g.and(state_guard.clone()))
-                                    });
+                                });
                                 assigns
-                            }
-
-                            // for state != 0, can compare single high bit
-                            else {
-
-                                match self.used_slicers.get(&(state - 1)) {
-                                    None => {
+                            }),
+                    );
+    
+                    // Transition assignments
+                    group.borrow_mut().assignments.extend(
+                        self.transitions.into_iter().flat_map(|(s, e, guard)| {
+                            structure!(self.builder;
+                                let end_const = constant(e, fsm_size);
+                                let start_const = constant(s, fsm_size);
+                            );
+                            let ec_borrow = end_const.borrow();
+                            let trans_guard =
+                                guard!((fsm["out"] == start_const["out"]) & guard);
+    
+                            vec![
+                                self.builder.build_assignment(
+                                    fsm.borrow().get("in"),
+                                    ec_borrow.get("out"),
+                                    trans_guard.clone(),
+                                ),
+                                self.builder.build_assignment(
+                                    fsm.borrow().get("write_en"),
+                                    signal_on.borrow().get("out"),
+                                    trans_guard,
+                                ),
+                            ]
+                        }),
+                    );
+    
+                    // Done condition for group
+                    let last_guard = guard!(fsm["out"] == last_state["out"]);
+                    let done_assign = self.builder.build_assignment(
+                        group.borrow().get("done"),
+                        signal_on.borrow().get("out"),
+                        last_guard.clone(),
+                    );
+                    group.borrow_mut().assignments.push(done_assign);
+    
+                    // Cleanup: Add a transition from last state to the first state.
+                    let reset_fsm = build_assignments!(self.builder;
+                        fsm["in"] = last_guard ? first_state["out"];
+                        fsm["write_en"] = last_guard ? signal_on["out"];
+                    );
+                    self.builder
+                        .component
+                        .continuous_assignments
+                        .extend(reset_fsm);
+    
+                    group
+                },
+                Encoding::OneHot => {
+                    let fsm_size = final_state; /* represent 0..final_state */
+    
+                    structure!(self.builder;
+                        let fsm = prim std_reg(fsm_size);
+                        let signal_on = constant(1, 1);
+                        let signal_off = constant(0, fsm_size);
+                        let last_state = constant(u64::pow(2, (final_state - 1).try_into().expect("failed to convert to u32")), fsm_size);
+                    );
+    
+                    // Enable assignments
+                    group.borrow_mut().assignments.extend(
+                        self.enables
+                            .into_iter()
+                            .sorted_by(|(k1, _), (k2, _)| k1.cmp(k2))
+                            .flat_map(|(state, mut assigns)| {
+    
+                                // initial fsm state is 0, need full bit-by-bit comparison
+                                if state == 0 {
+                                    let state_guard = guard!(fsm["out"] == signal_off["out"]);
+                                    assigns.iter_mut().for_each(|asgn| {
+                                        asgn.guard
+                                            .update(|g| g.and(state_guard.clone()))
+                                        });
+                                    assigns
+                                }
+    
+                                // for state != 0, can compare single high bit
+                                else {
+                                    structure!(
+                                        self.builder;
+                                        let slicer = prim std_bit_slice(fsm_size, state - 1, state, 1);
+                                    );
+                                    let fsm_to_slicer = self.builder.build_assignment(
+                                        slicer.borrow().get("in"), 
+                                        fsm.borrow().get("out"), 
+                                        ir::Guard::True
+                                    );
+                                    let state_guard = guard!(slicer["out"] == signal_on["out"]);
+                                    assigns.iter_mut().for_each(|asgn| {
+                                        asgn.guard
+                                        .update(|g| g.and(state_guard.clone()))
+                                    });
+                                    assigns.push(fsm_to_slicer);
+                                    assigns
+                                }
+                            }),
+                    );
+    
+                    // Transition assignments
+                    group.borrow_mut().assignments.extend(
+                        self.transitions.into_iter().flat_map(
+                            |(s, e, guard)| {
+                                match s {
+                                    0 => {
+                                        let end_constant_value = match e {
+                                            0 => 0,
+                                            _ => u64::pow(2, (e - 1).try_into().expect("failed to convert to u32"))
+                                        };
+                                        structure!(self.builder;
+                                            let end_const = constant(end_constant_value, fsm_size);
+                                            let start_const = constant(0, fsm_size);
+                                        );
+                                        let ec_borrow = end_const.borrow();
+    
+                                        // if s = 0, need to do full comparison
+                                        let trans_guard = guard!(
+                                            (fsm["out"] == start_const["out"]) & guard
+                                        );
+    
+                                        vec![
+                                            self.builder.build_assignment(
+                                                fsm.borrow().get("in"),
+                                                ec_borrow.get("out"),
+                                                trans_guard.clone(),
+                                            ),
+                                            self.builder.build_assignment(
+                                                fsm.borrow().get("write_en"),
+                                                signal_on.borrow().get("out"),
+                                                trans_guard,
+                                            ),
+                                        ]
+                                    }
+    
+                                    s => {
+                                        let end_constant_value = match e {
+                                            0 => 0,
+                                            _ => u64::pow(2, (e - 1).try_into().expect("failed to convert to u32"))
+                                        };
                                         structure!(
                                             self.builder;
-                                            let slicer = prim std_bit_slice(fsm_size, state - 1, state - 1, 1);
+                                            let end_const = constant(end_constant_value, fsm_size);
+                                            let slicer = prim std_bit_slice(fsm_size, s - 1, s, 1);
                                         );
-
+                                        let ec_borrow = end_const.borrow();
+                                        let trans_guard = guard!((slicer["out"] == signal_on["out"]) & guard);
                                         let fsm_to_slicer = self.builder.build_assignment(
-                                            slicer.borrow().get("in"), 
+                                            slicer.borrow().get("in"),
                                             fsm.borrow().get("out"), 
-                                            ir::Guard::True
-                                        );
-                                        let state_guard = guard!(slicer["out"] == signal_on["out"]);
-                                        assigns.iter_mut().for_each(|asgn| {
-                                            asgn.guard
-                                            .update(|g| g.and(state_guard.clone()))
-                                        });
-                                        assigns.push(fsm_to_slicer);
-
-                                        self.used_slicers.insert(state - 1, slicer);
-                                        assigns
-                                    }
-                                    Some(slicer) => {
-
-                                        let state_guard = guard!(slicer["out"] == signal_on["out"]);
-                                        assigns.iter_mut().for_each(|asgn| {
-                                            asgn.guard
-                                            .update(|g| g.and(state_guard.clone()))
-                                        });
-
-                                        assigns
+                                            ir::Guard::True);
+                                        vec![
+                                            fsm_to_slicer,
+                                            self.builder.build_assignment(
+                                                fsm.borrow().get("in"),
+                                                ec_borrow.get("out"),
+                                                trans_guard.clone(),
+                                            ),
+                                            self.builder.build_assignment(
+                                                fsm.borrow().get("write_en"),
+                                                signal_on.borrow().get("out"),
+                                                trans_guard,
+                                            ),
+                                        ]
                                     }
                                 }
                             }
-                        }
-                    ),
-                );
-
-                // Transition assignments
-                group.borrow_mut().assignments.extend(
-                    self.transitions.into_iter().flat_map(
-                        |(s, e, guard)| {
-                            match s {
-                                0 => {
-                                    let end_constant_value = match e {
-                                        0 => 0,
-                                        _ => u64::pow(2, (e - 1).try_into().expect("failed to convert to u32"))
-                                    };
-                                    structure!(self.builder;
-                                        let end_const = constant(end_constant_value, fsm_size);
-                                        let start_const = constant(0, fsm_size);
-                                    );
-                                    let ec_borrow = end_const.borrow();
-
-                                    // if s = 0, need to do full comparison
-                                    let trans_guard = guard!(
-                                        (fsm["out"] == start_const["out"]) & guard
-                                    );
-
-                                    vec![
-                                        self.builder.build_assignment(
-                                            fsm.borrow().get("in"),
-                                            ec_borrow.get("out"),
-                                            trans_guard.clone(),
-                                        ),
-                                        self.builder.build_assignment(
-                                            fsm.borrow().get("write_en"),
-                                            signal_on.borrow().get("out"),
-                                            trans_guard,
-                                        ),
-                                    ]
-                                }
-
-                                _ => {
-                                    let end_constant_value = match e {
-                                        0 => 0,
-                                        _ => u64::pow(2, (e - 1).try_into().expect("failed to convert to u32"))
-                                    };
-
-                                    match self.used_slicers.get(&(s - 1)) {
-                                        None => {
-                                            structure!(
-                                                self.builder;
-                                                let end_const = constant(end_constant_value, fsm_size);
-                                                let slicer = prim std_bit_slice(fsm_size, s - 1, s - 1, 1);
-                                            );
-                                            let ec_borrow = end_const.borrow();
-                                            let trans_guard = guard!((slicer["out"] == signal_on["out"]) & guard);
-                                            let fsm_to_slicer = self.builder.build_assignment(
-                                                slicer.borrow().get("in"),
-                                                fsm.borrow().get("out"), 
-                                                ir::Guard::True);
-                                            self.used_slicers.insert(s - 1, slicer);
-                                            vec![
-                                                fsm_to_slicer,
-                                                self.builder.build_assignment(
-                                                    fsm.borrow().get("in"),
-                                                    ec_borrow.get("out"),
-                                                    trans_guard.clone(),
-                                                ),
-                                                self.builder.build_assignment(
-                                                    fsm.borrow().get("write_en"),
-                                                    signal_on.borrow().get("out"),
-                                                    trans_guard,
-                                                ),
-                                            ]
-                                        },
-                                        Some(slicer) => {
-                                            structure!(
-                                                self.builder;
-                                                let end_const = constant(end_constant_value, fsm_size);
-                                            );
-                                            let ec_borrow = end_const.borrow();
-                                            let trans_guard = guard!((slicer["out"] == signal_on["out"]) & guard);
-
-                                            vec![
-                                                self.builder.build_assignment(
-                                                    fsm.borrow().get("in"),
-                                                    ec_borrow.get("out"),
-                                                    trans_guard.clone(),
-                                                ),
-                                                self.builder.build_assignment(
-                                                    fsm.borrow().get("write_en"),
-                                                    signal_on.borrow().get("out"),
-                                                    trans_guard,
-                                                ),
-                                            ]
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    ),
-                );
-
-                // Done condition for group
-                let last_guard = match self.used_slicers.get(&(final_state - 1))
-                {
-                    None => {
-                        structure!(
-                            self.builder;
-                            let slicer = prim std_bit_slice(fsm_size, final_state - 1, final_state - 1, 1);
-                        );
-                        let fsm_to_slicer = self.builder.build_assignment(
-                            slicer.borrow().get("in"),
-                            fsm.borrow().get("out"),
-                            ir::Guard::True,
-                        );
-                        let last_guard =
-                            guard!(slicer["out"] == signal_on["out"]);
-                        let done_assign = self.builder.build_assignment(
-                            group.borrow().get("done"),
-                            signal_on.borrow().get("out"),
-                            last_guard.clone(),
-                        );
-                        group.borrow_mut().assignments.push(fsm_to_slicer);
-                        group.borrow_mut().assignments.push(done_assign);
-                        last_guard
-                    }
-                    Some(slicer) => {
-                        let last_guard =
-                            guard!(slicer["out"] == signal_on["out"]);
-                        let done_assign = self.builder.build_assignment(
-                            group.borrow().get("done"),
-                            signal_on.borrow().get("out"),
-                            last_guard.clone(),
-                        );
-                        group.borrow_mut().assignments.push(done_assign);
-                        last_guard
-                    }
-                };
-
-                // Cleanup: Add a transition from last state to the first state.
-                let reset_fsm = build_assignments!(self.builder;
-                    fsm["in"] = last_guard ? signal_off["out"];
-                    fsm["write_en"] = last_guard ? signal_on["out"];
-                );
-                self.builder
-                    .component
-                    .continuous_assignments
-                    .extend(reset_fsm);
-
-                group
+                        ),
+                    );
+    
+                    // Done condition for group
+                    let last_guard = guard!(fsm["out"] == last_state["out"]);
+                    let done_assign = self.builder.build_assignment(
+                        group.borrow().get("done"),
+                        signal_on.borrow().get("out"),
+                        last_guard.clone(),
+                    );
+                    group.borrow_mut().assignments.push(done_assign);
+    
+                    // Cleanup: Add a transition from last state to the first state.
+                    let reset_fsm = build_assignments!(self.builder;
+                        fsm["in"] = last_guard ? signal_off["out"];
+                        fsm["write_en"] = last_guard ? signal_on["out"];
+                    );
+                    self.builder
+                        .component
+                        .continuous_assignments
+                        .extend(reset_fsm);
+    
+                    group
+                }
             }
         }
     }
-}
 
 /// Represents an edge from a predeccesor to the current control node.
 /// The `u64` represents the FSM state of the predeccesor and the guard needs

--- a/calyx-opt/src/passes/top_down_compile_control.rs
+++ b/calyx-opt/src/passes/top_down_compile_control.rs
@@ -327,13 +327,13 @@ impl<'b, 'a> Schedule<'b, 'a> {
             }
             Encoding::OneHot => {
                 let fsm_size = final_state + 1; /* represent 0..final_state */
-            
+
                 let fsm = self.builder.add_primitive(
                     "fsm",
                     "init_one_reg",
                     &[fsm_size],
                 );
-                let first_state = self.builder.add_constant(0, fsm_size);
+                let first_state = self.builder.add_constant(1, fsm_size);
                 (fsm, first_state, None, fsm_size)
             }
         };
@@ -348,13 +348,11 @@ impl<'b, 'a> Schedule<'b, 'a> {
                 .sorted_by(|(k1, _), (k2, _)| k1.cmp(k2))
                 .flat_map(|(state, mut assigns)| match encoding {
                     Encoding::Binary => {
-                        let state_const =
-                            self.builder.add_constant(state, fsm_size);
-                        let state_guard =
-                            guard!(fsm["out"] == state_const["out"]);
-                        assigns.iter_mut().for_each(|asgn| {
-                            asgn.guard.update(|g| g.and(state_guard.clone()))
-                        });
+                        let state_const = self.builder.add_constant(state, fsm_size);
+                        let state_guard = guard!(fsm["out"] == state_const["out"]);
+                        assigns
+                            .iter_mut()
+                            .for_each(|asgn| asgn.guard.update(|g| g.and(state_guard.clone())));
                         assigns
                     }
                     Encoding::OneHot => {
@@ -367,19 +365,22 @@ impl<'b, 'a> Schedule<'b, 'a> {
                                 );
                                 // build wire from fsm to slicer
                                 let fsm_to_slicer = self.builder.build_assignment(
-                                    slicer.borrow().get("in"), 
-                                    fsm.borrow().get("out"), 
-                                    ir::Guard::True
+                                    slicer.borrow().get("in"),
+                                    fsm.borrow().get("out"),
+                                    ir::Guard::True,
                                 );
                                 // add continuous assignments to slicer
-                                self.builder.component.continuous_assignments.push(fsm_to_slicer);
+                                self.builder
+                                    .component
+                                    .continuous_assignments
+                                    .push(fsm_to_slicer);
 
                                 // create a guard representing when to allow next-state transition
                                 let state_guard = guard!(slicer["out"] == signal_on["out"]);
                                 used_slicers.insert(state, slicer);
 
                                 state_guard
-                            },
+                            }
 
                             Some(slicer) => {
                                 let state_guard = guard!(slicer["out"] == signal_on["out"]);
@@ -387,92 +388,91 @@ impl<'b, 'a> Schedule<'b, 'a> {
                             }
                         };
 
-                        assigns.iter_mut().for_each(|asgn| {
-                            asgn.guard
-                            .update(|g| g.and(state_guard.clone()))
-                        });
+                        assigns
+                            .iter_mut()
+                            .for_each(|asgn| asgn.guard.update(|g| g.and(state_guard.clone())));
 
                         assigns
-                    },
-                }
-            ),
+                    }
+                }),
         );
 
         // transition assignments
-        group.borrow_mut().assignments.extend(
-            self.transitions.into_iter().flat_map(
-                |(s, e, guard)| {
-                    let (end_const, trans_guard) = match encoding {
-                        Encoding::Binary => {
-                            structure!(self.builder;
-                                let end_const = constant(e, fsm_size);
-                                let start_const = constant(s, fsm_size);
-                            );
-                            let trans_guard =
-                                guard!((fsm["out"] == start_const["out"]) & guard);
-                            
-                            (end_const, trans_guard)
-                        },
-                        Encoding::OneHot => {
+        group
+            .borrow_mut()
+            .assignments
+            .extend(self.transitions.into_iter().flat_map(|(s, e, guard)| {
+                let (end_const, trans_guard) = match encoding {
+                    Encoding::Binary => {
+                        structure!(self.builder;
+                            let end_const = constant(e, fsm_size);
+                            let start_const = constant(s, fsm_size);
+                        );
+                        let trans_guard = guard!((fsm["out"] == start_const["out"]) & guard);
 
-                            let end_constant_value =  u64::pow(2, e.try_into().expect("failed to convert to u32"));
-                            match used_slicers.get(&s) {
-                                None => {
-                                    structure!(
-                                        self.builder;
-                                        let end_const = constant(end_constant_value, fsm_size);
-                                        let slicer = prim std_bit_slice(fsm_size, s, s, 1);
-                                    );
-                                    let trans_guard = guard!((slicer["out"] == signal_on["out"]) & guard);
-                                    let fsm_to_slicer = self.builder.build_assignment(
-                                        slicer.borrow().get("in"),
-                                        fsm.borrow().get("out"), 
-                                        ir::Guard::True);
+                        (end_const, trans_guard)
+                    }
+                    Encoding::OneHot => {
+                        let end_constant_value =
+                            u64::pow(2, e.try_into().expect("failed to convert to u32"));
+                        match used_slicers.get(&s) {
+                            None => {
+                                structure!(
+                                    self.builder;
+                                    let end_const = constant(end_constant_value, fsm_size);
+                                    let slicer = prim std_bit_slice(fsm_size, s, s, 1);
+                                );
+                                let trans_guard =
+                                    guard!((slicer["out"] == signal_on["out"]) & guard);
+                                let fsm_to_slicer = self.builder.build_assignment(
+                                    slicer.borrow().get("in"),
+                                    fsm.borrow().get("out"),
+                                    ir::Guard::True,
+                                );
 
-                                    used_slicers.insert(s, slicer);
+                                used_slicers.insert(s, slicer);
 
-                                    // add wire from fsm to slicer
-                                    self.builder.component.continuous_assignments.push(fsm_to_slicer);
+                                // add wire from fsm to slicer
+                                self.builder
+                                    .component
+                                    .continuous_assignments
+                                    .push(fsm_to_slicer);
 
-                                    (end_const, trans_guard)
-                                },
-                                Some(slicer) => {
-                                    structure!(
-                                        self.builder;
-                                        let end_const = constant(end_constant_value, fsm_size);
-                                    );
-                                    let trans_guard = guard!((slicer["out"] == signal_on["out"]) & guard);
-
-                                    (end_const, trans_guard)
-
-                                }
+                                (end_const, trans_guard)
                             }
-                        },
-                    };
+                            Some(slicer) => {
+                                structure!(
+                                    self.builder;
+                                    let end_const = constant(end_constant_value, fsm_size);
+                                );
+                                let trans_guard =
+                                    guard!((slicer["out"] == signal_on["out"]) & guard);
 
-                    let ec_borrow = end_const.borrow();
-                    vec![
-                        self.builder.build_assignment(
-                            fsm.borrow().get("in"),
-                            ec_borrow.get("out"),
-                            trans_guard.clone(),
-                        ),
-                        self.builder.build_assignment(
-                            fsm.borrow().get("write_en"),
-                            signal_on.borrow().get("out"),
-                            trans_guard,
-                        ),
-                    ]
-                }
-            ),
-        );
+                                (end_const, trans_guard)
+                            }
+                        }
+                    }
+                };
+
+                let ec_borrow = end_const.borrow();
+                vec![
+                    self.builder.build_assignment(
+                        fsm.borrow().get("in"),
+                        ec_borrow.get("out"),
+                        trans_guard.clone(),
+                    ),
+                    self.builder.build_assignment(
+                        fsm.borrow().get("write_en"),
+                        signal_on.borrow().get("out"),
+                        trans_guard,
+                    ),
+                ]
+            }));
 
         // done condition for group
-        let reset_fsm = 
-        match last_state_opt {
+        let reset_fsm = match last_state_opt {
             // binary branch; only binary needs last state constant
             Some(last_state) => {
-
                 let last_guard = guard!(fsm["out"] == last_state["out"]);
                 let done_assign = self.builder.build_assignment(
                     group.borrow().get("done"),
@@ -488,11 +488,10 @@ impl<'b, 'a> Schedule<'b, 'a> {
                 );
 
                 reset_fsm.to_vec()
-            },
+            }
 
             // ohe branch does not need last state constant
             None => {
-
                 // Done condition for group
                 structure!(
                     self.builder;
@@ -517,8 +516,7 @@ impl<'b, 'a> Schedule<'b, 'a> {
                 );
 
                 reset_fsm.to_vec()
-
-            },
+            }
         };
 
         // extend with conditions to set fsm to initial state
@@ -657,7 +655,11 @@ impl Schedule<'_, '_> {
         early_transitions: bool,
     ) -> CalyxResult<Vec<PredEdge>> {
         if if_stmt.cond.is_some() {
-            return Err(Error::malformed_structure(format!("{}: Found group `{}` in with position of if. This should have compiled away.", TopDownCompileControl::name(), if_stmt.cond.as_ref().unwrap().borrow().name())));
+            return Err(Error::malformed_structure(format!(
+                "{}: Found group `{}` in with position of if. This should have compiled away.",
+                TopDownCompileControl::name(),
+                if_stmt.cond.as_ref().unwrap().borrow().name()
+            )));
         }
         let port_guard: ir::Guard<Nothing> = Rc::clone(&if_stmt.port).into();
         // Previous states transitioning into true branch need the conditional
@@ -708,7 +710,11 @@ impl Schedule<'_, '_> {
         early_transitions: bool,
     ) -> CalyxResult<Vec<PredEdge>> {
         if while_stmt.cond.is_some() {
-            return Err(Error::malformed_structure(format!("{}: Found group `{}` in with position of if. This should have compiled away.", TopDownCompileControl::name(), while_stmt.cond.as_ref().unwrap().borrow().name())));
+            return Err(Error::malformed_structure(format!(
+                "{}: Found group `{}` in with position of if. This should have compiled away.",
+                TopDownCompileControl::name(),
+                while_stmt.cond.as_ref().unwrap().borrow().name()
+            )));
         }
 
         let port_guard: ir::Guard<Nothing> = Rc::clone(&while_stmt.port).into();

--- a/calyx-opt/src/passes/top_down_compile_control.rs
+++ b/calyx-opt/src/passes/top_down_compile_control.rs
@@ -399,7 +399,6 @@ impl<'b, 'a> Schedule<'b, 'a> {
                     let fsm = prim std_reg(fsm_size);
                     let signal_on = constant(1, 1);
                     let signal_off = constant(0, fsm_size);
-                    // let last_state = constant(u64::pow(2, (final_state - 1).try_into().expect("failed to convert to u32")), fsm_size);
                 );
 
                 // Enable assignments
@@ -580,7 +579,7 @@ impl<'b, 'a> Schedule<'b, 'a> {
 
                 group.borrow_mut().assignments.push(done_assign);
 
-                // Add msb slicer as continuous assignment
+                // Add msb slicer as continuous assignment;
                 // Cleanup: Add a transition from last state to the first state.
                 let reset_fsm = build_assignments!(self.builder;
                     slicer["in"] = ? fsm["out"];

--- a/calyx-opt/src/passes/top_down_compile_control.rs
+++ b/calyx-opt/src/passes/top_down_compile_control.rs
@@ -530,7 +530,6 @@ impl<'b, 'a> Schedule<'b, 'a> {
 
                                         },
                                         Some(slicer) => {
-                                            println!("bruh");
                                             structure!(
                                                 self.builder;
                                                 let end_const = constant(end_constant_value, fsm_size);

--- a/runt.toml
+++ b/runt.toml
@@ -213,6 +213,27 @@ fud exec --from calyx --to jq \
 timeout = 120
 
 [[tests]]
+name = "correctness dynamic one-hot encoding"
+paths = [
+  "tests/correctness/*.futil",
+  "tests/correctness/ref-cells/*.futil",
+  "tests/correctness/sync/*.futil",
+  "tests/correctness/static-interface/*.futil",
+]
+cmd = """
+fud exec --from calyx --to jq \
+         --through verilog \
+         --through dat \
+         -s calyx.exec './target/debug/calyx' \
+         -s calyx.flags '-x tdcc:one-hot-cutoff=500' \
+         -s verilog.cycle_limit 500 \
+         -s verilog.data {}.data \
+         -s jq.expr ".memories" \
+         {} -q
+"""
+timeout = 120
+
+[[tests]]
 name = "correctness static timing"
 paths = [
   "tests/correctness/*.futil",

--- a/tests/passes/tdcc-ohe/par.expect
+++ b/tests/passes/tdcc-ohe/par.expect
@@ -8,10 +8,11 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     @generated pd = std_reg(1);
     @generated pd0 = std_reg(1);
     @generated pd1 = std_reg(1);
-    @generated fsm = std_reg(3);
-    @generated slicer = std_bit_slice(3, 0, 0, 1);
-    @generated slicer0 = std_bit_slice(3, 1, 1, 1);
-    @generated slicer1 = std_bit_slice(3, 2, 2, 1);
+    @generated fsm = init_one_reg(4);
+    @generated slicer = std_bit_slice(4, 0, 0, 1);
+    @generated slicer0 = std_bit_slice(4, 1, 1, 1);
+    @generated slicer1 = std_bit_slice(4, 2, 2, 1);
+    @generated slicer2 = std_bit_slice(4, 3, 3, 1);
   }
   wires {
     group A {
@@ -42,16 +43,16 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
       par0[done] = pd.out & pd0.out & pd1.out ? 1'd1;
     }
     group tdcc {
-      A[go] = !A[done] & fsm.out == 3'd0 ? 1'd1;
-      par0[go] = !par0[done] & slicer.out == 1'd1 ? 1'd1;
-      B[go] = !B[done] & slicer0.out == 1'd1 ? 1'd1;
-      fsm.in = fsm.out == 3'd0 & A[done] ? 3'd1;
-      fsm.write_en = fsm.out == 3'd0 & A[done] ? 1'd1;
-      fsm.in = slicer.out == 1'd1 & par0[done] ? 3'd2;
-      fsm.write_en = slicer.out == 1'd1 & par0[done] ? 1'd1;
-      fsm.in = slicer0.out == 1'd1 & B[done] ? 3'd4;
-      fsm.write_en = slicer0.out == 1'd1 & B[done] ? 1'd1;
-      tdcc[done] = slicer1.out == 1'd1 ? 1'd1;
+      A[go] = !A[done] & slicer.out == 1'd1 ? 1'd1;
+      par0[go] = !par0[done] & slicer0.out == 1'd1 ? 1'd1;
+      B[go] = !B[done] & slicer1.out == 1'd1 ? 1'd1;
+      fsm.in = slicer.out == 1'd1 & A[done] ? 4'd2;
+      fsm.write_en = slicer.out == 1'd1 & A[done] ? 1'd1;
+      fsm.in = slicer0.out == 1'd1 & par0[done] ? 4'd4;
+      fsm.write_en = slicer0.out == 1'd1 & par0[done] ? 1'd1;
+      fsm.in = slicer1.out == 1'd1 & B[done] ? 4'd8;
+      fsm.write_en = slicer1.out == 1'd1 & B[done] ? 1'd1;
+      tdcc[done] = slicer2.out == 1'd1 ? 1'd1;
     }
     pd.in = pd.out & pd0.out & pd1.out ? 1'd0;
     pd.write_en = pd.out & pd0.out & pd1.out ? 1'd1;
@@ -62,8 +63,9 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     slicer.in = fsm.out;
     slicer0.in = fsm.out;
     slicer1.in = fsm.out;
-    fsm.in = slicer1.out == 1'd1 ? 3'd0;
-    fsm.write_en = slicer1.out == 1'd1 ? 1'd1;
+    slicer2.in = fsm.out;
+    fsm.in = slicer2.out == 1'd1 ? 4'd1;
+    fsm.write_en = slicer2.out == 1'd1 ? 1'd1;
   }
   control {
     tdcc;

--- a/tests/passes/tdcc-ohe/par.expect
+++ b/tests/passes/tdcc-ohe/par.expect
@@ -1,0 +1,71 @@
+import "primitives/core.futil";
+import "primitives/memories/comb.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    a = std_reg(2);
+    b = std_reg(2);
+    c = std_reg(2);
+    @generated pd = std_reg(1);
+    @generated pd0 = std_reg(1);
+    @generated pd1 = std_reg(1);
+    @generated fsm = std_reg(3);
+    @generated slicer = std_bit_slice(3, 0, 0, 1);
+    @generated slicer0 = std_bit_slice(3, 1, 1, 1);
+    @generated slicer1 = std_bit_slice(3, 2, 2, 1);
+  }
+  wires {
+    group A {
+      a.in = 2'd0;
+      a.write_en = 1'd1;
+      A[done] = a.done;
+    }
+    group B {
+      b.in = 2'd1;
+      b.write_en = 1'd1;
+      B[done] = b.done;
+    }
+    group C {
+      c.in = 2'd2;
+      c.write_en = 1'd1;
+      C[done] = c.done;
+    }
+    group par0 {
+      A[go] = !(pd.out | A[done]) ? 1'd1;
+      pd.in = A[done] ? 1'd1;
+      pd.write_en = A[done] ? 1'd1;
+      B[go] = !(pd0.out | B[done]) ? 1'd1;
+      pd0.in = B[done] ? 1'd1;
+      pd0.write_en = B[done] ? 1'd1;
+      C[go] = !(pd1.out | C[done]) ? 1'd1;
+      pd1.in = C[done] ? 1'd1;
+      pd1.write_en = C[done] ? 1'd1;
+      par0[done] = pd.out & pd0.out & pd1.out ? 1'd1;
+    }
+    group tdcc {
+      A[go] = !A[done] & fsm.out == 3'd0 ? 1'd1;
+      par0[go] = !par0[done] & slicer.out == 1'd1 ? 1'd1;
+      B[go] = !B[done] & slicer0.out == 1'd1 ? 1'd1;
+      fsm.in = fsm.out == 3'd0 & A[done] ? 3'd1;
+      fsm.write_en = fsm.out == 3'd0 & A[done] ? 1'd1;
+      fsm.in = slicer.out == 1'd1 & par0[done] ? 3'd2;
+      fsm.write_en = slicer.out == 1'd1 & par0[done] ? 1'd1;
+      fsm.in = slicer0.out == 1'd1 & B[done] ? 3'd4;
+      fsm.write_en = slicer0.out == 1'd1 & B[done] ? 1'd1;
+      tdcc[done] = slicer1.out == 1'd1 ? 1'd1;
+    }
+    pd.in = pd.out & pd0.out & pd1.out ? 1'd0;
+    pd.write_en = pd.out & pd0.out & pd1.out ? 1'd1;
+    pd0.in = pd.out & pd0.out & pd1.out ? 1'd0;
+    pd0.write_en = pd.out & pd0.out & pd1.out ? 1'd1;
+    pd1.in = pd.out & pd0.out & pd1.out ? 1'd0;
+    pd1.write_en = pd.out & pd0.out & pd1.out ? 1'd1;
+    slicer.in = fsm.out;
+    slicer0.in = fsm.out;
+    slicer1.in = fsm.out;
+    fsm.in = slicer1.out == 1'd1 ? 3'd0;
+    fsm.write_en = slicer1.out == 1'd1 ? 1'd1;
+  }
+  control {
+    tdcc;
+  }
+}

--- a/tests/passes/tdcc-ohe/par.futil
+++ b/tests/passes/tdcc-ohe/par.futil
@@ -1,0 +1,40 @@
+// -x tdcc:one-hot-cutoff=20 -p tdcc
+
+import "primitives/core.futil";
+import "primitives/memories/comb.futil";
+
+component main() -> () {
+  cells {
+    a = std_reg(2);
+    b = std_reg(2);
+    c = std_reg(2);
+  }
+
+  wires {
+    group A {
+      a.in = 2'd0;
+      a.write_en = 1'b1;
+      A[done] = a.done;
+    }
+
+    group B {
+      b.in = 2'd1;
+      b.write_en = 1'b1;
+      B[done] = b.done;
+    }
+
+    group C {
+      c.in = 2'd2;
+      c.write_en = 1'b1;
+      C[done] = c.done;
+    }
+  }
+
+  control {
+    seq {
+      A;
+      par { A; B; C; }
+      B;
+    }
+  }
+}


### PR DESCRIPTION
Adds one hot encoding representation for dynamic FSMs. Can pass in threshold for OHE/Binary with argument `one-hot-cutoff` on the `tdcc` pass. Defaults to 0 (i.e. always binary representation unless otherwise specified).