### PR TITLE
[fud2] Show op/state source

### DIFF
--- a/fud2/fud-core/Cargo.toml
+++ b/fud2/fud-core/Cargo.toml
@@ -19,7 +19,7 @@ camino = "1.1.6"
 anyhow.workspace = true
 log.workspace = true
 env_logger.workspace = true
-rhai = "1.18.0"
+rhai = { version = "1.18.0", features = ["internals"] }
 once_cell = "1.19.0"
 ariadne = "0.4.1"
 itertools.workspace = true

--- a/fud2/fud-core/src/exec/data.rs
+++ b/fud2/fud-core/src/exec/data.rs
@@ -13,6 +13,9 @@ pub struct State {
     /// Pseudo-states can only be final outputs; they are appropraite for representing actions that
     /// interact directly with the user, for example.
     pub extensions: Vec<String>,
+
+    /// Describes where this operation was defined.
+    pub source: Option<String>,
 }
 
 impl State {
@@ -39,6 +42,8 @@ pub struct Operation {
     pub output: StateRef,
     pub setups: Vec<SetupRef>,
     pub emit: Box<dyn run::EmitBuild>,
+    /// Describes where this operation was defined.
+    pub source: Option<String>,
 }
 
 /// A reference to an Operation.

--- a/fud2/fud-core/src/script/plugin.rs
+++ b/fud2/fud-core/src/script/plugin.rs
@@ -119,10 +119,32 @@ impl ScriptRunner {
         let bld = Rc::clone(&self.builder);
         self.engine.register_fn(
             "state",
-            move |name: &str, extensions: rhai::Array| {
+            move |ctx: rhai::NativeCallContext,
+                  name: &str,
+                  extensions: rhai::Array| {
                 let v = to_str_slice(&extensions);
                 let v = v.iter().map(|x| &**x).collect::<Vec<_>>();
-                bld.borrow_mut().state(name, &v)
+                let state = bld.borrow_mut().state(name, &v);
+
+                #[cfg(not(debug_assertions))]
+                // use ctx when we build in release mode
+                // so that we don't get a warning
+                {
+                    _ = ctx;
+                }
+
+                // try to set state source
+                #[cfg(debug_assertions)]
+                if let Some(src) =
+                    ctx.global_runtime_state().source().and_then(|p| {
+                        PathBuf::from(p)
+                            .file_name()
+                            .map(|s| s.to_string_lossy().to_string())
+                    })
+                {
+                    bld.borrow_mut().state_source(state, src);
+                }
+                state
             },
         );
     }
@@ -153,7 +175,15 @@ impl ScriptRunner {
                   output: StateRef,
                   rule_name: &str| {
                 let setups = sctx.setups_array(&ctx, setups)?;
-                Ok(bld.borrow_mut().rule(&setups, input, output, rule_name))
+                let op =
+                    bld.borrow_mut().rule(&setups, input, output, rule_name);
+
+                // try to set op source
+                #[cfg(debug_assertions)]
+                if let Some(name) = sctx.path.file_name() {
+                    bld.borrow_mut().op_source(op, name.to_string_lossy());
+                }
+                Ok(op)
             },
         );
     }
@@ -174,7 +204,15 @@ impl ScriptRunner {
                     ast: Rc::new(sctx.ast.clone_functions_only()),
                     name: build.fn_name().to_string(),
                 };
-                Ok(bld.borrow_mut().add_op(name, &setups, input, output, rctx))
+                let op =
+                    bld.borrow_mut().add_op(name, &setups, input, output, rctx);
+
+                // try to set op source
+                #[cfg(debug_assertions)]
+                if let Some(name) = sctx.path.file_name() {
+                    bld.borrow_mut().op_source(op, name.to_string_lossy());
+                }
+                Ok(op)
             },
         );
     }


### PR DESCRIPTION
When fud2 is build in debug mode, include the file where states and operations are defined in the list view. This is useful when you are writing a script and want to figure out where some state is defined.