### PR TITLE
Avoid name clashes with `incr` (resp. `decr`) groups using the same register

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -753,7 +753,7 @@ class ComponentBuilder:
 
     def decr(self, reg, val=1, signed=False, cellname=None):
         """Inserts wiring into `self` to perform `reg := reg - val`."""
-        cellname = cellname or f"{reg.name}_decr"
+        cellname = cellname or f"{reg.name}_decr_{val}"
         width = reg.infer_width_reg()
         sub_cell = self.sub(width, cellname, signed)
         with self.group(f"{cellname}_group") as decr_group:

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -734,7 +734,7 @@ class ComponentBuilder:
 
     def incr(self, reg, val=1, signed=False, cellname=None, static=False):
         """Inserts wiring into `self` to perform `reg := reg + val`."""
-        cellname = cellname or f"{reg.name}_incr"
+        cellname = cellname or f"{reg.name}_incr_{val}"
         width = reg.infer_width_reg()
         add_cell = self.add(width, cellname, signed)
         group = (

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -734,7 +734,7 @@ class ComponentBuilder:
 
     def incr(self, reg, val=1, signed=False, cellname=None, static=False):
         """Inserts wiring into `self` to perform `reg := reg + val`."""
-        cellname = cellname or f"{reg.name}_incr_{val}"
+        cellname = cellname or self.generate_name(f"{reg.name}_incr_{val}")
         width = reg.infer_width_reg()
         add_cell = self.add(width, cellname, signed)
         group = (
@@ -753,7 +753,7 @@ class ComponentBuilder:
 
     def decr(self, reg, val=1, signed=False, cellname=None):
         """Inserts wiring into `self` to perform `reg := reg - val`."""
-        cellname = cellname or f"{reg.name}_decr_{val}"
+        cellname = cellname or self.generate_name(f"{reg.name}_decr_{val}")
         width = reg.infer_width_reg()
         sub_cell = self.sub(width, cellname, signed)
         with self.group(f"{cellname}_group") as decr_group:

--- a/calyx-py/test/walkthrough.expect
+++ b/calyx-py/test/walkthrough.expect
@@ -116,36 +116,36 @@ component map(v: 32) -> () {
   cells {
     ref mem = comb_mem_d1(32, 10, 32);
     reg_1 = std_reg(8);
-    reg_1_incr_1 = std_add(8);
-    mult_pipe_2 = std_mult_pipe(32);
-    lt_3 = std_lt(8);
+    reg_1_incr_1_2 = std_add(8);
+    mult_pipe_3 = std_mult_pipe(32);
+    lt_4 = std_lt(8);
   }
   wires {
-    group reg_1_incr_1_group {
-      reg_1_incr_1.left = reg_1.out;
-      reg_1_incr_1.right = 8'd1;
+    group reg_1_incr_1_2_group {
+      reg_1_incr_1_2.left = reg_1.out;
+      reg_1_incr_1_2.right = 8'd1;
       reg_1.write_en = 1'd1;
-      reg_1.in = reg_1_incr_1.out;
-      reg_1_incr_1_group[done] = reg_1.done;
+      reg_1.in = reg_1_incr_1_2.out;
+      reg_1_incr_1_2_group[done] = reg_1.done;
     }
-    comb group lt_3_group {
-      lt_3.left = reg_1.out;
-      lt_3.right = 8'd10;
+    comb group lt_4_group {
+      lt_4.left = reg_1.out;
+      lt_4.right = 8'd10;
     }
     group mul_at_position_i {
       mem.addr0 = reg_1.out;
-      mult_pipe_2.left = mem.read_data;
-      mult_pipe_2.right = v;
-      mem.write_en = mult_pipe_2.done ? 1'd1;
-      mem.write_data = mult_pipe_2.out;
+      mult_pipe_3.left = mem.read_data;
+      mult_pipe_3.right = v;
+      mem.write_en = mult_pipe_3.done ? 1'd1;
+      mem.write_data = mult_pipe_3.out;
       mul_at_position_i[done] = mem.done;
     }
   }
   control {
-    while lt_3.out with lt_3_group {
+    while lt_4.out with lt_4_group {
       seq {
         mul_at_position_i;
-        reg_1_incr_1_group;
+        reg_1_incr_1_2_group;
       }
     }
   }

--- a/calyx-py/test/walkthrough.expect
+++ b/calyx-py/test/walkthrough.expect
@@ -116,17 +116,17 @@ component map(v: 32) -> () {
   cells {
     ref mem = comb_mem_d1(32, 10, 32);
     reg_1 = std_reg(8);
-    reg_1_incr = std_add(8);
+    reg_1_incr_1 = std_add(8);
     mult_pipe_2 = std_mult_pipe(32);
     lt_3 = std_lt(8);
   }
   wires {
-    group reg_1_incr_group {
-      reg_1_incr.left = reg_1.out;
-      reg_1_incr.right = 8'd1;
+    group reg_1_incr_1_group {
+      reg_1_incr_1.left = reg_1.out;
+      reg_1_incr_1.right = 8'd1;
       reg_1.write_en = 1'd1;
-      reg_1.in = reg_1_incr.out;
-      reg_1_incr_group[done] = reg_1.done;
+      reg_1.in = reg_1_incr_1.out;
+      reg_1_incr_1_group[done] = reg_1.done;
     }
     comb group lt_3_group {
       lt_3.left = reg_1.out;
@@ -145,7 +145,7 @@ component map(v: 32) -> () {
     while lt_3.out with lt_3_group {
       seq {
         mul_at_position_i;
-        reg_1_incr_group;
+        reg_1_incr_1_group;
       }
     }
   }

--- a/tests/frontend/exp/degree-2-unsigned.expect
+++ b/tests/frontend/exp/degree-2-unsigned.expect
@@ -112,8 +112,8 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
     pow = std_reg(32);
     count = std_reg(32);
     mul = std_fp_mult_pipe(32, 16, 16);
-    count_incr_1 = std_add(32);
-    lt_1 = std_lt(32);
+    count_incr_1_1 = std_add(32);
+    lt_2 = std_lt(32);
   }
   wires {
     group init_pow {
@@ -134,16 +134,16 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
       pow.in = mul.out;
       execute_mul[done] = pow.done;
     }
-    group count_incr_1_group {
-      count_incr_1.left = count.out;
-      count_incr_1.right = 32'd1;
+    group count_incr_1_1_group {
+      count_incr_1_1.left = count.out;
+      count_incr_1_1.right = 32'd1;
       count.write_en = 1'd1;
-      count.in = count_incr_1.out;
-      count_incr_1_group[done] = count.done;
+      count.in = count_incr_1_1.out;
+      count_incr_1_1_group[done] = count.done;
     }
-    comb group lt_1_group {
-      lt_1.left = count.out;
-      lt_1.right = integer_exp;
+    comb group lt_2_group {
+      lt_2.left = count.out;
+      lt_2.right = integer_exp;
     }
     out = pow.out;
   }
@@ -153,10 +153,10 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
         init_pow;
         init_count;
       }
-      while lt_1.out with lt_1_group {
+      while lt_2.out with lt_2_group {
         par {
           execute_mul;
-          count_incr_1_group;
+          count_incr_1_1_group;
         }
       }
     }

--- a/tests/frontend/exp/degree-2-unsigned.expect
+++ b/tests/frontend/exp/degree-2-unsigned.expect
@@ -112,7 +112,7 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
     pow = std_reg(32);
     count = std_reg(32);
     mul = std_fp_mult_pipe(32, 16, 16);
-    count_incr = std_add(32);
+    count_incr_1 = std_add(32);
     lt_1 = std_lt(32);
   }
   wires {
@@ -134,12 +134,12 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
       pow.in = mul.out;
       execute_mul[done] = pow.done;
     }
-    group count_incr_group {
-      count_incr.left = count.out;
-      count_incr.right = 32'd1;
+    group count_incr_1_group {
+      count_incr_1.left = count.out;
+      count_incr_1.right = 32'd1;
       count.write_en = 1'd1;
-      count.in = count_incr.out;
-      count_incr_group[done] = count.done;
+      count.in = count_incr_1.out;
+      count_incr_1_group[done] = count.done;
     }
     comb group lt_1_group {
       lt_1.left = count.out;
@@ -156,7 +156,7 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
       while lt_1.out with lt_1_group {
         par {
           execute_mul;
-          count_incr_group;
+          count_incr_1_group;
         }
       }
     }

--- a/tests/frontend/exp/degree-4-signed.expect
+++ b/tests/frontend/exp/degree-4-signed.expect
@@ -205,8 +205,8 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
     pow = std_reg(16);
     count = std_reg(16);
     mul = std_fp_smult_pipe(16, 8, 8);
-    count_incr_1 = std_sadd(16);
-    lt_1 = std_slt(16);
+    count_incr_1_1 = std_sadd(16);
+    lt_2 = std_slt(16);
   }
   wires {
     group init_pow {
@@ -227,16 +227,16 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
       pow.in = mul.out;
       execute_mul[done] = pow.done;
     }
-    group count_incr_1_group {
-      count_incr_1.left = count.out;
-      count_incr_1.right = 16'd1;
+    group count_incr_1_1_group {
+      count_incr_1_1.left = count.out;
+      count_incr_1_1.right = 16'd1;
       count.write_en = 1'd1;
-      count.in = count_incr_1.out;
-      count_incr_1_group[done] = count.done;
+      count.in = count_incr_1_1.out;
+      count_incr_1_1_group[done] = count.done;
     }
-    comb group lt_1_group {
-      lt_1.left = count.out;
-      lt_1.right = integer_exp;
+    comb group lt_2_group {
+      lt_2.left = count.out;
+      lt_2.right = integer_exp;
     }
     out = pow.out;
   }
@@ -246,10 +246,10 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
         init_pow;
         init_count;
       }
-      while lt_1.out with lt_1_group {
+      while lt_2.out with lt_2_group {
         par {
           execute_mul;
-          count_incr_1_group;
+          count_incr_1_1_group;
         }
       }
     }

--- a/tests/frontend/exp/degree-4-signed.expect
+++ b/tests/frontend/exp/degree-4-signed.expect
@@ -205,7 +205,7 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
     pow = std_reg(16);
     count = std_reg(16);
     mul = std_fp_smult_pipe(16, 8, 8);
-    count_incr = std_sadd(16);
+    count_incr_1 = std_sadd(16);
     lt_1 = std_slt(16);
   }
   wires {
@@ -227,12 +227,12 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
       pow.in = mul.out;
       execute_mul[done] = pow.done;
     }
-    group count_incr_group {
-      count_incr.left = count.out;
-      count_incr.right = 16'd1;
+    group count_incr_1_group {
+      count_incr_1.left = count.out;
+      count_incr_1.right = 16'd1;
       count.write_en = 1'd1;
-      count.in = count_incr.out;
-      count_incr_group[done] = count.done;
+      count.in = count_incr_1.out;
+      count_incr_1_group[done] = count.done;
     }
     comb group lt_1_group {
       lt_1.left = count.out;
@@ -249,7 +249,7 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
       while lt_1.out with lt_1_group {
         par {
           execute_mul;
-          count_incr_group;
+          count_incr_1_group;
         }
       }
     }

--- a/tests/frontend/exp/degree-4-unsigned.expect
+++ b/tests/frontend/exp/degree-4-unsigned.expect
@@ -176,7 +176,7 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
     pow = std_reg(16);
     count = std_reg(16);
     mul = std_fp_mult_pipe(16, 8, 8);
-    count_incr = std_add(16);
+    count_incr_1 = std_add(16);
     lt_1 = std_lt(16);
   }
   wires {
@@ -198,12 +198,12 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
       pow.in = mul.out;
       execute_mul[done] = pow.done;
     }
-    group count_incr_group {
-      count_incr.left = count.out;
-      count_incr.right = 16'd1;
+    group count_incr_1_group {
+      count_incr_1.left = count.out;
+      count_incr_1.right = 16'd1;
       count.write_en = 1'd1;
-      count.in = count_incr.out;
-      count_incr_group[done] = count.done;
+      count.in = count_incr_1.out;
+      count_incr_1_group[done] = count.done;
     }
     comb group lt_1_group {
       lt_1.left = count.out;
@@ -220,7 +220,7 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
       while lt_1.out with lt_1_group {
         par {
           execute_mul;
-          count_incr_group;
+          count_incr_1_group;
         }
       }
     }

--- a/tests/frontend/exp/degree-4-unsigned.expect
+++ b/tests/frontend/exp/degree-4-unsigned.expect
@@ -176,8 +176,8 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
     pow = std_reg(16);
     count = std_reg(16);
     mul = std_fp_mult_pipe(16, 8, 8);
-    count_incr_1 = std_add(16);
-    lt_1 = std_lt(16);
+    count_incr_1_1 = std_add(16);
+    lt_2 = std_lt(16);
   }
   wires {
     group init_pow {
@@ -198,16 +198,16 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
       pow.in = mul.out;
       execute_mul[done] = pow.done;
     }
-    group count_incr_1_group {
-      count_incr_1.left = count.out;
-      count_incr_1.right = 16'd1;
+    group count_incr_1_1_group {
+      count_incr_1_1.left = count.out;
+      count_incr_1_1.right = 16'd1;
       count.write_en = 1'd1;
-      count.in = count_incr_1.out;
-      count_incr_1_group[done] = count.done;
+      count.in = count_incr_1_1.out;
+      count_incr_1_1_group[done] = count.done;
     }
-    comb group lt_1_group {
-      lt_1.left = count.out;
-      lt_1.right = integer_exp;
+    comb group lt_2_group {
+      lt_2.left = count.out;
+      lt_2.right = integer_exp;
     }
     out = pow.out;
   }
@@ -217,10 +217,10 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
         init_pow;
         init_count;
       }
-      while lt_1.out with lt_1_group {
+      while lt_2.out with lt_2_group {
         par {
           execute_mul;
-          count_incr_1_group;
+          count_incr_1_1_group;
         }
       }
     }

--- a/tests/frontend/relay/softmax.expect
+++ b/tests/frontend/relay/softmax.expect
@@ -626,8 +626,8 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
     pow = std_reg(32);
     count = std_reg(32);
     mul = std_fp_smult_pipe(32, 16, 16);
-    count_incr_1 = std_sadd(32);
-    lt_1 = std_slt(32);
+    count_incr_1_1 = std_sadd(32);
+    lt_2 = std_slt(32);
   }
   wires {
     group init_pow {
@@ -648,16 +648,16 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
       pow.in = mul.out;
       execute_mul[done] = pow.done;
     }
-    group count_incr_1_group {
-      count_incr_1.left = count.out;
-      count_incr_1.right = 32'd1;
+    group count_incr_1_1_group {
+      count_incr_1_1.left = count.out;
+      count_incr_1_1.right = 32'd1;
       count.write_en = 1'd1;
-      count.in = count_incr_1.out;
-      count_incr_1_group[done] = count.done;
+      count.in = count_incr_1_1.out;
+      count_incr_1_1_group[done] = count.done;
     }
-    comb group lt_1_group {
-      lt_1.left = count.out;
-      lt_1.right = integer_exp;
+    comb group lt_2_group {
+      lt_2.left = count.out;
+      lt_2.right = integer_exp;
     }
     out = pow.out;
   }
@@ -667,10 +667,10 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
         init_pow;
         init_count;
       }
-      while lt_1.out with lt_1_group {
+      while lt_2.out with lt_2_group {
         par {
           execute_mul;
-          count_incr_1_group;
+          count_incr_1_1_group;
         }
       }
     }

--- a/tests/frontend/relay/softmax.expect
+++ b/tests/frontend/relay/softmax.expect
@@ -626,7 +626,7 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
     pow = std_reg(32);
     count = std_reg(32);
     mul = std_fp_smult_pipe(32, 16, 16);
-    count_incr = std_sadd(32);
+    count_incr_1 = std_sadd(32);
     lt_1 = std_slt(32);
   }
   wires {
@@ -648,12 +648,12 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
       pow.in = mul.out;
       execute_mul[done] = pow.done;
     }
-    group count_incr_group {
-      count_incr.left = count.out;
-      count_incr.right = 32'd1;
+    group count_incr_1_group {
+      count_incr_1.left = count.out;
+      count_incr_1.right = 32'd1;
       count.write_en = 1'd1;
-      count.in = count_incr.out;
-      count_incr_group[done] = count.done;
+      count.in = count_incr_1.out;
+      count_incr_1_group[done] = count.done;
     }
     comb group lt_1_group {
       lt_1.left = count.out;
@@ -670,7 +670,7 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
       while lt_1.out with lt_1_group {
         par {
           execute_mul;
-          count_incr_group;
+          count_incr_1_group;
         }
       }
     }

--- a/yxi/tests/axi/read-compute-write/seq-mem-vec-add.expect
+++ b/yxi/tests/axi/read-compute-write/seq-mem-vec-add.expect
@@ -133,8 +133,8 @@ component m_read_channel(ARESETn: 1, RVALID: 1, RLAST: 1, RDATA: 32, RRESP: 2) -
     n_RLAST = std_reg(1);
     read_data_reg = std_reg(32);
     bt_reg = std_reg(1);
-    curr_addr_internal_mem_incr_1 = std_add(3);
-    curr_addr_axi_incr_4 = std_add(64);
+    curr_addr_internal_mem_incr_1_1 = std_add(3);
+    curr_addr_axi_incr_4_2 = std_add(64);
   }
   wires {
     RREADY = rready.out;
@@ -162,19 +162,19 @@ component m_read_channel(ARESETn: 1, RVALID: 1, RLAST: 1, RDATA: 32, RRESP: 2) -
       mem_ref.content_en = 1'd1;
       service_read_transfer[done] = mem_ref.done;
     }
-    group curr_addr_internal_mem_incr_1_group {
-      curr_addr_internal_mem_incr_1.left = curr_addr_internal_mem.out;
-      curr_addr_internal_mem_incr_1.right = 3'd1;
+    group curr_addr_internal_mem_incr_1_1_group {
+      curr_addr_internal_mem_incr_1_1.left = curr_addr_internal_mem.out;
+      curr_addr_internal_mem_incr_1_1.right = 3'd1;
       curr_addr_internal_mem.write_en = 1'd1;
-      curr_addr_internal_mem.in = curr_addr_internal_mem_incr_1.out;
-      curr_addr_internal_mem_incr_1_group[done] = curr_addr_internal_mem.done;
+      curr_addr_internal_mem.in = curr_addr_internal_mem_incr_1_1.out;
+      curr_addr_internal_mem_incr_1_1_group[done] = curr_addr_internal_mem.done;
     }
-    group curr_addr_axi_incr_4_group {
-      curr_addr_axi_incr_4.left = curr_addr_axi.out;
-      curr_addr_axi_incr_4.right = 64'd4;
+    group curr_addr_axi_incr_4_2_group {
+      curr_addr_axi_incr_4_2.left = curr_addr_axi.out;
+      curr_addr_axi_incr_4_2.right = 64'd4;
       curr_addr_axi.write_en = 1'd1;
-      curr_addr_axi.in = curr_addr_axi_incr_4.out;
-      curr_addr_axi_incr_4_group[done] = curr_addr_axi.done;
+      curr_addr_axi.in = curr_addr_axi_incr_4_2.out;
+      curr_addr_axi_incr_4_2_group[done] = curr_addr_axi.done;
     }
   }
   control {
@@ -186,8 +186,8 @@ component m_read_channel(ARESETn: 1, RVALID: 1, RLAST: 1, RDATA: 32, RRESP: 2) -
           block_transfer;
           service_read_transfer;
           par {
-            curr_addr_internal_mem_incr_1_group;
-            curr_addr_axi_incr_4_group;
+            curr_addr_internal_mem_incr_1_1_group;
+            curr_addr_axi_incr_4_2_group;
           }
         }
       }
@@ -205,9 +205,9 @@ component m_write_channel(ARESETn: 1, WREADY: 1) -> (WVALID: 1, WLAST: 1, WDATA:
     ref max_transfers = std_reg(8);
     n_finished_last_transfer = std_reg(1);
     bt_reg = std_reg(1);
-    curr_addr_internal_mem_incr_1 = std_add(3);
-    curr_addr_axi_incr_4 = std_add(64);
-    curr_transfer_count_incr_1 = std_add(8);
+    curr_addr_internal_mem_incr_1_1 = std_add(3);
+    curr_addr_axi_incr_4_2 = std_add(64);
+    curr_transfer_count_incr_1_3 = std_add(8);
   }
   wires {
     WVALID = wvalid.out;
@@ -231,26 +231,26 @@ component m_write_channel(ARESETn: 1, WREADY: 1) -> (WVALID: 1, WLAST: 1, WDATA:
       bt_reg.write_en = 1'd1;
       service_write_transfer[done] = bt_reg.out;
     }
-    group curr_addr_internal_mem_incr_1_group {
-      curr_addr_internal_mem_incr_1.left = curr_addr_internal_mem.out;
-      curr_addr_internal_mem_incr_1.right = 3'd1;
+    group curr_addr_internal_mem_incr_1_1_group {
+      curr_addr_internal_mem_incr_1_1.left = curr_addr_internal_mem.out;
+      curr_addr_internal_mem_incr_1_1.right = 3'd1;
       curr_addr_internal_mem.write_en = 1'd1;
-      curr_addr_internal_mem.in = curr_addr_internal_mem_incr_1.out;
-      curr_addr_internal_mem_incr_1_group[done] = curr_addr_internal_mem.done;
+      curr_addr_internal_mem.in = curr_addr_internal_mem_incr_1_1.out;
+      curr_addr_internal_mem_incr_1_1_group[done] = curr_addr_internal_mem.done;
     }
-    group curr_addr_axi_incr_4_group {
-      curr_addr_axi_incr_4.left = curr_addr_axi.out;
-      curr_addr_axi_incr_4.right = 64'd4;
+    group curr_addr_axi_incr_4_2_group {
+      curr_addr_axi_incr_4_2.left = curr_addr_axi.out;
+      curr_addr_axi_incr_4_2.right = 64'd4;
       curr_addr_axi.write_en = 1'd1;
-      curr_addr_axi.in = curr_addr_axi_incr_4.out;
-      curr_addr_axi_incr_4_group[done] = curr_addr_axi.done;
+      curr_addr_axi.in = curr_addr_axi_incr_4_2.out;
+      curr_addr_axi_incr_4_2_group[done] = curr_addr_axi.done;
     }
-    group curr_transfer_count_incr_1_group {
-      curr_transfer_count_incr_1.left = curr_transfer_count.out;
-      curr_transfer_count_incr_1.right = 8'd1;
+    group curr_transfer_count_incr_1_3_group {
+      curr_transfer_count_incr_1_3.left = curr_transfer_count.out;
+      curr_transfer_count_incr_1_3.right = 8'd1;
       curr_transfer_count.write_en = 1'd1;
-      curr_transfer_count.in = curr_transfer_count_incr_1.out;
-      curr_transfer_count_incr_1_group[done] = curr_transfer_count.done;
+      curr_transfer_count.in = curr_transfer_count_incr_1_3.out;
+      curr_transfer_count_incr_1_3_group[done] = curr_transfer_count.done;
     }
   }
   control {
@@ -262,9 +262,9 @@ component m_write_channel(ARESETn: 1, WREADY: 1) -> (WVALID: 1, WLAST: 1, WDATA:
           invoke bt_reg(in=1'd0)();
           service_write_transfer;
           par {
-            curr_addr_internal_mem_incr_1_group;
-            curr_transfer_count_incr_1_group;
-            curr_addr_axi_incr_4_group;
+            curr_addr_internal_mem_incr_1_1_group;
+            curr_transfer_count_incr_1_3_group;
+            curr_addr_axi_incr_4_2_group;
             invoke w_handshake_occurred(in=1'd0)();
           }
         }

--- a/yxi/tests/axi/read-compute-write/seq-mem-vec-add.expect
+++ b/yxi/tests/axi/read-compute-write/seq-mem-vec-add.expect
@@ -133,8 +133,8 @@ component m_read_channel(ARESETn: 1, RVALID: 1, RLAST: 1, RDATA: 32, RRESP: 2) -
     n_RLAST = std_reg(1);
     read_data_reg = std_reg(32);
     bt_reg = std_reg(1);
-    curr_addr_internal_mem_incr = std_add(3);
-    curr_addr_axi_incr = std_add(64);
+    curr_addr_internal_mem_incr_1 = std_add(3);
+    curr_addr_axi_incr_4 = std_add(64);
   }
   wires {
     RREADY = rready.out;
@@ -162,19 +162,19 @@ component m_read_channel(ARESETn: 1, RVALID: 1, RLAST: 1, RDATA: 32, RRESP: 2) -
       mem_ref.content_en = 1'd1;
       service_read_transfer[done] = mem_ref.done;
     }
-    group curr_addr_internal_mem_incr_group {
-      curr_addr_internal_mem_incr.left = curr_addr_internal_mem.out;
-      curr_addr_internal_mem_incr.right = 3'd1;
+    group curr_addr_internal_mem_incr_1_group {
+      curr_addr_internal_mem_incr_1.left = curr_addr_internal_mem.out;
+      curr_addr_internal_mem_incr_1.right = 3'd1;
       curr_addr_internal_mem.write_en = 1'd1;
-      curr_addr_internal_mem.in = curr_addr_internal_mem_incr.out;
-      curr_addr_internal_mem_incr_group[done] = curr_addr_internal_mem.done;
+      curr_addr_internal_mem.in = curr_addr_internal_mem_incr_1.out;
+      curr_addr_internal_mem_incr_1_group[done] = curr_addr_internal_mem.done;
     }
-    group curr_addr_axi_incr_group {
-      curr_addr_axi_incr.left = curr_addr_axi.out;
-      curr_addr_axi_incr.right = 64'd4;
+    group curr_addr_axi_incr_4_group {
+      curr_addr_axi_incr_4.left = curr_addr_axi.out;
+      curr_addr_axi_incr_4.right = 64'd4;
       curr_addr_axi.write_en = 1'd1;
-      curr_addr_axi.in = curr_addr_axi_incr.out;
-      curr_addr_axi_incr_group[done] = curr_addr_axi.done;
+      curr_addr_axi.in = curr_addr_axi_incr_4.out;
+      curr_addr_axi_incr_4_group[done] = curr_addr_axi.done;
     }
   }
   control {
@@ -186,8 +186,8 @@ component m_read_channel(ARESETn: 1, RVALID: 1, RLAST: 1, RDATA: 32, RRESP: 2) -
           block_transfer;
           service_read_transfer;
           par {
-            curr_addr_internal_mem_incr_group;
-            curr_addr_axi_incr_group;
+            curr_addr_internal_mem_incr_1_group;
+            curr_addr_axi_incr_4_group;
           }
         }
       }
@@ -205,9 +205,9 @@ component m_write_channel(ARESETn: 1, WREADY: 1) -> (WVALID: 1, WLAST: 1, WDATA:
     ref max_transfers = std_reg(8);
     n_finished_last_transfer = std_reg(1);
     bt_reg = std_reg(1);
-    curr_addr_internal_mem_incr = std_add(3);
-    curr_addr_axi_incr = std_add(64);
-    curr_transfer_count_incr = std_add(8);
+    curr_addr_internal_mem_incr_1 = std_add(3);
+    curr_addr_axi_incr_4 = std_add(64);
+    curr_transfer_count_incr_1 = std_add(8);
   }
   wires {
     WVALID = wvalid.out;
@@ -231,26 +231,26 @@ component m_write_channel(ARESETn: 1, WREADY: 1) -> (WVALID: 1, WLAST: 1, WDATA:
       bt_reg.write_en = 1'd1;
       service_write_transfer[done] = bt_reg.out;
     }
-    group curr_addr_internal_mem_incr_group {
-      curr_addr_internal_mem_incr.left = curr_addr_internal_mem.out;
-      curr_addr_internal_mem_incr.right = 3'd1;
+    group curr_addr_internal_mem_incr_1_group {
+      curr_addr_internal_mem_incr_1.left = curr_addr_internal_mem.out;
+      curr_addr_internal_mem_incr_1.right = 3'd1;
       curr_addr_internal_mem.write_en = 1'd1;
-      curr_addr_internal_mem.in = curr_addr_internal_mem_incr.out;
-      curr_addr_internal_mem_incr_group[done] = curr_addr_internal_mem.done;
+      curr_addr_internal_mem.in = curr_addr_internal_mem_incr_1.out;
+      curr_addr_internal_mem_incr_1_group[done] = curr_addr_internal_mem.done;
     }
-    group curr_addr_axi_incr_group {
-      curr_addr_axi_incr.left = curr_addr_axi.out;
-      curr_addr_axi_incr.right = 64'd4;
+    group curr_addr_axi_incr_4_group {
+      curr_addr_axi_incr_4.left = curr_addr_axi.out;
+      curr_addr_axi_incr_4.right = 64'd4;
       curr_addr_axi.write_en = 1'd1;
-      curr_addr_axi.in = curr_addr_axi_incr.out;
-      curr_addr_axi_incr_group[done] = curr_addr_axi.done;
+      curr_addr_axi.in = curr_addr_axi_incr_4.out;
+      curr_addr_axi_incr_4_group[done] = curr_addr_axi.done;
     }
-    group curr_transfer_count_incr_group {
-      curr_transfer_count_incr.left = curr_transfer_count.out;
-      curr_transfer_count_incr.right = 8'd1;
+    group curr_transfer_count_incr_1_group {
+      curr_transfer_count_incr_1.left = curr_transfer_count.out;
+      curr_transfer_count_incr_1.right = 8'd1;
       curr_transfer_count.write_en = 1'd1;
-      curr_transfer_count.in = curr_transfer_count_incr.out;
-      curr_transfer_count_incr_group[done] = curr_transfer_count.done;
+      curr_transfer_count.in = curr_transfer_count_incr_1.out;
+      curr_transfer_count_incr_1_group[done] = curr_transfer_count.done;
     }
   }
   control {
@@ -262,9 +262,9 @@ component m_write_channel(ARESETn: 1, WREADY: 1) -> (WVALID: 1, WLAST: 1, WDATA:
           invoke bt_reg(in=1'd0)();
           service_write_transfer;
           par {
-            curr_addr_internal_mem_incr_group;
-            curr_transfer_count_incr_group;
-            curr_addr_axi_incr_group;
+            curr_addr_internal_mem_incr_1_group;
+            curr_transfer_count_incr_1_group;
+            curr_addr_axi_incr_4_group;
             invoke w_handshake_occurred(in=1'd0)();
           }
         }

--- a/yxi/tests/axi/read-compute-write/seq-vec-add.expect
+++ b/yxi/tests/axi/read-compute-write/seq-vec-add.expect
@@ -133,8 +133,8 @@ component m_read_channel(ARESETn: 1, RVALID: 1, RLAST: 1, RDATA: 32, RRESP: 2) -
     n_RLAST = std_reg(1);
     read_data_reg = std_reg(32);
     bt_reg = std_reg(1);
-    curr_addr_internal_mem_incr_1 = std_add(3);
-    curr_addr_axi_incr_4 = std_add(64);
+    curr_addr_internal_mem_incr_1_1 = std_add(3);
+    curr_addr_axi_incr_4_2 = std_add(64);
   }
   wires {
     RREADY = rready.out;
@@ -162,19 +162,19 @@ component m_read_channel(ARESETn: 1, RVALID: 1, RLAST: 1, RDATA: 32, RRESP: 2) -
       mem_ref.content_en = 1'd1;
       service_read_transfer[done] = mem_ref.done;
     }
-    group curr_addr_internal_mem_incr_1_group {
-      curr_addr_internal_mem_incr_1.left = curr_addr_internal_mem.out;
-      curr_addr_internal_mem_incr_1.right = 3'd1;
+    group curr_addr_internal_mem_incr_1_1_group {
+      curr_addr_internal_mem_incr_1_1.left = curr_addr_internal_mem.out;
+      curr_addr_internal_mem_incr_1_1.right = 3'd1;
       curr_addr_internal_mem.write_en = 1'd1;
-      curr_addr_internal_mem.in = curr_addr_internal_mem_incr_1.out;
-      curr_addr_internal_mem_incr_1_group[done] = curr_addr_internal_mem.done;
+      curr_addr_internal_mem.in = curr_addr_internal_mem_incr_1_1.out;
+      curr_addr_internal_mem_incr_1_1_group[done] = curr_addr_internal_mem.done;
     }
-    group curr_addr_axi_incr_4_group {
-      curr_addr_axi_incr_4.left = curr_addr_axi.out;
-      curr_addr_axi_incr_4.right = 64'd4;
+    group curr_addr_axi_incr_4_2_group {
+      curr_addr_axi_incr_4_2.left = curr_addr_axi.out;
+      curr_addr_axi_incr_4_2.right = 64'd4;
       curr_addr_axi.write_en = 1'd1;
-      curr_addr_axi.in = curr_addr_axi_incr_4.out;
-      curr_addr_axi_incr_4_group[done] = curr_addr_axi.done;
+      curr_addr_axi.in = curr_addr_axi_incr_4_2.out;
+      curr_addr_axi_incr_4_2_group[done] = curr_addr_axi.done;
     }
   }
   control {
@@ -186,8 +186,8 @@ component m_read_channel(ARESETn: 1, RVALID: 1, RLAST: 1, RDATA: 32, RRESP: 2) -
           block_transfer;
           service_read_transfer;
           par {
-            curr_addr_internal_mem_incr_1_group;
-            curr_addr_axi_incr_4_group;
+            curr_addr_internal_mem_incr_1_1_group;
+            curr_addr_axi_incr_4_2_group;
           }
         }
       }
@@ -205,9 +205,9 @@ component m_write_channel(ARESETn: 1, WREADY: 1) -> (WVALID: 1, WLAST: 1, WDATA:
     ref max_transfers = std_reg(8);
     n_finished_last_transfer = std_reg(1);
     bt_reg = std_reg(1);
-    curr_addr_internal_mem_incr_1 = std_add(3);
-    curr_addr_axi_incr_4 = std_add(64);
-    curr_transfer_count_incr_1 = std_add(8);
+    curr_addr_internal_mem_incr_1_1 = std_add(3);
+    curr_addr_axi_incr_4_2 = std_add(64);
+    curr_transfer_count_incr_1_3 = std_add(8);
   }
   wires {
     WVALID = wvalid.out;
@@ -231,26 +231,26 @@ component m_write_channel(ARESETn: 1, WREADY: 1) -> (WVALID: 1, WLAST: 1, WDATA:
       bt_reg.write_en = 1'd1;
       service_write_transfer[done] = bt_reg.out;
     }
-    group curr_addr_internal_mem_incr_1_group {
-      curr_addr_internal_mem_incr_1.left = curr_addr_internal_mem.out;
-      curr_addr_internal_mem_incr_1.right = 3'd1;
+    group curr_addr_internal_mem_incr_1_1_group {
+      curr_addr_internal_mem_incr_1_1.left = curr_addr_internal_mem.out;
+      curr_addr_internal_mem_incr_1_1.right = 3'd1;
       curr_addr_internal_mem.write_en = 1'd1;
-      curr_addr_internal_mem.in = curr_addr_internal_mem_incr_1.out;
-      curr_addr_internal_mem_incr_1_group[done] = curr_addr_internal_mem.done;
+      curr_addr_internal_mem.in = curr_addr_internal_mem_incr_1_1.out;
+      curr_addr_internal_mem_incr_1_1_group[done] = curr_addr_internal_mem.done;
     }
-    group curr_addr_axi_incr_4_group {
-      curr_addr_axi_incr_4.left = curr_addr_axi.out;
-      curr_addr_axi_incr_4.right = 64'd4;
+    group curr_addr_axi_incr_4_2_group {
+      curr_addr_axi_incr_4_2.left = curr_addr_axi.out;
+      curr_addr_axi_incr_4_2.right = 64'd4;
       curr_addr_axi.write_en = 1'd1;
-      curr_addr_axi.in = curr_addr_axi_incr_4.out;
-      curr_addr_axi_incr_4_group[done] = curr_addr_axi.done;
+      curr_addr_axi.in = curr_addr_axi_incr_4_2.out;
+      curr_addr_axi_incr_4_2_group[done] = curr_addr_axi.done;
     }
-    group curr_transfer_count_incr_1_group {
-      curr_transfer_count_incr_1.left = curr_transfer_count.out;
-      curr_transfer_count_incr_1.right = 8'd1;
+    group curr_transfer_count_incr_1_3_group {
+      curr_transfer_count_incr_1_3.left = curr_transfer_count.out;
+      curr_transfer_count_incr_1_3.right = 8'd1;
       curr_transfer_count.write_en = 1'd1;
-      curr_transfer_count.in = curr_transfer_count_incr_1.out;
-      curr_transfer_count_incr_1_group[done] = curr_transfer_count.done;
+      curr_transfer_count.in = curr_transfer_count_incr_1_3.out;
+      curr_transfer_count_incr_1_3_group[done] = curr_transfer_count.done;
     }
   }
   control {
@@ -262,9 +262,9 @@ component m_write_channel(ARESETn: 1, WREADY: 1) -> (WVALID: 1, WLAST: 1, WDATA:
           invoke bt_reg(in=1'd0)();
           service_write_transfer;
           par {
-            curr_addr_internal_mem_incr_1_group;
-            curr_transfer_count_incr_1_group;
-            curr_addr_axi_incr_4_group;
+            curr_addr_internal_mem_incr_1_1_group;
+            curr_transfer_count_incr_1_3_group;
+            curr_addr_axi_incr_4_2_group;
             invoke w_handshake_occurred(in=1'd0)();
           }
         }

--- a/yxi/tests/axi/read-compute-write/seq-vec-add.expect
+++ b/yxi/tests/axi/read-compute-write/seq-vec-add.expect
@@ -133,8 +133,8 @@ component m_read_channel(ARESETn: 1, RVALID: 1, RLAST: 1, RDATA: 32, RRESP: 2) -
     n_RLAST = std_reg(1);
     read_data_reg = std_reg(32);
     bt_reg = std_reg(1);
-    curr_addr_internal_mem_incr = std_add(3);
-    curr_addr_axi_incr = std_add(64);
+    curr_addr_internal_mem_incr_1 = std_add(3);
+    curr_addr_axi_incr_4 = std_add(64);
   }
   wires {
     RREADY = rready.out;
@@ -162,19 +162,19 @@ component m_read_channel(ARESETn: 1, RVALID: 1, RLAST: 1, RDATA: 32, RRESP: 2) -
       mem_ref.content_en = 1'd1;
       service_read_transfer[done] = mem_ref.done;
     }
-    group curr_addr_internal_mem_incr_group {
-      curr_addr_internal_mem_incr.left = curr_addr_internal_mem.out;
-      curr_addr_internal_mem_incr.right = 3'd1;
+    group curr_addr_internal_mem_incr_1_group {
+      curr_addr_internal_mem_incr_1.left = curr_addr_internal_mem.out;
+      curr_addr_internal_mem_incr_1.right = 3'd1;
       curr_addr_internal_mem.write_en = 1'd1;
-      curr_addr_internal_mem.in = curr_addr_internal_mem_incr.out;
-      curr_addr_internal_mem_incr_group[done] = curr_addr_internal_mem.done;
+      curr_addr_internal_mem.in = curr_addr_internal_mem_incr_1.out;
+      curr_addr_internal_mem_incr_1_group[done] = curr_addr_internal_mem.done;
     }
-    group curr_addr_axi_incr_group {
-      curr_addr_axi_incr.left = curr_addr_axi.out;
-      curr_addr_axi_incr.right = 64'd4;
+    group curr_addr_axi_incr_4_group {
+      curr_addr_axi_incr_4.left = curr_addr_axi.out;
+      curr_addr_axi_incr_4.right = 64'd4;
       curr_addr_axi.write_en = 1'd1;
-      curr_addr_axi.in = curr_addr_axi_incr.out;
-      curr_addr_axi_incr_group[done] = curr_addr_axi.done;
+      curr_addr_axi.in = curr_addr_axi_incr_4.out;
+      curr_addr_axi_incr_4_group[done] = curr_addr_axi.done;
     }
   }
   control {
@@ -186,8 +186,8 @@ component m_read_channel(ARESETn: 1, RVALID: 1, RLAST: 1, RDATA: 32, RRESP: 2) -
           block_transfer;
           service_read_transfer;
           par {
-            curr_addr_internal_mem_incr_group;
-            curr_addr_axi_incr_group;
+            curr_addr_internal_mem_incr_1_group;
+            curr_addr_axi_incr_4_group;
           }
         }
       }
@@ -205,9 +205,9 @@ component m_write_channel(ARESETn: 1, WREADY: 1) -> (WVALID: 1, WLAST: 1, WDATA:
     ref max_transfers = std_reg(8);
     n_finished_last_transfer = std_reg(1);
     bt_reg = std_reg(1);
-    curr_addr_internal_mem_incr = std_add(3);
-    curr_addr_axi_incr = std_add(64);
-    curr_transfer_count_incr = std_add(8);
+    curr_addr_internal_mem_incr_1 = std_add(3);
+    curr_addr_axi_incr_4 = std_add(64);
+    curr_transfer_count_incr_1 = std_add(8);
   }
   wires {
     WVALID = wvalid.out;
@@ -231,26 +231,26 @@ component m_write_channel(ARESETn: 1, WREADY: 1) -> (WVALID: 1, WLAST: 1, WDATA:
       bt_reg.write_en = 1'd1;
       service_write_transfer[done] = bt_reg.out;
     }
-    group curr_addr_internal_mem_incr_group {
-      curr_addr_internal_mem_incr.left = curr_addr_internal_mem.out;
-      curr_addr_internal_mem_incr.right = 3'd1;
+    group curr_addr_internal_mem_incr_1_group {
+      curr_addr_internal_mem_incr_1.left = curr_addr_internal_mem.out;
+      curr_addr_internal_mem_incr_1.right = 3'd1;
       curr_addr_internal_mem.write_en = 1'd1;
-      curr_addr_internal_mem.in = curr_addr_internal_mem_incr.out;
-      curr_addr_internal_mem_incr_group[done] = curr_addr_internal_mem.done;
+      curr_addr_internal_mem.in = curr_addr_internal_mem_incr_1.out;
+      curr_addr_internal_mem_incr_1_group[done] = curr_addr_internal_mem.done;
     }
-    group curr_addr_axi_incr_group {
-      curr_addr_axi_incr.left = curr_addr_axi.out;
-      curr_addr_axi_incr.right = 64'd4;
+    group curr_addr_axi_incr_4_group {
+      curr_addr_axi_incr_4.left = curr_addr_axi.out;
+      curr_addr_axi_incr_4.right = 64'd4;
       curr_addr_axi.write_en = 1'd1;
-      curr_addr_axi.in = curr_addr_axi_incr.out;
-      curr_addr_axi_incr_group[done] = curr_addr_axi.done;
+      curr_addr_axi.in = curr_addr_axi_incr_4.out;
+      curr_addr_axi_incr_4_group[done] = curr_addr_axi.done;
     }
-    group curr_transfer_count_incr_group {
-      curr_transfer_count_incr.left = curr_transfer_count.out;
-      curr_transfer_count_incr.right = 8'd1;
+    group curr_transfer_count_incr_1_group {
+      curr_transfer_count_incr_1.left = curr_transfer_count.out;
+      curr_transfer_count_incr_1.right = 8'd1;
       curr_transfer_count.write_en = 1'd1;
-      curr_transfer_count.in = curr_transfer_count_incr.out;
-      curr_transfer_count_incr_group[done] = curr_transfer_count.done;
+      curr_transfer_count.in = curr_transfer_count_incr_1.out;
+      curr_transfer_count_incr_1_group[done] = curr_transfer_count.done;
     }
   }
   control {
@@ -262,9 +262,9 @@ component m_write_channel(ARESETn: 1, WREADY: 1) -> (WVALID: 1, WLAST: 1, WDATA:
           invoke bt_reg(in=1'd0)();
           service_write_transfer;
           par {
-            curr_addr_internal_mem_incr_group;
-            curr_transfer_count_incr_group;
-            curr_addr_axi_incr_group;
+            curr_addr_internal_mem_incr_1_group;
+            curr_transfer_count_incr_1_group;
+            curr_addr_axi_incr_4_group;
             invoke w_handshake_occurred(in=1'd0)();
           }
         }


### PR DESCRIPTION
Small PR that tweaks the names of the group and cells used in `ComponentBuilder.incr` and `ComponentBuilder.decr`.

Previously, eDSL code like this
```
a_incr_2 = comp.incr(a, 2)
a_incr_4 = comp.incr(a, 4)
```
would raise the assertion error `cell 'a_incr' already exists`. Now, we can construct `incr` (resp. `decr`)' groups with the same register and different `val`s without name clashes. 