### PR TITLE
Generalize where `wire_inliner` looks for `go` and `done` ports.

### DIFF
--- a/calyx-opt/src/passes/wire_inliner.rs
+++ b/calyx-opt/src/passes/wire_inliner.rs
@@ -63,13 +63,15 @@ impl Visitor for WireInliner {
                 let this = Rc::clone(&comp.signature);
                 let mut builder = ir::Builder::new(comp, sigs);
                 let group = &data.group;
+                let go_port = this.borrow().find_unique_with_attr(ir::NumAttr::Go)?.unwrap();
+                let done_port = this.borrow().find_unique_with_attr(ir::NumAttr::Done)?.unwrap();
 
                 structure!(builder;
                     let one = constant(1, 1);
                 );
-                let group_done = guard!(group["done"]);
+                let group_done = guard!(group[done_port.borrow().name]);
                 let assigns = build_assignments!(builder;
-                    group["go"] = ? this["go"];
+                    group["go"] = ? this[go_port.borrow().name];
                     this["done"] = group_done ? one["out"];
                 );
                 comp.continuous_assignments.extend(assigns);

--- a/calyx-opt/src/passes/wire_inliner.rs
+++ b/calyx-opt/src/passes/wire_inliner.rs
@@ -63,15 +63,21 @@ impl Visitor for WireInliner {
                 let this = Rc::clone(&comp.signature);
                 let mut builder = ir::Builder::new(comp, sigs);
                 let group = &data.group;
-                let go_port = this.borrow().find_unique_with_attr(ir::NumAttr::Go)?.unwrap();
-                let done_port = this.borrow().find_unique_with_attr(ir::NumAttr::Done)?.unwrap();
+                let this_go_port = this
+                    .borrow()
+                    .find_unique_with_attr(ir::NumAttr::Go)?
+                    .unwrap();
+                let this_done_port = this
+                    .borrow()
+                    .find_unique_with_attr(ir::NumAttr::Done)?
+                    .unwrap();
 
                 structure!(builder;
                     let one = constant(1, 1);
                 );
-                let group_done = guard!(group[done_port.borrow().name]);
+                let group_done = guard!(group[this_done_port.borrow().name]);
                 let assigns = build_assignments!(builder;
-                    group["go"] = ? this[go_port.borrow().name];
+                    group["go"] = ? this[this_go_port.borrow().name];
                     this["done"] = group_done ? one["out"];
                 );
                 comp.continuous_assignments.extend(assigns);


### PR DESCRIPTION
Now `wire_inliner` more generally looks for ports marked with `@go` and `@done`. This has proved necessary when creating an `axi_seq_mem` (#1733) that has it's `content_en` marked with `@go`  to conform to [primitive memory signatures](https://github.com/calyxir/calyx/blob/main/primitives/memories/seq.futil#L7).

