### PR TITLE
Docs: Fix a link to Python source code

### DIFF
--- a/docs/lang/memories-by-reference.md
+++ b/docs/lang/memories-by-reference.md
@@ -104,7 +104,7 @@ component wrap3(i: 32, j: 32) -> () {
 ```
 
 That is, they have the same signature including `input` ports, `output` ports, and `ref` cells.
-We have elided the logic, but feel free to explore the [source code][arbiter_6.futil].
+We have elided the logic, but feel free to explore the [source code][arbiter_6.py] in Python. You can also generate the Calyx code by running `python calyx-py/test/correctness/arbiter_6.py`.
 
 Now the invoker has six locally defined memories.
 By passing these memories to the components above, the invoker is able to wrap the same six memories two different ways, and then maintain two different fictional indexing systems at the same time.
@@ -226,4 +226,4 @@ Here is an example of a memory copy (referred to as `mem_cpy` in the C language)
 {{#include ../../tests/correctness/invoke-memory.futil}}
 ```
 
-[arbiter_6.futil]: https://github.com/calyxir/calyx/blob/master/calyx-py/test/arbiter_6.futil
+[arbiter_6.py]: https://github.com/calyxir/calyx/blob/main/calyx-py/test/correctness/arbiter_6.py


### PR DESCRIPTION
Because of a restructuring of the `calyx-py` directory, a link from the docs was looking valid from an mdbook point of view but was actually getting a 404 inside of Github. This PR fixes that.