### PR TITLE
[Cider 2] fud2 fixes

### DIFF
--- a/fud2/src/lib.rs
+++ b/fud2/src/lib.rs
@@ -562,9 +562,6 @@ pub fn build_driver(bld: &mut DriverBuilder) {
             &["$cider-converter"],
         )?;
 
-        // this is probably not a great way to do it but I think it works for now
-        e.config_var_or("args", "calyx.args", "--log off")?;
-
         Ok(())
     });
     bld.op(

--- a/fud2/src/lib.rs
+++ b/fud2/src/lib.rs
@@ -562,6 +562,9 @@ pub fn build_driver(bld: &mut DriverBuilder) {
             &["$cider-converter"],
         )?;
 
+        // this is probably not a great way to do it but I think it works for now
+        e.config_var_or("args", "calyx.args", "--log off")?;
+
         Ok(())
     });
     bld.op(

--- a/fud2/src/lib.rs
+++ b/fud2/src/lib.rs
@@ -501,6 +501,9 @@ pub fn build_driver(bld: &mut DriverBuilder) {
 
     // Interpreter.
     let debug = bld.state("debug", &[]); // A pseudo-state.
+                                         // A pseudo-state for cider input
+    let cider_state = bld.state("cider", &[]);
+
     let cider_setup = bld.setup("Cider interpreter", |e| {
         e.config_var_or(
             "cider-exe",
@@ -538,7 +541,7 @@ pub fn build_driver(bld: &mut DriverBuilder) {
         )?;
 
         e.rule(
-            "cider2",
+            "run-cider",
             "$cider-exe -l $calyx-base --data data.dump $in flat > $out",
         )?;
 
@@ -576,13 +579,13 @@ pub fn build_driver(bld: &mut DriverBuilder) {
         },
     );
     bld.op(
-        "interp-flat",
+        "cider",
         &[sim_setup, calyx_setup, cider_setup],
         calyx,
         dat,
         |e, input, output| {
             let out_file = "interp_out.dump";
-            e.build_cmd(&[out_file], "cider2", &[input], &["data.dump"])?;
+            e.build_cmd(&[out_file], "run-cider", &[input], &["data.dump"])?;
             e.build_cmd(
                 &[output],
                 "interp-to-dump",

--- a/fud2/tests/snapshots/tests__emit@calyx_debug.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_debug.snap
@@ -31,6 +31,9 @@ rule calyx
   command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
 rule calyx-pass
   command = $calyx-exe -l $calyx-base -p $pass $args $in > $out
+flags = -p none
+rule calyx-with-flags
+  command = $calyx-exe -l $calyx-base $flags $args $in > $out
 
 # Cider interpreter
 cider-exe = $calyx-base/target/debug/cider
@@ -47,7 +50,7 @@ rule dat-to-interp
 rule interp-to-dat
   command = $python interp-dat.py --from-interp $in $sim_data > $out
 build data.json: dat-to-interp $sim_data | interp-dat.py
-rule cider2
+rule run-cider
   command = $cider-exe -l $calyx-base --data data.dump $in flat > $out
 rule dump-to-interp
   command = $cider-converter --to cider $in > $out

--- a/fud2/tests/snapshots/tests__emit@calyx_firrtl_verilog-refmem.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_firrtl_verilog-refmem.snap
@@ -14,6 +14,9 @@ rule calyx
   command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
 rule calyx-pass
   command = $calyx-exe -l $calyx-base -p $pass $args $in > $out
+flags = -p none
+rule calyx-with-flags
+  command = $calyx-exe -l $calyx-base $flags $args $in > $out
 
 # Custom Testbench Setup
 rule ref-to-external

--- a/fud2/tests/snapshots/tests__emit@calyx_icarus_dat.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_icarus_dat.snap
@@ -14,6 +14,9 @@ rule calyx
   command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
 rule calyx-pass
   command = $calyx-exe -l $calyx-base -p $pass $args $in > $out
+flags = -p none
+rule calyx-with-flags
+  command = $calyx-exe -l $calyx-base $flags $args $in > $out
 
 # RTL simulation
 python = python3

--- a/fud2/tests/snapshots/tests__emit@calyx_icarus_vcd.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_icarus_vcd.snap
@@ -14,6 +14,9 @@ rule calyx
   command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
 rule calyx-pass
   command = $calyx-exe -l $calyx-base -p $pass $args $in > $out
+flags = -p none
+rule calyx-with-flags
+  command = $calyx-exe -l $calyx-base $flags $args $in > $out
 
 # RTL simulation
 python = python3

--- a/fud2/tests/snapshots/tests__emit@calyx_interp_dat.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_interp_dat.snap
@@ -31,6 +31,9 @@ rule calyx
   command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
 rule calyx-pass
   command = $calyx-exe -l $calyx-base -p $pass $args $in > $out
+flags = -p none
+rule calyx-with-flags
+  command = $calyx-exe -l $calyx-base $flags $args $in > $out
 
 # Cider interpreter
 cider-exe = $calyx-base/target/debug/cider
@@ -47,7 +50,7 @@ rule dat-to-interp
 rule interp-to-dat
   command = $python interp-dat.py --from-interp $in $sim_data > $out
 build data.json: dat-to-interp $sim_data | interp-dat.py
-rule cider2
+rule run-cider
   command = $cider-exe -l $calyx-base --data data.dump $in flat > $out
 rule dump-to-interp
   command = $cider-converter --to cider $in > $out

--- a/fud2/tests/snapshots/tests__emit@calyx_verilator_dat.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_verilator_dat.snap
@@ -14,6 +14,9 @@ rule calyx
   command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
 rule calyx-pass
   command = $calyx-exe -l $calyx-base -p $pass $args $in > $out
+flags = -p none
+rule calyx-with-flags
+  command = $calyx-exe -l $calyx-base $flags $args $in > $out
 
 # RTL simulation
 python = python3

--- a/fud2/tests/snapshots/tests__emit@calyx_verilator_vcd.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_verilator_vcd.snap
@@ -14,6 +14,9 @@ rule calyx
   command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
 rule calyx-pass
   command = $calyx-exe -l $calyx-base -p $pass $args $in > $out
+flags = -p none
+rule calyx-with-flags
+  command = $calyx-exe -l $calyx-base $flags $args $in > $out
 
 # RTL simulation
 python = python3

--- a/fud2/tests/snapshots/tests__emit@calyx_verilog.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_verilog.snap
@@ -14,6 +14,9 @@ rule calyx
   command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
 rule calyx-pass
   command = $calyx-exe -l $calyx-base -p $pass $args $in > $out
+flags = -p none
+rule calyx-with-flags
+  command = $calyx-exe -l $calyx-base $flags $args $in > $out
 
 # build targets
 build stdin.sv: calyx stdin

--- a/fud2/tests/snapshots/tests__emit@calyx_xrt-trace_vcd.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_xrt-trace_vcd.snap
@@ -14,6 +14,9 @@ rule calyx
   command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
 rule calyx-pass
   command = $calyx-exe -l $calyx-base -p $pass $args $in > $out
+flags = -p none
+rule calyx-with-flags
+  command = $calyx-exe -l $calyx-base $flags $args $in > $out
 
 # Xilinx tools
 vivado-dir = /test/xilinx/vivado

--- a/fud2/tests/snapshots/tests__emit@calyx_xrt_dat.snap
+++ b/fud2/tests/snapshots/tests__emit@calyx_xrt_dat.snap
@@ -14,6 +14,9 @@ rule calyx
   command = $calyx-exe -l $calyx-base -b $backend $args $in > $out
 rule calyx-pass
   command = $calyx-exe -l $calyx-base -p $pass $args $in > $out
+flags = -p none
+rule calyx-with-flags
+  command = $calyx-exe -l $calyx-base $flags $args $in > $out
 
 # Xilinx tools
 vivado-dir = /test/xilinx/vivado

--- a/interp/cider2-tests/runt.toml
+++ b/interp/cider2-tests/runt.toml
@@ -67,7 +67,7 @@ expect_dir = "control"
 name = "invoke"
 paths = ["../tests/control/invoke/*.futil"]
 cmd = """
-fud2 {} --from calyx --to dat --through cider -s sim.data={}.data | jq --sort-keys
+fud2 {} --from calyx --to dat --through cider -s sim.data={}.data -s calyx.args="--log off" | jq --sort-keys
 """
 timeout = 10
 expect_dir = "invoke"
@@ -108,6 +108,7 @@ cmd = """
 fud2 --from calyx --to dat \
          --through cider \
          -s sim.data={}.data \
+         -s calyx.args="--log off" \
          {} | jq --sort-keys
 """
 

--- a/interp/cider2-tests/runt.toml
+++ b/interp/cider2-tests/runt.toml
@@ -67,7 +67,7 @@ expect_dir = "control"
 name = "invoke"
 paths = ["../tests/control/invoke/*.futil"]
 cmd = """
-fud2 {} --from calyx --to dat --through interp-flat -s sim.data={}.data | jq --sort-keys
+fud2 {} --from calyx --to dat --through cider -s sim.data={}.data | jq --sort-keys
 """
 timeout = 10
 expect_dir = "invoke"
@@ -106,7 +106,7 @@ name = "correctness dynamic"
 paths = ["../../tests/correctness/*.futil"]
 cmd = """
 fud2 --from calyx --to dat \
-         --through interp-flat \
+         --through cider \
          -s sim.data={}.data \
          {} | jq --sort-keys
 """

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -1296,7 +1296,7 @@ impl<'a> Simulator<'a> {
 
                             has_changed |= changed.as_bool();
                         } else if self.env.ports[dest].is_def() {
-                            todo!("Raise an error here since this assignment is undefining things: {}", self.env.ctx.printer().print_assignment(ledger.comp_id, assign_idx))
+                            todo!("Raise an error here since this assignment is undefining things: {}. Port currently has value: {}", self.env.ctx.printer().print_assignment(ledger.comp_id, assign_idx), &self.env.ports[dest])
                         }
                     }
                 }


### PR DESCRIPTION
Part of #1913.

This updates the fud2 configuration for cider to run the Calyx compiler before running cider which lets us use fud2 in the same way as fud1 for the tests.

It also does some slight renaming so that you now need to do `--through cider` rather than `--through interp-flat`.