### PR TITLE
Queues: edge case in data-gen when `num_cmds` is odd

### DIFF
--- a/calyx-py/calyx/queue_data_gen.py
+++ b/calyx-py/calyx/queue_data_gen.py
@@ -52,7 +52,14 @@ def no_err_cmds_list(queue_size, num_cmds):
             commands += (push_goal - total_pop_count) * [0]
             break
 
-    assert len(commands) == num_cmds
+    # If the total number of commands is not `num_cmds`, pad it with `peek`s.
+    # This is because the `commands` list must have `num_cmds` items.
+    commands += (num_cmds - len(commands)) * [1]
+    # The above command will add either zero or one `peek` command to the end.
+
+    assert (
+        len(commands) == num_cmds
+    ), f"Length of commands list was {len(commands)}, expected {num_cmds}"
     return commands
 
 
@@ -109,6 +116,7 @@ def dump_json(num_cmds, use_rank: bool, no_err: bool, queue_size: Optional[int] 
         print(json.dumps(commands | values | ranks | ans_mem, indent=2))
     else:
         print(json.dumps(commands | values | ans_mem, indent=2))
+
 
 if __name__ == "__main__":
     # Accept a flag that we pass to dump_json.


### PR DESCRIPTION
This PR fixes a funny little corner case when trying to generate our fancy commands list sans underflow or overflow. 

Given some target number of commands `n`, the special helper inserts `n/2` `push`es and as many `pop`s into a list, while additionally taking care to ensure that no overflows or underflows occur. However, this can cause an issue when `n` is odd: the commands list thus generated ends up with `n-1` elements, while the rest of the infrastructure expects a `n`-length command list. This PR fixes this by padding a `peek` command at the end when needed.