### PR TITLE
[Cider 2] Fix explain string + add little message on repeated command errors

### DIFF
--- a/interp/src/debugger/commands/core.rs
+++ b/interp/src/debugger/commands/core.rs
@@ -380,7 +380,7 @@ lazy_static! {
             // print-state
             CIBuilder::new().invocation("print-state")
                 .description("Print the internal state of the target cell. Takes an optional print code before the target")
-                .usage("> watch after GROUP with print-state \\s mem").build(),
+                .usage("> print-state \\s mem").build(),
             // watch
             CIBuilder::new().invocation("watch")
                 .description("Watch a given group with a print statement. Takes an optional position (before/after)")

--- a/interp/src/debugger/debugger_core.rs
+++ b/interp/src/debugger/debugger_core.rs
@@ -207,15 +207,29 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
             "r".underline()
         );
 
+        let mut err_count = 0_u8;
+
         while !self.interpreter.is_done() {
             let comm = input_stream.next_command();
             let comm = match comm {
-                Ok(c) => c,
+                Ok(c) => {
+                    err_count = 0;
+                    c
+                }
                 Err(e) => match *e {
                     InterpreterError::InvalidCommand(_)
                     | InterpreterError::UnknownCommand(_)
                     | InterpreterError::ParseError(_) => {
                         println!("Error: {}", e.red().bold());
+                        err_count += 1;
+                        if err_count == 3 {
+                            println!(
+                                "Type {} for a list of commands or {} for usage examples.",
+                                "help".yellow().bold().underline(),
+                                "explain".yellow().bold().underline()
+                            );
+                            err_count = 0;
+                        }
                         continue;
                     }
                     _ => return Err(e),

--- a/interp/src/debugger/debugger_core.rs
+++ b/interp/src/debugger/debugger_core.rs
@@ -289,7 +289,7 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
                 }
 
                 Command::Explain => {
-                    print!("{}", Command::get_explain_string().blue())
+                    print!("{}", Command::get_explain_string())
                 }
 
                 Command::Restart => {
@@ -342,7 +342,7 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
                     return Ok(DebuggerReturnStatus::Exit);
                 }
                 Command::Explain => {
-                    print!("{}", Command::get_explain_string().blue().bold())
+                    print!("{}", Command::get_explain_string())
                 }
                 Command::Restart => {
                     return Ok(DebuggerReturnStatus::Restart(Box::new(


### PR DESCRIPTION
tiny patch to fix some printing and add a (hopefully helpful) message when an invalid command is given 3 times in a row