### PR TITLE
Fix test case for duplicate FSM optimization

### DIFF
--- a/calyx-opt/src/passes/top_down_compile_control.rs
+++ b/calyx-opt/src/passes/top_down_compile_control.rs
@@ -507,6 +507,9 @@ impl<'b, 'a> Schedule<'b, 'a> {
         fsms: &[RRC<ir::Cell>],
     ) -> usize {
         let num_registers: u64 = fsms.len().try_into().unwrap();
+        // num_states+1 is needed to prevent error (the done condition needs
+        // to check past the number of states, i.e., will check fsm == 3 when
+        // num_states == 3).
         let reg_to_query: usize = (state * num_registers / (num_states + 1))
             .try_into()
             .unwrap();

--- a/calyx-opt/src/passes/top_down_compile_control.rs
+++ b/calyx-opt/src/passes/top_down_compile_control.rs
@@ -365,8 +365,11 @@ impl<'b, 'a> Schedule<'b, 'a> {
         fsm_size: &u64,
     ) -> ir::Guard<Nothing> {
         let (fsm, used_slicers) = {
-            let reg_to_query =
-                Self::register_to_query(*state, fsm_rep.last_state, fsms);
+            let reg_to_query = Self::register_to_query(
+                *state,
+                fsm_rep.last_state,
+                fsms.len().try_into().unwrap(),
+            );
             (
                 fsms.get(reg_to_query)
                     .expect("the register at this index does not exist"),
@@ -506,9 +509,8 @@ impl<'b, 'a> Schedule<'b, 'a> {
     fn register_to_query(
         state: u64,
         num_states: u64,
-        fsms: &[RRC<ir::Cell>],
+        num_registers: u64,
     ) -> usize {
-        let num_registers: u64 = fsms.len().try_into().unwrap();
         // num_states+1 is needed to prevent error (the done condition needs
         // to check past the number of states, i.e., will check fsm == 3 when
         // num_states == 3).

--- a/calyx-opt/src/passes/top_down_compile_control.rs
+++ b/calyx-opt/src/passes/top_down_compile_control.rs
@@ -357,7 +357,7 @@ impl<'b, 'a> Schedule<'b, 'a> {
     /// which register to query from (only relevant in the duplication case.)
     fn query_state(
         builder: &mut ir::Builder,
-        used_slicers_vec: &mut Vec<HashMap<u64, RRC<Cell>>>,
+        used_slicers_vec: &mut [HashMap<u64, RRC<Cell>>],
         fsm_rep: &FSMRepresentation,
         fsms: &[RRC<ir::Cell>],
         signal_on: &RRC<Cell>,

--- a/calyx-opt/src/passes/top_down_compile_control.rs
+++ b/calyx-opt/src/passes/top_down_compile_control.rs
@@ -495,31 +495,6 @@ impl<'b, 'a> Schedule<'b, 'a> {
         (fsms, first_state, fsm_size)
     }
 
-    /// Given the state of the FSM, returns the index for the register in `fsms``
-    /// that should be queried.
-    /// A query for each state must read from one of the `num_registers` registers.
-    /// For `r` registers and `n` states, we split into "buckets" as follows:
-    /// `{0, ... , n/r - 1} -> reg. @ index 0`,
-    /// `{n/r, ... , 2n/r - 1} -> reg. @ index 1`,
-    /// ...,
-    /// `{(r-1)n/r, ... , n - 1} -> reg. @ index n - 1`.
-    /// Note that dividing each state by the value `n/r`normalizes the state w.r.t.
-    /// the FSM register from which it should read. We can then take the floor of this value
-    /// (or, equivalently, use unsigned integer division) to get this register index.
-    fn register_to_query(
-        state: u64,
-        num_states: u64,
-        num_registers: u64,
-    ) -> usize {
-        // num_states+1 is needed to prevent error (the done condition needs
-        // to check past the number of states, i.e., will check fsm == 3 when
-        // num_states == 3).
-        let reg_to_query: usize = (state * num_registers / (num_states + 1))
-            .try_into()
-            .unwrap();
-        reg_to_query
-    }
-
     /// Implement a given [Schedule] and return the name of the [ir::Group] that
     /// implements it.
     fn realize_schedule(
@@ -704,6 +679,31 @@ impl<'b, 'a> Schedule<'b, 'a> {
 type PredEdge = (u64, ir::Guard<Nothing>);
 
 impl Schedule<'_, '_> {
+    /// Given the state of the FSM, returns the index for the register in `fsms``
+    /// that should be queried.
+    /// A query for each state must read from one of the `num_registers` registers.
+    /// For `r` registers and `n` states, we split into "buckets" as follows:
+    /// `{0, ... , n/r - 1} -> reg. @ index 0`,
+    /// `{n/r, ... , 2n/r - 1} -> reg. @ index 1`,
+    /// ...,
+    /// `{(r-1)n/r, ... , n - 1} -> reg. @ index n - 1`.
+    /// Note that dividing each state by the value `n/r`normalizes the state w.r.t.
+    /// the FSM register from which it should read. We can then take the floor of this value
+    /// (or, equivalently, use unsigned integer division) to get this register index.
+    fn register_to_query(
+        state: u64,
+        num_states: u64,
+        num_registers: u64,
+    ) -> usize {
+        // num_states+1 is needed to prevent error (the done condition needs
+        // to check past the number of states, i.e., will check fsm == 3 when
+        // num_states == 3).
+        let reg_to_query: usize = (state * num_registers / (num_states + 1))
+            .try_into()
+            .unwrap();
+        reg_to_query
+    }
+
     /// Recursively build an dynamic finite state machine represented by a [Schedule].
     /// Does the following, given an [ir::Control]:
     ///     1. If needed, add transitions from predeccesors to the current state.

--- a/calyx-opt/src/passes/top_down_compile_control.rs
+++ b/calyx-opt/src/passes/top_down_compile_control.rs
@@ -507,8 +507,9 @@ impl<'b, 'a> Schedule<'b, 'a> {
         fsms: &[RRC<ir::Cell>],
     ) -> usize {
         let num_registers: u64 = fsms.len().try_into().unwrap();
-        let reg_to_query: usize =
-            (state * num_registers / (num_states)).try_into().unwrap();
+        let reg_to_query: usize = (state * num_registers / (num_states + 1))
+            .try_into()
+            .unwrap();
         reg_to_query
     }
 

--- a/calyx-opt/src/passes/top_down_compile_control.rs
+++ b/calyx-opt/src/passes/top_down_compile_control.rs
@@ -353,6 +353,8 @@ impl<'b, 'a> Schedule<'b, 'a> {
             });
     }
 
+    /// Thin layer on top of `query_between` that first chooses
+    /// which register to query from (only relevant in the duplication case.)
     fn query_state(
         builder: &mut ir::Builder,
         used_slicers_vec: &mut Vec<HashMap<u64, RRC<Cell>>>,
@@ -384,7 +386,7 @@ impl<'b, 'a> Schedule<'b, 'a> {
         )
     }
 
-    // Queries the FSM by building a new slicer and corresponding assignments if
+    /// Queries the FSM by building a new slicer and corresponding assignments if
     /// the query hasn't yet been made. If this query has been made before with one-hot
     /// encoding, it reuses the old query, but always returns a new guard representing the query.
     fn build_query(

--- a/runt.toml
+++ b/runt.toml
@@ -258,7 +258,7 @@ fud exec --from calyx --to jq \
          --through verilog \
          --through dat \
          -s calyx.exec './target/debug/calyx' \
-         -s calyx.flags '-x tdcc:spread=duplicate -d static-promotion' \
+         -s calyx.flags '-x tdcc:duplicate-cutoff=0 -d static-promotion' \
          -s verilog.cycle_limit 500 \
          -s verilog.data {}.data \
          -s jq.expr ".memories" \

--- a/tests/passes/tdcc-duplicate/seq.expect
+++ b/tests/passes/tdcc-duplicate/seq.expect
@@ -36,16 +36,16 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
       fsm0.write_en = fsm0.out == 2'd1 & B[done] ? 1'd1;
       fsm1.in = fsm0.out == 2'd1 & B[done] ? 2'd2;
       fsm1.write_en = fsm0.out == 2'd1 & B[done] ? 1'd1;
-      fsm0.in = fsm1.out == 2'd2 & C[done] ? 2'd3;
-      fsm0.write_en = fsm1.out == 2'd2 & C[done] ? 1'd1;
-      fsm1.in = fsm1.out == 2'd2 & C[done] ? 2'd3;
-      fsm1.write_en = fsm1.out == 2'd2 & C[done] ? 1'd1;
-      tdcc[done] = fsm1.out == 2'd3 ? 1'd1;
+      fsm0.in = fsm0.out == 2'd2 & C[done] ? 2'd3;
+      fsm0.write_en = fsm0.out == 2'd2 & C[done] ? 1'd1;
+      fsm1.in = fsm0.out == 2'd2 & C[done] ? 2'd3;
+      fsm1.write_en = fsm0.out == 2'd2 & C[done] ? 1'd1;
+      tdcc[done] = fsm0.out == 2'd3 ? 1'd1;
     }
-    fsm0.in = fsm1.out == 2'd3 ? 2'd0;
-    fsm0.write_en = fsm1.out == 2'd3 ? 1'd1;
-    fsm1.in = fsm1.out == 2'd3 ? 2'd0;
-    fsm1.write_en = fsm1.out == 2'd3 ? 1'd1;
+    fsm0.in = fsm0.out == 2'd3 ? 2'd0;
+    fsm0.write_en = fsm0.out == 2'd3 ? 1'd1;
+    fsm1.in = fsm0.out == 2'd3 ? 2'd0;
+    fsm1.write_en = fsm0.out == 2'd3 ? 1'd1;
   }
   control {
     tdcc;

--- a/tests/passes/tdcc-duplicate/seq.expect
+++ b/tests/passes/tdcc-duplicate/seq.expect
@@ -36,14 +36,14 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
       fsm0.write_en = fsm0.out == 2'd1 & B[done] ? 1'd1;
       fsm1.in = fsm0.out == 2'd1 & B[done] ? 2'd2;
       fsm1.write_en = fsm0.out == 2'd1 & B[done] ? 1'd1;
-      fsm0.in = fsm0.out == 2'd2 & C[done] ? 2'd3;
-      fsm0.write_en = fsm0.out == 2'd2 & C[done] ? 1'd1;
-      fsm1.in = fsm0.out == 2'd2 & C[done] ? 2'd3;
-      fsm1.write_en = fsm0.out == 2'd2 & C[done] ? 1'd1;
-      tdcc[done] = fsm0.out == 2'd3 ? 1'd1;
+      fsm0.in = fsm1.out == 2'd2 & C[done] ? 2'd3;
+      fsm0.write_en = fsm1.out == 2'd2 & C[done] ? 1'd1;
+      fsm1.in = fsm1.out == 2'd2 & C[done] ? 2'd3;
+      fsm1.write_en = fsm1.out == 2'd2 & C[done] ? 1'd1;
+      tdcc[done] = fsm1.out == 2'd3 ? 1'd1;
     }
-    fsm0.in = fsm0.out == 2'd3 ? 2'd0;
-    fsm0.write_en = fsm0.out == 2'd3 ? 1'd1;
+    fsm0.in = fsm1.out == 2'd3 ? 2'd0;
+    fsm0.write_en = fsm1.out == 2'd3 ? 1'd1;
     fsm1.in = fsm1.out == 2'd3 ? 2'd0;
     fsm1.write_en = fsm1.out == 2'd3 ? 1'd1;
   }

--- a/tests/passes/tdcc-duplicate/seq.expect
+++ b/tests/passes/tdcc-duplicate/seq.expect
@@ -1,0 +1,53 @@
+import "primitives/core.futil";
+import "primitives/memories/comb.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    a = std_reg(2);
+    b = std_reg(2);
+    c = std_reg(2);
+    @generated fsm0 = std_reg(2);
+    @generated fsm1 = std_reg(2);
+  }
+  wires {
+    group A {
+      a.in = 2'd0;
+      a.write_en = 1'd1;
+      A[done] = a.done;
+    }
+    group B {
+      b.in = 2'd1;
+      b.write_en = 1'd1;
+      B[done] = b.done;
+    }
+    group C {
+      c.in = 2'd2;
+      c.write_en = 1'd1;
+      C[done] = c.done;
+    }
+    group tdcc {
+      A[go] = !A[done] & fsm0.out == 2'd0 ? 1'd1;
+      B[go] = !B[done] & fsm0.out == 2'd1 ? 1'd1;
+      C[go] = !C[done] & fsm1.out == 2'd2 ? 1'd1;
+      fsm0.in = fsm0.out == 2'd0 & A[done] ? 2'd1;
+      fsm0.write_en = fsm0.out == 2'd0 & A[done] ? 1'd1;
+      fsm1.in = fsm0.out == 2'd0 & A[done] ? 2'd1;
+      fsm1.write_en = fsm0.out == 2'd0 & A[done] ? 1'd1;
+      fsm0.in = fsm0.out == 2'd1 & B[done] ? 2'd2;
+      fsm0.write_en = fsm0.out == 2'd1 & B[done] ? 1'd1;
+      fsm1.in = fsm0.out == 2'd1 & B[done] ? 2'd2;
+      fsm1.write_en = fsm0.out == 2'd1 & B[done] ? 1'd1;
+      fsm0.in = fsm0.out == 2'd2 & C[done] ? 2'd3;
+      fsm0.write_en = fsm0.out == 2'd2 & C[done] ? 1'd1;
+      fsm1.in = fsm0.out == 2'd2 & C[done] ? 2'd3;
+      fsm1.write_en = fsm0.out == 2'd2 & C[done] ? 1'd1;
+      tdcc[done] = fsm0.out == 2'd3 ? 1'd1;
+    }
+    fsm0.in = fsm0.out == 2'd3 ? 2'd0;
+    fsm0.write_en = fsm0.out == 2'd3 ? 1'd1;
+    fsm1.in = fsm1.out == 2'd3 ? 2'd0;
+    fsm1.write_en = fsm1.out == 2'd3 ? 1'd1;
+  }
+  control {
+    tdcc;
+  }
+}

--- a/tests/passes/tdcc-duplicate/seq.futil
+++ b/tests/passes/tdcc-duplicate/seq.futil
@@ -1,0 +1,36 @@
+// -x tdcc:duplicate-cutoff=0 -p tdcc
+
+import "primitives/core.futil";
+import "primitives/memories/comb.futil";
+
+component main() -> () {
+  cells {
+    a = std_reg(2);
+    b = std_reg(2);
+    c = std_reg(2);
+  }
+
+  wires {
+    group A {
+      a.in = 2'd0;
+      a.write_en = 1'b1;
+      A[done] = a.done;
+    }
+
+    group B {
+      b.in = 2'd1;
+      b.write_en = 1'b1;
+      B[done] = b.done;
+    }
+
+    group C {
+      c.in = 2'd2;
+      c.write_en = 1'b1;
+      C[done] = c.done;
+    }
+  }
+
+  control {
+    seq { A; B; C; }
+  }
+}


### PR DESCRIPTION
@parthsarkar17 The runt test for duplicate FSMs was passing in the incorrect parameter. What probably happened was that it was using an old pass input parameter name that was updated but then the runt command was not updated. 

This is one of the reasons why we should have at least one snapshot test for the FSM optimizations, so things like this are easier to catch (not a big deal at all, but I think it's good practice from now on). 