### PR TITLE
[Cider 2 | Debugger] Preserve debugger info and command history on restart

### DIFF
--- a/interp/src/debugger/commands/core.rs
+++ b/interp/src/debugger/commands/core.rs
@@ -422,7 +422,7 @@ lazy_static! {
             CIBuilder::new().invocation("explain")
                 .description("Show examples of commands which take arguments").build(),
             CIBuilder::new().invocation("restart")
-                .description("Restart the debugger from the beginning of the execution. This will reset all breakpoints, watchpoints, and the command history").build(),
+                .description("Restart the debugger from the beginning of the execution. Command history, breakpoints, watchpoints, etc. are preserved").build(),
             // exit/quit
             CIBuilder::new().invocation("exit")
                 .invocation("quit")

--- a/interp/src/debugger/debugging_context/context.rs
+++ b/interp/src/debugger/debugging_context/context.rs
@@ -739,3 +739,9 @@ impl DebuggingContext {
         }
     }
 }
+
+impl Default for DebuggingContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/interp/src/debugger/mod.rs
+++ b/interp/src/debugger/mod.rs
@@ -6,6 +6,7 @@ mod macros;
 pub mod source;
 
 pub use debugger_core::Debugger;
+pub use debugger_core::DebuggerInfo;
 pub use debugger_core::DebuggerReturnStatus;
 pub use debugger_core::OwnedDebugger;
 pub use debugger_core::ProgramStatus;

--- a/interp/src/debugger/mod.rs
+++ b/interp/src/debugger/mod.rs
@@ -5,10 +5,8 @@ mod io_utils;
 mod macros;
 pub mod source;
 
-pub use debugger_core::Debugger;
-pub use debugger_core::DebuggerInfo;
-pub use debugger_core::DebuggerReturnStatus;
-pub use debugger_core::OwnedDebugger;
-pub use debugger_core::ProgramStatus;
+pub use debugger_core::{
+    Debugger, DebuggerInfo, DebuggerReturnStatus, OwnedDebugger, ProgramStatus,
+};
 
 pub(crate) use macros::unwrap_error_message;

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -3,7 +3,7 @@ use argh::FromArgs;
 use calyx_utils::OutputFile;
 use interp::{
     configuration,
-    debugger::{Debugger, DebuggerReturnStatus},
+    debugger::{Debugger, DebuggerInfo, DebuggerReturnStatus},
     errors::InterpreterResult,
     flatten::structures::environment::Simulator,
 };
@@ -128,13 +128,16 @@ fn main() -> InterpreterResult<()> {
             Ok(())
         }
         Command::Debug(_) => {
+            let mut info: Option<DebuggerInfo> = None;
             loop {
                 let debugger = Debugger::new(&i_ctx, &opts.data_file)?;
 
-                let result = debugger.main_loop()?;
+                let result = debugger.main_loop(info)?;
                 match result {
                     DebuggerReturnStatus::Exit => break,
-                    DebuggerReturnStatus::Restart => continue,
+                    DebuggerReturnStatus::Restart(new_info) => {
+                        info = Some(*new_info);
+                    }
                 }
             }
             Ok(())


### PR DESCRIPTION
A small patch that makes the new `restart` command preserve the watchpoints, breakpoints, and command history of the debugger rather than fully resetting it.