### PR TITLE
[fud2] Additional Syntax to Rhai DSL

### DIFF
--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -87,6 +87,20 @@ impl EmitBuild for EmitBuildFn {
     }
 }
 
+pub type EmitBuildClosure =
+    Box<dyn Fn(&mut StreamEmitter, &[&str], &[&str]) -> EmitResult>;
+
+impl EmitBuild for EmitBuildClosure {
+    fn build(
+        &self,
+        emitter: &mut StreamEmitter,
+        input: &[&str],
+        output: &[&str],
+    ) -> EmitResult {
+        self(emitter, input, output)
+    }
+}
+
 // TODO make this unnecessary...
 /// A simple `build` emitter that just runs a Ninja rule.
 pub struct EmitRuleBuild {

--- a/fud2/fud-core/src/script/error.rs
+++ b/fud2/fud-core/src/script/error.rs
@@ -13,6 +13,7 @@ pub(super) enum RhaiSystemErrorKind {
     SetupRef(String),
     StateRef(String),
     BeganOp(String, String),
+    NoOp(String),
 }
 
 impl RhaiSystemError {
@@ -40,6 +41,13 @@ impl RhaiSystemError {
         }
     }
 
+    pub(super) fn no_op(cmd: &str) -> Self {
+        Self {
+            kind: RhaiSystemErrorKind::NoOp(cmd.to_string()),
+            position: rhai::Position::NONE,
+        }
+    }
+
     pub(super) fn with_pos(mut self, p: rhai::Position) -> Self {
         self.position = p;
         self
@@ -56,7 +64,10 @@ impl Display for RhaiSystemError {
                 write!(f, "Unable to construct StateRef: `{v:?}`")
             }
             RhaiSystemErrorKind::BeganOp(old_name, new_name) => {
-                write!(f, "Cannot build two ops at once: trying to build `{new_name:?}` but already building `{old_name:?}`")
+                write!(f, "Unable to build two ops at once: trying to build `{new_name:?}` but already building `{old_name:?}`")
+            }
+            RhaiSystemErrorKind::NoOp(cmd) => {
+                write!(f, "No op exists: unable to add cmd `{cmd:?}`")
             }
         }
     }

--- a/fud2/fud-core/src/script/error.rs
+++ b/fud2/fud-core/src/script/error.rs
@@ -10,13 +10,32 @@ pub(super) struct RhaiSystemError {
 
 #[derive(Debug)]
 pub(super) enum RhaiSystemErrorKind {
-    ErrorSetupRef(String),
+    SetupRef(String),
+    StateRef(String),
+    BeganOp(String, String),
 }
 
 impl RhaiSystemError {
     pub(super) fn setup_ref(v: rhai::Dynamic) -> Self {
         Self {
-            kind: RhaiSystemErrorKind::ErrorSetupRef(v.to_string()),
+            kind: RhaiSystemErrorKind::SetupRef(v.to_string()),
+            position: rhai::Position::NONE,
+        }
+    }
+
+    pub(super) fn state_ref(v: rhai::Dynamic) -> Self {
+        Self {
+            kind: RhaiSystemErrorKind::StateRef(v.to_string()),
+            position: rhai::Position::NONE,
+        }
+    }
+
+    pub(super) fn began_op(old_name: &str, new_name: &str) -> Self {
+        Self {
+            kind: RhaiSystemErrorKind::BeganOp(
+                old_name.to_string(),
+                new_name.to_string(),
+            ),
             position: rhai::Position::NONE,
         }
     }
@@ -30,8 +49,14 @@ impl RhaiSystemError {
 impl Display for RhaiSystemError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.kind {
-            RhaiSystemErrorKind::ErrorSetupRef(v) => {
+            RhaiSystemErrorKind::SetupRef(v) => {
                 write!(f, "Unable to construct SetupRef: `{v:?}`")
+            }
+            RhaiSystemErrorKind::StateRef(v) => {
+                write!(f, "Unable to construct StateRef: `{v:?}`")
+            }
+            RhaiSystemErrorKind::BeganOp(old_name, new_name) => {
+                write!(f, "Cannot build two ops at once: trying to build `{new_name:?}` but already building `{old_name:?}`")
             }
         }
     }

--- a/fud2/fud-core/src/script/error.rs
+++ b/fud2/fud-core/src/script/error.rs
@@ -13,7 +13,7 @@ pub(super) enum RhaiSystemErrorKind {
     SetupRef(String),
     StateRef(String),
     BeganOp(String, String),
-    NoOp(String),
+    NoOp,
 }
 
 impl RhaiSystemError {
@@ -41,9 +41,9 @@ impl RhaiSystemError {
         }
     }
 
-    pub(super) fn no_op(cmd: &str) -> Self {
+    pub(super) fn no_op() -> Self {
         Self {
-            kind: RhaiSystemErrorKind::NoOp(cmd.to_string()),
+            kind: RhaiSystemErrorKind::NoOp,
             position: rhai::Position::NONE,
         }
     }
@@ -66,8 +66,8 @@ impl Display for RhaiSystemError {
             RhaiSystemErrorKind::BeganOp(old_name, new_name) => {
                 write!(f, "Unable to build two ops at once: trying to build `{new_name:?}` but already building `{old_name:?}`")
             }
-            RhaiSystemErrorKind::NoOp(cmd) => {
-                write!(f, "No op exists: unable to add cmd `{cmd:?}`")
+            RhaiSystemErrorKind::NoOp => {
+                write!(f, "Unable to find current op being built. Consider calling start_op_stmts earlier in the program.")
             }
         }
     }


### PR DESCRIPTION
## Description
This pull request adds new syntax for defining ops which punts most of the work of the DSL to Rhai. That is, the PR defines new syntax to define ops in Rhai by directly associating a sequence of shell commands with ops. Variables and setups can be done using Rhai's scripting instead of variables and multiple rules in ninja. This leaves only very simple, one rule for each op, ninja files. 

As currently written, this style of op creation may be easier to write and read, however, it may also generate less readable ninja files. 

## Example of Final Syntax
```
export const verilog_state = state("verilog", ["sv", "v"]);
export const calyx_state = state("calyx", ["futil"]);
export const verilog_noverify = state("verilog-noverify", ["sv"]);

fn calyx_setup() {
    // Rhai syntax for object maps.
    #{ 
        calyx_base: config("calyx.base"), 
        calyx_exe: config_or("calyx.exe", "${calyx_base}/target/debug/calyx"),
        args: config_or("calyx.args", ""),
    }

defop calyx_to_verilog(c: calyx_state) >> v: verilog_state {
    let s = calyx_setup();
    // ${var} is Rhai syntax for variable substitution.
    // {$var} is custom syntax for substituting file names specified at runtime.
    shell("${s.calyx_exe} -l ${s.calyx_base} -b verilog ${s.args} {$c} > {$v}");
}

defop calyx_noverify(c: calyx_state) >> v: verilog_noverify {
    let s = calyx_setup();
    shell("${s.calyx_exe} -l ${s.calyx_base} -b verilog ${s.args} --disable-verify {$c} > {$v}");
}
```
The strings passed to `shell` can be constructed with a function to remove some repetition if desired.

While this style of creating ops does clash with the current style, they should still be able to work together. 

## TODO
- [x] Implement `defop` syntax.
- [x] Implement `shell` function.
- [ ] Implement `config` and `config_or` function.
- [ ] Make the two types of substitution more distinct.