### PR TITLE
[fud] Fix multiple paths error doc link

### DIFF
--- a/fud/fud/errors.py
+++ b/fud/fud/errors.py
@@ -139,8 +139,8 @@ class MultiplePaths(FudError):
             f"Multiple stage pipelines can transform {src} to {dst}:\n"
             + paths
             + "\nUse the --through flag to select an intermediate stage."
-            + " See https://docs.calyxir.org/fud/multiple-paths.html for"
-            + " more information."
+            + " See https://docs.calyxir.org/running-calyx/fud/multiple-paths.html"
+            + " for more information."
         )
         super().__init__(msg)
 


### PR DESCRIPTION
The multiple paths error displays an old link that leads to a 404, so I fixed it! Thanks @KabirSamsi for spotting this :)