### PR TITLE
Only reading/writing to ref memories don't need to be turned into an interface memory

### DIFF
--- a/calyx-opt/src/passes/synthesis_papercut.rs
+++ b/calyx-opt/src/passes/synthesis_papercut.rs
@@ -84,7 +84,7 @@ impl Visitor for SynthesisPapercut {
                     if self.memories.contains(parent) {
                         let has_external =
                             cell.get_attribute(ir::BoolAttr::External);
-                        if has_external.is_none() {
+                        if has_external.is_none() && !cell.is_reference() {
                             return Some(cell.name());
                         }
                     }


### PR DESCRIPTION
This PR resolves #2151 