### PR TITLE
[fud2] Fix planner so that it doesn't rely on the order operations are defined

### DIFF
--- a/fud2/fud-core/src/exec/planner.rs
+++ b/fud2/fud-core/src/exec/planner.rs
@@ -92,11 +92,11 @@ impl SingleOpOutputPlanner {
                     state_queue.push(op.output[0]);
                     visited[op.output[0]] = true;
                     breadcrumbs[op.output[0]] = Some(op_ref);
-                }
 
-                // Finish when we reach the goal edge.
-                if end == Destination::Op(op_ref) {
-                    break;
+                    // Finish when we reach the goal edge.
+                    if end == Destination::Op(op_ref) {
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
There was a small bug with the planner where it would stop searching when a through op appeared anywhere in the `ops` map. It really should only stop if an op is one edge away from the current state. This worked before because I guess the `ops` map happened to be ordered in such a way where things worked.

Fixes #2209.