### PR TITLE
Re-enable old queue tests

### DIFF
--- a/runt.toml
+++ b/runt.toml
@@ -131,27 +131,14 @@ python3 {} |\
 [[tests]]
 name = "[calyx-py] queues correctness"
 paths = [
-    "calyx-py/test/correctness/queues/binheap/*.py"
+    "calyx-py/test/correctness/queues/*.py",
+    "calyx-py/test/correctness/queues/binheap/*.py",
+    "calyx-py/test/correctness/queues/rr_queues/rr_queue*.py"
 ]
 cmd = """
 name=$(basename {} .py) &&
 dir=$(dirname {}) &&
 python3 {} 20000 --keepgoing |\
- fud e --from calyx --to jq \
-       --through verilog \
-       --through dat \
-       -s verilog.data "$dir/$name.data" \
-       -s jq.expr ".memories" \
-       -q
-"""
-
-[[tests]]
-name = "[calyx-py] queues correctness"
-paths = ["calyx-py/test/correctness/queues/rr_queues/rr_queue*.py"]
-cmd = """
-name=$(basename {} .py) &&
-dir=$(dirname {}) &&
-python3 {} 20000 |\
  fud e --from calyx --to jq \
        --through verilog \
        --through dat \


### PR DESCRIPTION
It looks like `calyx-py/test/correctness/queues/*.py` was removed from the path of its runt test by  #2177: i.e. the old `fifo`, `pifo`, and `pifo_tree` tests aren't running at CI. Was this intentional? In case it wasn't, I've made a minor fix to `runt.toml`.