### PR TITLE
[Cider2] Add a magic number to the data dump serialization

### DIFF
--- a/interp/tests/unit/uninitialized-port-returns-zero.expect
+++ b/interp/tests/unit/uninitialized-port-returns-zero.expect
@@ -1,5 +1,3 @@
 ---STDERR---
 Error: Attempted to write an undefined value to register or memory named "main.reg0"
-thread 'main' panicked at interp/src/serialization/data_dump.rs:242:48:
-called `Result::unwrap()` on an `Err` value: Error { kind: UnexpectedEof, message: "failed to fill whole buffer" }
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Error: Input is not a valid data dump


### PR DESCRIPTION
A simple fix to make the error messages better for the data converter. Particularly it should no longer fail by trying to allocate extremely large amounts of memory when given garbage input, which was generally confusing. Also added a few more error types to make failures a little more understandable when they happen. 

I reserved the first 4 bytes for the magic number and used the remaining 4 for the header length. Previously all 8 bytes were for the header length so this does limit the max header size, but if we find ourselves with multiple gigs worth of header information alone things have probably gone wrong already. That said, it wouldn't be hard to extend in the future if the need arises.