### PR TITLE
Docs: Add fud registration instructions for Interpreter

### DIFF
--- a/docs/debug/cider.md
+++ b/docs/debug/cider.md
@@ -8,7 +8,7 @@ debugging Calyx programs.
 
 If you are using [`fud`][fud], getting started with the debugger is easy.
 
-First, follow the instructions in the [interpreter section][interp-fud] to build the interpreter and register it as a `fud` stage.
+First, follow [these instructions][interp-fud] to build the interpreter and register it as a `fud` stage.
 
 Assuming you are trying to debug a program called `my_program.futil` with data
 file `my_program.futil.data`, invoke the debugger with the following command:
@@ -18,6 +18,13 @@ fud e --to debugger -q my_program.futil -s verilog.data my_program.futil.data
 ```
 
 This will open the target program in the interactive debugger. Note that we use `fud`'s *quiet* flag, `-q`, here. This avoids clashes between `fud`'s outputs and the debugger's outputs, since both tools interact with `stdout`.
+
+The interpreter does not currently support the [invoke][] command.
+To run the debugger on a program that uses `invoke`, you must first run the `compile-invoke` pass before interpreting the program:
+
+```
+fud e --to debugger -s calyx.flags '-p compile-invoke' -q my_program.futil -s verilog.data my_program.futil.data
+```
 
 ## Advancing Program execution
 
@@ -282,3 +289,4 @@ Use `help` to see all commands. Use `exit` to exit the debugger.
 [gdb]: https://sourceware.org/gdb/
 [interp]: ../running-calyx/interpreter.md
 [interp-fud]: ../running-calyx/interpreter.md#interpreting-via-fud
+[invoke]: ../lang/ref.md#invoke

--- a/docs/debug/cider.md
+++ b/docs/debug/cider.md
@@ -19,8 +19,8 @@ fud e --to debugger -q my_program.futil -s verilog.data my_program.futil.data
 
 This will open the target program in the interactive debugger. Note that we use `fud`'s *quiet* flag, `-q`, here. This avoids clashes between `fud`'s outputs and the debugger's outputs, since both tools interact with `stdout`.
 
-The interpreter does not currently support the [invoke][] command.
-To run the debugger on a program that uses `invoke`, you must first run the `compile-invoke` pass before interpreting the program:
+The interpreter does not currently support [`ref` cells][ref-cells].
+To run the debugger on a program that uses these, you must first compile them away by running the `compile-invoke` pass:
 
 ```
 fud e --to debugger -s calyx.flags '-p compile-invoke' -q my_program.futil -s verilog.data my_program.futil.data
@@ -289,4 +289,4 @@ Use `help` to see all commands. Use `exit` to exit the debugger.
 [gdb]: https://sourceware.org/gdb/
 [interp]: ../running-calyx/interpreter.md
 [interp-fud]: ../running-calyx/interpreter.md#interpreting-via-fud
-[invoke]: ../lang/ref.md#invoke
+[ref-cells]: ../lang/memories-by-reference.md#the-easy-way-ref-cells

--- a/docs/debug/cider.md
+++ b/docs/debug/cider.md
@@ -6,7 +6,10 @@ debugging Calyx programs.
 
 ## Getting Started
 
-If you are using [`fud`][fud] getting started with the debugger is easy.
+If you are using [`fud`][fud], getting started with the debugger is easy.
+
+First, follow the instructions in the [interpreter section][interp-fud] to build the interpreter and register it as a `fud` stage.
+
 Assuming you are trying to debug a program called `my_program.futil` with data
 file `my_program.futil.data`, invoke the debugger with the following command:
 
@@ -14,9 +17,7 @@ file `my_program.futil.data`, invoke the debugger with the following command:
 fud e --to debugger -q my_program.futil -s verilog.data my_program.futil.data
 ```
 
-This will open the target program in the interactive debugger. Note that `fud`
-uses **the quiet flag**, `-q`, here. This prevents the printing from the `fud` tool
-from conflicting the debugger as both tools interact with standard out.
+This will open the target program in the interactive debugger. Note that we use `fud`'s *quiet* flag, `-q`, here. This avoids clashes between `fud`'s outputs and the debugger's outputs, since both tools interact with `stdout`.
 
 ## Advancing Program execution
 
@@ -280,3 +281,4 @@ Use `help` to see all commands. Use `exit` to exit the debugger.
 [fud]: ../running-calyx/fud/index.md
 [gdb]: https://sourceware.org/gdb/
 [interp]: ../running-calyx/interpreter.md
+[interp-fud]: ../running-calyx/interpreter.md#interpreting-via-fud

--- a/docs/running-calyx/interpreter.md
+++ b/docs/running-calyx/interpreter.md
@@ -22,7 +22,11 @@ The interpreter is available as a stage in [fud][], which lets you provide stand
 
 You'll want to build the interpreter first:
 
-    cd interp && cargo build
+    cd interp && cargo build && cd ..
+
+Now register the interpreter as a fud stage:
+
+    fud config stages.interpreter.exec <full path to Calyx repository>/target/debug/cider
 
 Here's how to run a Calyx program:
 
@@ -42,4 +46,8 @@ For example, to fully lower the Calyx program before interpreting it:
         -s calyx.flags '-p all' \
         interp/tests/control/if.futil
 
+In particular, the interpreter does not currently support the [invoke][] command.
+To run the interpreter on a program that uses `invoke`s, you must first run the `compile-invoke` pass before interpreting the program.
+
 [fud]: fud/index.md
+[invoke]: ../lang/ref.md#invoke

--- a/docs/running-calyx/interpreter.md
+++ b/docs/running-calyx/interpreter.md
@@ -47,7 +47,7 @@ For example, to fully lower the Calyx program before interpreting it:
         interp/tests/control/if.futil
 
 In particular, the interpreter does not currently support the [invoke][] command.
-To run the interpreter on a program that uses `invoke`s, you must first run the `compile-invoke` pass before interpreting the program.
+To run the interpreter on a program that uses `invoke`, you must first run the `compile-invoke` pass before interpreting the program.
 
 [fud]: fud/index.md
 [invoke]: ../lang/ref.md#invoke

--- a/docs/running-calyx/interpreter.md
+++ b/docs/running-calyx/interpreter.md
@@ -46,8 +46,8 @@ For example, to fully lower the Calyx program before interpreting it:
         -s calyx.flags '-p all' \
         interp/tests/control/if.futil
 
-In particular, the interpreter does not currently support the [invoke][] command.
-To run the interpreter on a program that uses `invoke`, you must first run the `compile-invoke` pass before interpreting the program.
+In particular, the interpreter does not currently support [`ref` cells][ref-cells].
+To run the interpreter on a program that uses these, you must first compile them away by running the `compile-invoke` pass.
 
 [fud]: fud/index.md
-[invoke]: ../lang/ref.md#invoke
+[ref-cells]: ../lang/memories-by-reference.md#the-easy-way-ref-cells


### PR DESCRIPTION
Closes #2050.

In the [page about the interpreter](https://docs.calyxir.org/running-calyx/interpreter.html#interpreting-via-fud), the docs were not showing people how to register the interpreter as a fud stage. In the [page about the debugger](https://docs.calyxir.org/debug/cider.html#getting-started), the docs were not telling people to build and register the interpreter first. This PR fixes both of these and makes a couple quick clarity changes.

The PR also guides users about the interpreter not supporting the `invoke` command, and explains how to make progress by running the `compile-invoke` pass. This is needed in both pages.