### PR TITLE
[Cider2] Fixed point data initialization and serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,8 @@ dependencies = [
  "interp",
  "itertools 0.11.0",
  "num-bigint",
+ "num-rational",
+ "num-traits",
  "proptest",
  "serde",
  "serde_json",
@@ -1881,11 +1883,10 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1894,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -2945,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -2966,9 +2967,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -1892,7 +1892,7 @@ impl<C: AsRef<Context> + Clone> Simulator<C> {
                             } else {
                                 MemoryDeclaration::new_bitnum(
                                     name,
-                                    *width as usize,
+                                    *width,
                                     dims.as_serializing_dim(),
                                     false,
                                 )
@@ -1900,7 +1900,7 @@ impl<C: AsRef<Context> + Clone> Simulator<C> {
                         } else {
                             MemoryDeclaration::new_bitnum(
                                 name,
-                                *width as usize,
+                                *width,
                                 dims.as_serializing_dim(),
                                 false,
                             )
@@ -1921,7 +1921,7 @@ impl<C: AsRef<Context> + Clone> Simulator<C> {
                     if dump_registers {
                         dump.push_reg(
                             name,
-                            *width as usize,
+                            *width,
                             self.env.cells[cell_index]
                                 .unwrap_primitive()
                                 .dump_memory_state()

--- a/interp/src/flatten/structures/indexed_map.rs
+++ b/interp/src/flatten/structures/indexed_map.rs
@@ -143,7 +143,7 @@ where
         Self::new()
     }
 }
-
+#[allow(dead_code)]
 pub struct IndexedMapRangeIterator<'range, 'data, K, D>
 where
     K: IndexRef + PartialOrd,

--- a/interp/src/serialization/data_dump.rs
+++ b/interp/src/serialization/data_dump.rs
@@ -48,12 +48,12 @@ impl From<(usize, usize, usize, usize)> for Dimensions {
 pub enum FormatInfo {
     Bitnum {
         signed: bool,
-        width: usize,
+        width: u32,
     },
     Fixed {
         signed: bool,
-        int_width: usize,
-        frac_width: usize,
+        int_width: u32,
+        frac_width: u32,
     },
 }
 
@@ -65,7 +65,7 @@ impl FormatInfo {
         }
     }
 
-    pub fn width(&self) -> usize {
+    pub fn width(&self) -> u32 {
         match self {
             FormatInfo::Bitnum { width, .. } => *width,
             FormatInfo::Fixed {
@@ -87,7 +87,7 @@ pub struct MemoryDeclaration {
 impl MemoryDeclaration {
     pub fn new_bitnum(
         name: String,
-        width: usize,
+        width: u32,
         dimensions: Dimensions,
         signed: bool,
     ) -> Self {
@@ -102,8 +102,8 @@ impl MemoryDeclaration {
         name: String,
         dimensions: Dimensions,
         signed: bool,
-        int_width: usize,
-        frac_width: usize,
+        int_width: u32,
+        frac_width: u32,
     ) -> Self {
         assert!(int_width + frac_width > 0, "width must be greater than 0");
 
@@ -135,10 +135,10 @@ impl MemoryDeclaration {
     }
 
     pub fn byte_count(&self) -> usize {
-        self.format.width().div_ceil(8) * self.dimensions.size()
+        self.format.width().div_ceil(8) as usize * self.dimensions.size()
     }
 
-    pub fn width(&self) -> usize {
+    pub fn width(&self) -> u32 {
         self.format.width()
     }
 
@@ -208,7 +208,7 @@ impl DataDump {
     pub fn push_reg<T: IntoIterator<Item = u8>>(
         &mut self,
         name: String,
-        width: usize,
+        width: u32,
         data: T,
     ) {
         let declaration = MemoryDeclaration::new_bitnum(
@@ -389,7 +389,7 @@ mod tests {
     use proptest::prelude::*;
 
     prop_compose! {
-        fn arb_memory_declaration()(name in any::<String>(), signed in any::<bool>(), width in 1_usize..=256, size in 1_usize..=500) -> MemoryDeclaration {
+        fn arb_memory_declaration()(name in any::<String>(), signed in any::<bool>(), width in 1_u32..=256, size in 1_usize..=500) -> MemoryDeclaration {
             MemoryDeclaration::new_bitnum(name.to_string(), width, Dimensions::D1(size), signed)
         }
     }
@@ -429,7 +429,7 @@ mod tests {
             // produced from the memory primitive to not match the one
             // serialized into it in the first place
             for mem in &header.memories {
-                let bytes_per_val = mem.width().div_ceil(8);
+                let bytes_per_val = mem.width().div_ceil(8) as usize;
                 let rem = mem.width() % 8;
                 let mask = if rem != 0 { 255u8 >> (8 - rem) } else { 255_u8 };
 

--- a/interp/src/serialization/data_dump.rs
+++ b/interp/src/serialization/data_dump.rs
@@ -475,7 +475,7 @@ mod tests {
         #[test]
         fn comb_roundtrip(dump in arb_data_dump()) {
             for mem in &dump.header.memories {
-                let memory_prim = CombMemD1::new_with_init(GlobalPortIdx::new(0), mem.width() as u32, false, mem.size(), dump.get_data(&mem.name).unwrap());
+                let memory_prim = CombMemD1::new_with_init(GlobalPortIdx::new(0), mem.width(), false, mem.size(), dump.get_data(&mem.name).unwrap());
                 let data = memory_prim.dump_data();
                 prop_assert_eq!(dump.get_data(&mem.name).unwrap(), data);
             }
@@ -484,7 +484,7 @@ mod tests {
         #[test]
         fn seq_roundtrip(dump in arb_data_dump()) {
             for mem in &dump.header.memories {
-                let memory_prim = SeqMemD1::new_with_init(GlobalPortIdx::new(0), mem.width() as u32, false, mem.size(), dump.get_data(&mem.name).unwrap());
+                let memory_prim = SeqMemD1::new_with_init(GlobalPortIdx::new(0), mem.width(), false, mem.size(), dump.get_data(&mem.name).unwrap());
                 let data = memory_prim.dump_data();
                 prop_assert_eq!(dump.get_data(&mem.name).unwrap(), data);
             }

--- a/tools/cider-data-converter/Cargo.toml
+++ b/tools/cider-data-converter/Cargo.toml
@@ -15,6 +15,8 @@ itertools = { workspace = true }
 argh = { workspace = true }
 thiserror = "1.0.59"
 num-bigint = { version = "0.4.6" }
+num-rational = { version = "0.4.2" }
+num-traits = { version = "0.2.19" }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/tools/cider-data-converter/src/converter.rs
+++ b/tools/cider-data-converter/src/converter.rs
@@ -182,6 +182,7 @@ fn unroll_float(
             let new = val * w.to_f64().unwrap();
             let new = new.round();
 
+            // this is, to put it charitably, weapons grade silly
             BigInt::from_str_radix(&format!("{:.0}", new), 10).unwrap()
         } else if frac_log.is_none() {
             panic!("Number cannot be represented as a fixed-point number");

--- a/tools/cider-data-converter/src/json_data.rs
+++ b/tools/cider-data-converter/src/json_data.rs
@@ -40,10 +40,30 @@ impl FormatInfo {
         }
     }
 
-    fn is_fixedpt(&self) -> bool {
+    pub fn is_fixedpt(&self) -> bool {
         self.int_width.is_some() && self.frac_width.is_some()
             || self.width.is_some() && self.frac_width.is_some()
             || self.width.is_some() && self.int_width.is_some()
+    }
+
+    pub fn int_width(&self) -> Option<u32> {
+        if self.int_width.is_some() {
+            self.int_width
+        } else if self.width.is_some() && self.frac_width.is_some() {
+            Some(self.width.unwrap() - self.frac_width.unwrap())
+        } else {
+            None
+        }
+    }
+
+    pub fn frac_width(&self) -> Option<u32> {
+        if self.frac_width.is_some() {
+            self.frac_width
+        } else if self.int_width.is_some() && self.width.is_some() {
+            Some(self.width.unwrap() - self.int_width.unwrap())
+        } else {
+            None
+        }
     }
 
     pub fn as_data_dump_format(&self) -> interp::serialization::FormatInfo {

--- a/tools/cider-data-converter/src/json_data.rs
+++ b/tools/cider-data-converter/src/json_data.rs
@@ -20,17 +20,17 @@ pub struct FormatInfo {
     pub is_signed: bool,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub width: Option<u64>,
+    pub width: Option<u32>,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub int_width: Option<u64>,
+    pub int_width: Option<u32>,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub frac_width: Option<u64>,
+    pub frac_width: Option<u32>,
 }
 
 impl FormatInfo {
-    pub fn get_width(&self) -> u64 {
+    pub fn get_width(&self) -> u32 {
         if let Some(w) = self.width {
             w
         } else if self.int_width.is_some() && self.frac_width.is_some() {
@@ -50,7 +50,7 @@ impl FormatInfo {
         match &self.numeric_type {
             NumericType::Bitnum => interp::serialization::FormatInfo::Bitnum {
                 signed: self.is_signed,
-                width: self.width.unwrap() as usize,
+                width: self.width.unwrap(),
             },
             NumericType::Fixed => {
                 let (int_width, frac_width) = if self.int_width.is_some()
@@ -75,8 +75,8 @@ impl FormatInfo {
 
                 interp::serialization::FormatInfo::Fixed {
                     signed: self.is_signed,
-                    int_width: int_width as usize,
-                    frac_width: frac_width as usize,
+                    int_width,
+                    frac_width,
                 }
             }
         }

--- a/tools/cider-data-converter/src/main.rs
+++ b/tools/cider-data-converter/src/main.rs
@@ -63,6 +63,11 @@ struct Opts {
     #[argh(option, short = 'o')]
     output_path: Option<PathBuf>,
 
+    /// whether to round un-representable floating point instantiations rather than
+    /// throwing an error
+    #[argh(switch, short = 'r', long = "round-float")]
+    round_float: bool,
+
     /// optional specification of what action to perform. Can be "cider" or
     /// "json". If not provided, the converter will try to guess based on file names
     #[argh(option, short = 't', long = "to")]
@@ -108,7 +113,7 @@ fn main() -> Result<(), CiderDataConverterError> {
             Action::ToDataDump => {
                 let parsed_json: JsonData =
                     serde_json::from_reader(&mut input)?;
-                converter::convert_to_data_dump(&parsed_json)
+                converter::convert_to_data_dump(&parsed_json, opts.round_float)
                     .serialize(&mut output)?;
             }
             Action::ToJson => {


### PR DESCRIPTION
Part of #1913.
Closes #2219.

This ended up being a real headache but I think I have things working enough. There are some glaring inefficiencies in the fixed point conversion code but for the time being I am not overly concerned. For the most part I tried to replicate the original `fud` conversion but did deviate when it comes to rounding with the more standard approach (insofar as I understand it). This doesn't yet adjust the `fud2` path to include the rounding flag, that'll need to come later.