### PR TITLE
[fud2] Add ability to look for a config key that must be associated with a constrained set of values

### DIFF
--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -16,7 +16,11 @@ pub enum RunError {
     MissingConfig(String),
 
     /// An invalid value was found for a configuration key the configuration.
-    InvalidValue{key : String, value : String, valid_values: Vec<String>},
+    InvalidValue {
+        key: String,
+        value: String,
+        valid_values: Vec<String>,
+    },
 
     /// The Ninja process exited with nonzero status.
     NinjaFailed(ExitStatus),
@@ -35,7 +39,11 @@ impl std::fmt::Display for RunError {
             RunError::MissingConfig(s) => {
                 write!(f, "missing required config key: {}", s)
             }
-            RunError::InvalidValue{key, value, valid_values} => {
+            RunError::InvalidValue {
+                key,
+                value,
+                valid_values,
+            } => {
                 write!(
                     f,
                     "invalid value '{}' for key '{}'. Valid values are {:?}",
@@ -368,11 +376,14 @@ impl<W: Write> Emitter<W> {
         if valid_values.contains(&value.as_str()) {
             Ok(value)
         } else {
-            Err(RunError::InvalidValue{
-                key : key.to_string(),
-                value : value,
-                valid_values : valid_values.iter().map(|s| s.to_string()).collect(),
-        })
+            Err(RunError::InvalidValue {
+                key: key.to_string(),
+                value,
+                valid_values: valid_values
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+            })
         }
     }
 

--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -2,6 +2,7 @@ use crate::config;
 use crate::exec::{Driver, OpRef, Plan, SetupRef, StateRef};
 use crate::utils::relative_path;
 use camino::{Utf8Path, Utf8PathBuf};
+use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::process::{Command, ExitStatus};
@@ -46,8 +47,8 @@ impl std::fmt::Display for RunError {
             } => {
                 write!(
                     f,
-                    "invalid value '{}' for key '{}'. Valid values are {:?}",
-                    value, key, valid_values
+                    "invalid value '{}' for key '{}'. Valid values are [{}]",
+                    value, key, valid_values.iter().join(", ")
                 )
             }
             RunError::NinjaFailed(c) => {

--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -48,7 +48,9 @@ impl std::fmt::Display for RunError {
                 write!(
                     f,
                     "invalid value '{}' for key '{}'. Valid values are [{}]",
-                    value, key, valid_values.iter().join(", ")
+                    value,
+                    key,
+                    valid_values.iter().join(", ")
                 )
             }
             RunError::NinjaFailed(c) => {


### PR DESCRIPTION
This PR allows one to use `config_constrained_*` methods to ensure that the value passed in via `--set` is constrained to a set of values.

This seems useful for things expected to be `true` or `false` and is used in #2136 

If this goes against the grain of what we hope `fud2` to be, we can close this without merging.