### PR TITLE
Update Debugging Section with `fud2`

### DIFF
--- a/docs/debug/debug.md
+++ b/docs/debug/debug.md
@@ -123,7 +123,9 @@ Suppose that we want to make sure that `let0` is correctly performing its
 computation.
 We can generate the control FSM for the program using:
 
-      futil <filename> -p top-down-cc
+```
+fud2 <code.futil> -s sim.data=data.json --through icarus -o trace.vcd
+```
 
 This generates a Calyx program with several new groups.
 We want to look for groups with the prefix `tdcc` which look something like


### PR DESCRIPTION
I have replaced the out-dated `futil` command with the `fud2` program, using the example @sampsyo shared in Zulip. 

This whole file needs to have its `futil` invocations replaced with their equivalent `fud2` replacements, but I am not knowledgeable enough to make all the necessary changes. I hope this PR centralizes all the changes that are needed for this file.