### PR TITLE
Add error handling to width inference for `invoke`

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -1097,7 +1097,7 @@ def invoke(cell: CellBuilder, **kwargs) -> ast.Invoke:
         width = cell.infer_width(x)
         if not width:
             raise WidthInferenceError(
-                "Cannot infer width. "
+                f"Could not infer width of input '{x}' when invoking component '{cell.name}'. "
                 "Consider providing width as an argument."
             )
         return width

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -408,7 +408,10 @@ class ComponentBuilder:
         """Generate a StdMemD2 cell."""
         self.prog.import_("primitives/memories/comb.futil")
         return self.cell(
-            name, ast.Stdlib.comb_mem_d2(bitwidth, len0, len1, idx_size0, idx_size1), is_external, is_ref
+            name,
+            ast.Stdlib.comb_mem_d2(bitwidth, len0, len1, idx_size0, idx_size1),
+            is_external,
+            is_ref,
         )
 
     def seq_mem_d1(
@@ -440,7 +443,10 @@ class ComponentBuilder:
         """Generate a SeqMemD2 cell."""
         self.prog.import_("primitives/memories/seq.futil")
         return self.cell(
-            name, ast.Stdlib.seq_mem_d2(bitwidth, len0, len1, idx_size0, idx_size1), is_external, is_ref
+            name,
+            ast.Stdlib.seq_mem_d2(bitwidth, len0, len1, idx_size0, idx_size1),
+            is_external,
+            is_ref,
         )
 
     def binary(
@@ -787,7 +793,7 @@ class ComponentBuilder:
 
     def mem_load_d1(self, mem, i, reg, groupname):
         """Inserts wiring into `self` to perform `reg := mem[i]`,
-        where `mem` is a seq_d1 memory or a comb_mem_d1 memory 
+        where `mem` is a seq_d1 memory or a comb_mem_d1 memory
         """
         assert mem.is_seq_mem_d1() or mem.is_comb_mem_d1()
         is_comb = mem.is_comb_mem_d1()
@@ -805,7 +811,7 @@ class ComponentBuilder:
 
     def mem_load_d2(self, mem, i, j, reg, groupname):
         """Inserts wiring into `self` to perform `reg := mem[i]`,
-        where `mem` is a seq_d2 memory or a comb_mem_d2 memory 
+        where `mem` is a seq_d2 memory or a comb_mem_d2 memory
         """
         assert mem.is_seq_mem_d2() or mem.is_comb_mem_d2()
         is_comb = mem.is_comb_mem_d2()
@@ -824,7 +830,7 @@ class ComponentBuilder:
 
     def mem_store_d1(self, mem, i, val, groupname):
         """Inserts wiring into `self` to perform `mem[i] := val`,
-        where `mem` is a seq_d1 memory or a comb_mem_d1 memory 
+        where `mem` is a seq_d1 memory or a comb_mem_d1 memory
         """
         assert mem.is_seq_mem_d1() or mem.is_comb_mem_d1()
         is_comb = mem.is_comb_mem_d1()
@@ -839,7 +845,7 @@ class ComponentBuilder:
 
     def mem_store_d2(self, mem, i, j, val, groupname):
         """Inserts wiring into `self` to perform `mem[i] := val`,
-        where `mem` is a seq_d2 memory or a comb_mem_d2 memory 
+        where `mem` is a seq_d2 memory or a comb_mem_d2 memory
         """
         assert mem.is_seq_mem_d2() or mem.is_comb_mem_d2()
         is_comb = mem.is_comb_mem_d2()
@@ -1097,8 +1103,8 @@ def invoke(cell: CellBuilder, **kwargs) -> ast.Invoke:
         width = cell.infer_width(x)
         if not width:
             raise WidthInferenceError(
-                f"Could not infer width of input '{x}' when invoking component '{cell.name}'. "
-                "Consider providing width as an argument."
+                f"Could not infer width of input '{x}' when invoking cell '{cell.name}'. "
+                "Consider using `const(width, value)` instead of `value`."
             )
         return width
 

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -1094,7 +1094,7 @@ def invoke(cell: CellBuilder, **kwargs) -> ast.Invoke:
     """
 
     def try_infer_width(x):
-        width = cell.infer_width(x[3:])
+        width = cell.infer_width(x)
         if not width:
             raise WidthInferenceError(
                 "Cannot infer width. "

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -1092,6 +1092,16 @@ def invoke(cell: CellBuilder, **kwargs) -> ast.Invoke:
     The keyword arguments should have the form `in_*`, `out_*`, or `ref_*`, where
     `*` is the name of an input port, output port, or ref cell on the invoked cell.
     """
+
+    def try_infer_width(x):
+        width = cell.infer_width(x[3:])
+        if not width:
+            raise WidthInferenceError(
+                "Cannot infer width. "
+                "Consider providing width as an argument."
+            )
+        return width
+
     return ast.Invoke(
         cell._cell.id,
         [
@@ -1099,7 +1109,7 @@ def invoke(cell: CellBuilder, **kwargs) -> ast.Invoke:
                 k[3:],
                 (
                     (
-                        const(cell.infer_width(k[3:]), v).expr
+                        const(try_infer_width(k[3:]), v).expr
                         if isinstance(v, int)
                         else ExprBuilder.unwrap(v)
                     )


### PR DESCRIPTION
Consider this small eDSL program
```python
# bad_invoke.py
import calyx.builder as cb

def insert_comp(prog):
    comp = prog.component("adder")

    a = comp.input("a", 32)

    comp.control += []

    return comp

def insert_main(prog):
    main = prog.component("main")

    adder = insert_comp(prog)
    adder = main.cell("adder", adder)

    main.control += [cb.invoke(adder, in_a=10)]

if __name__ == "__main__":
    prog = cb.Builder()
    insert_main(prog)
    prog.program.emit()
```
For examples like these, the eDSL is unable to automatically infer the widths of constant inputs to `invoke`: in this case`10` and `12`. Instead of throwing an error when running `python bad_invoke.py`, it generates the following Calyx code, in which the widths of `a` and `b` are `None`:
```
import "primitives/core.futil";
component main() -> () {
  cells {
    adder = adder();
  }
  wires {

  }
  control {
    seq {
      invoke adder(a=None'd10, b=None'd12)();
    }
  }
}
component adder(a: 32) -> () {
  cells {

  }
  wires {

  }
  control {
    seq {

    }
  }
}
```
Until width inference is extended to handle these cases, this short PR ensures running `python <eDSL_program_name>.py` generates an error instead of malformed Calyx code.