### PR TITLE
[Cider2] Add missing Fixed Prims

### DIFF
--- a/interp/src/flatten/flat_ir/cell_prototype.rs
+++ b/interp/src/flatten/flat_ir/cell_prototype.rs
@@ -64,7 +64,7 @@ pub enum SingleWidthType {
 
 /// An enum for encoding FP primitives operator types
 #[derive(Debug, Clone)]
-pub enum FPType {
+pub enum FXType {
     Add,
     Sub,
     Mult,
@@ -196,7 +196,7 @@ pub enum CellPrototype {
         width: ParamWidth,
     },
     FixedPoint {
-        op: FPType,
+        op: FXType,
         width: ParamWidth,
         int_width: ParamWidth,
         frac_width: ParamWidth,
@@ -313,9 +313,9 @@ impl CellPrototype {
 
                     Self::FixedPoint {
                         op: if n == "std_fp_add" {
-                            FPType::Add
+                            FXType::Add
                         } else {
-                            FPType::SignedAdd
+                            FXType::SignedAdd
                         },
                         width: width.try_into().unwrap(),
                         int_width: int_width.try_into().unwrap(),
@@ -331,9 +331,9 @@ impl CellPrototype {
 
                     Self::FixedPoint {
                         op: if n == "std_fp_sub" {
-                            FPType::Sub
+                            FXType::Sub
                         } else {
-                            FPType::SignedSub
+                            FXType::SignedSub
                         },
                         width: width.try_into().unwrap(),
                         int_width: int_width.try_into().unwrap(),
@@ -380,7 +380,7 @@ impl CellPrototype {
                     ];
 
                     Self::FixedPoint {
-                        op: FPType::Sqrt,
+                        op: FXType::Sqrt,
                         width: width.try_into().unwrap(),
                         int_width: int_width.try_into().unwrap(),
                         frac_width: frac_width.try_into().unwrap(),
@@ -397,10 +397,10 @@ impl CellPrototype {
 
                     Self::FixedPoint {
                         op: match n {
-                            "std_fp_mult_pipe" => FPType::Mult,
-                            "std_fp_smult_pipe" => FPType::SignedMult,
-                            "std_fp_div_pipe" => FPType::Div,
-                            _ => FPType::SignedDiv,
+                            "std_fp_mult_pipe" => FXType::Mult,
+                            "std_fp_smult_pipe" => FXType::SignedMult,
+                            "std_fp_div_pipe" => FXType::Div,
+                            _ => FXType::SignedDiv,
                         },
                         width: width.try_into().unwrap(),
                         int_width: int_width.try_into().unwrap(),
@@ -484,11 +484,11 @@ impl CellPrototype {
 
                     Self::FixedPoint {
                         op: if n == "std_fp_gt" {
-                            FPType::Gt
+                            FXType::Gt
                         } else if n == "std_fp_sgt" {
-                            FPType::SignedGt
+                            FXType::SignedGt
                         } else {
-                            FPType::SignedLt
+                            FXType::SignedLt
                         },
                         width: width.try_into().unwrap(),
                         int_width: int_width.try_into().unwrap(),

--- a/interp/src/flatten/primitives/builder.rs
+++ b/interp/src/flatten/primitives/builder.rs
@@ -4,7 +4,7 @@ use super::{combinational::*, stateful::*, Primitive};
 use crate::{
     flatten::{
         flat_ir::{
-            cell_prototype::{CellPrototype, MemType, SingleWidthType},
+            cell_prototype::{CellPrototype, FXType, MemType, SingleWidthType},
             prelude::{CellInfo, GlobalPortIdx},
         },
         structures::context::Context,
@@ -108,11 +108,26 @@ pub fn build_primitive(
             base_port, *start_idx, *end_idx, *out_width,
         )),
         CellPrototype::FixedPoint {
-            op: _,
-            width: _,
-            int_width: _,
-            frac_width: _,
-        } => todo!("Fixed point implementations not available yet"),
+            op: op,
+            width: width,
+            int_width: int_width,
+            frac_width: frac_width,
+        } => match op {
+            FXType::Add | FXType::SignedAdd => Box::new(StdAdd::new(base_port)),
+            FXType::Sub | FXType::SignedSub => Box::new(StdSub::new(base_port)),
+            FXType::Mult => todo!(),
+            FXType::Div => todo!(),
+            FXType::SignedMult => {
+                todo!()
+            }
+            FXType::SignedDiv => {
+                todo!()
+            }
+            FXType::Gt => Box::new(StdGt::new(base_port)),
+            FXType::SignedGt => Box::new(StdSgt::new(base_port)),
+            FXType::SignedLt => Box::new(StdSlt::new(base_port)),
+            FXType::Sqrt => todo!(),
+        },
         CellPrototype::Slice {
             in_width: _, // Not actually needed, should probably remove
             out_width,

--- a/interp/src/flatten/primitives/builder.rs
+++ b/interp/src/flatten/primitives/builder.rs
@@ -108,25 +108,35 @@ pub fn build_primitive(
             base_port, *start_idx, *end_idx, *out_width,
         )),
         CellPrototype::FixedPoint {
-            op: op,
-            width: width,
-            int_width: int_width,
-            frac_width: frac_width,
+            op,
+            width,
+            int_width,
+            frac_width,
         } => match op {
             FXType::Add | FXType::SignedAdd => Box::new(StdAdd::new(base_port)),
             FXType::Sub | FXType::SignedSub => Box::new(StdSub::new(base_port)),
-            FXType::Mult => todo!(),
-            FXType::Div => todo!(),
-            FXType::SignedMult => {
-                todo!()
-            }
-            FXType::SignedDiv => {
-                todo!()
-            }
+            FXType::Mult | FXType::SignedMult => Box::new(
+                FxpMultPipe::<2>::new(base_port, *int_width, *frac_width),
+            ),
+            FXType::Div => Box::new(FxpDivPipe::<2, false>::new(
+                base_port,
+                *int_width,
+                *frac_width,
+            )),
+
+            FXType::SignedDiv => Box::new(FxpDivPipe::<2, true>::new(
+                base_port,
+                *int_width,
+                *frac_width,
+            )),
             FXType::Gt => Box::new(StdGt::new(base_port)),
             FXType::SignedGt => Box::new(StdSgt::new(base_port)),
             FXType::SignedLt => Box::new(StdSlt::new(base_port)),
-            FXType::Sqrt => todo!(),
+            FXType::Sqrt => Box::new(Sqrt::<true>::new(
+                base_port,
+                *width,
+                Some(*frac_width),
+            )),
         },
         CellPrototype::Slice {
             in_width: _, // Not actually needed, should probably remove

--- a/interp/src/flatten/primitives/stateful/math.rs
+++ b/interp/src/flatten/primitives/stateful/math.rs
@@ -320,3 +320,255 @@ impl<const IS_FIXED_POINT: bool> Primitive for Sqrt<IS_FIXED_POINT> {
         Ok(out_changed | done_signal)
     }
 }
+
+pub struct FxpMultPipe<const DEPTH: usize> {
+    base_port: GlobalPortIdx,
+    pipeline: ShiftBuffer<(PortValue, PortValue), DEPTH>,
+    current_output: PortValue,
+    int_width: u32,
+    frac_width: u32,
+    done_is_high: bool,
+}
+
+impl<const DEPTH: usize> FxpMultPipe<DEPTH> {
+    declare_ports![_CLK: 0, RESET: 1, GO: 2, LEFT: 3, RIGHT: 4, OUT: 5, DONE: 6];
+    pub fn new(
+        base_port: GlobalPortIdx,
+        int_width: u32,
+        frac_width: u32,
+    ) -> Self {
+        Self {
+            base_port,
+            pipeline: ShiftBuffer::default(),
+            current_output: PortValue::new_cell(Value::zeroes(
+                int_width + frac_width,
+            )),
+            int_width,
+            frac_width,
+            done_is_high: false,
+        }
+    }
+}
+
+impl<const DEPTH: usize> Primitive for FxpMultPipe<DEPTH> {
+    fn exec_comb(&self, port_map: &mut PortMap) -> UpdateResult {
+        ports![&self.base_port; out: Self::OUT, done: Self::DONE];
+
+        let out_changed =
+            port_map.write_exact_unchecked(out, self.current_output.clone());
+
+        let done_signal = port_map.insert_val(
+            done,
+            AssignedValue::cell_value(if self.done_is_high {
+                Value::bit_high()
+            } else {
+                Value::bit_low()
+            }),
+        )?;
+
+        Ok(out_changed | done_signal)
+    }
+
+    fn exec_cycle(&mut self, port_map: &mut PortMap) -> UpdateResult {
+        ports![&self.base_port;
+            left: Self::LEFT,
+            right: Self::RIGHT,
+            reset: Self::RESET,
+            go: Self::GO,
+            out: Self::OUT,
+            done: Self::DONE
+        ];
+
+        if port_map[reset].as_bool().unwrap_or_default() {
+            self.current_output = PortValue::new_cell(Value::zeroes(
+                self.int_width + self.frac_width,
+            ));
+            self.done_is_high = false;
+            self.pipeline.reset();
+        } else if port_map[go].as_bool().unwrap_or_default() {
+            let output = self
+                .pipeline
+                .shift(Some((port_map[left].clone(), port_map[right].clone())));
+            if let Some((l, r)) = output {
+                let out_val = l.as_option().and_then(|left| {
+                    r.as_option().map(|right| {
+                        Value::from(
+                            left.val().as_unsigned()
+                                * right.val().as_unsigned(),
+                            2 * (self.frac_width + self.int_width),
+                        )
+                        .slice_out(
+                            self.frac_width as usize,
+                            (2 * self.frac_width + self.int_width - 1) as usize,
+                        )
+                    })
+                });
+                self.current_output =
+                    out_val.map_or(PortValue::new_undef(), PortValue::new_cell);
+                self.done_is_high = true;
+            } else {
+                self.current_output = PortValue::new_cell(Value::zeroes(
+                    self.frac_width + self.int_width,
+                ));
+                self.done_is_high = false;
+            }
+        } else {
+            self.pipeline.reset();
+            self.done_is_high = false;
+        }
+
+        let done_signal = port_map.insert_val(
+            done,
+            AssignedValue::cell_value(if self.done_is_high {
+                Value::bit_high()
+            } else {
+                Value::bit_low()
+            }),
+        )?;
+
+        Ok(
+            port_map.write_exact_unchecked(out, self.current_output.clone())
+                | done_signal,
+        )
+    }
+}
+
+pub struct FxpDivPipe<const DEPTH: usize, const SIGNED: bool> {
+    base_port: GlobalPortIdx,
+    pipeline: ShiftBuffer<(PortValue, PortValue), DEPTH>,
+    output_quotient: PortValue,
+    output_remainder: PortValue,
+    int_width: u32,
+    frac_width: u32,
+    done_is_high: bool,
+}
+
+impl<const DEPTH: usize, const SIGNED: bool> FxpDivPipe<DEPTH, SIGNED> {
+    declare_ports![_CLK: 0, RESET: 1, GO: 2, LEFT: 3, RIGHT: 4, OUT_QUOTIENT: 5, OUT_REMAINDER: 6, DONE: 7];
+    pub fn new(
+        base_port: GlobalPortIdx,
+        int_width: u32,
+        frac_width: u32,
+    ) -> Self {
+        Self {
+            base_port,
+            pipeline: ShiftBuffer::default(),
+            output_quotient: PortValue::new_cell(Value::zeroes(int_width)),
+            output_remainder: PortValue::new_cell(Value::zeroes(
+                frac_width + int_width,
+            )),
+            int_width,
+            frac_width,
+            done_is_high: false,
+        }
+    }
+
+    fn width(&self) -> u32 {
+        self.int_width + self.frac_width
+    }
+}
+
+impl<const DEPTH: usize, const SIGNED: bool> Primitive
+    for FxpDivPipe<DEPTH, SIGNED>
+{
+    fn exec_comb(&self, port_map: &mut PortMap) -> UpdateResult {
+        ports![&self.base_port;
+               out_quot: Self::OUT_QUOTIENT,
+               out_rem: Self::OUT_REMAINDER,
+               done: Self::DONE];
+
+        let quot_changed = port_map
+            .write_exact_unchecked(out_quot, self.output_quotient.clone());
+        let rem_changed = port_map
+            .write_exact_unchecked(out_rem, self.output_remainder.clone());
+
+        let done_signal = port_map.set_done(done, self.done_is_high)?;
+
+        Ok(quot_changed | rem_changed | done_signal)
+    }
+
+    fn exec_cycle(&mut self, port_map: &mut PortMap) -> UpdateResult {
+        ports![&self.base_port;
+            left: Self::LEFT,
+            right: Self::RIGHT,
+            reset: Self::RESET,
+            go: Self::GO,
+            out_quot: Self::OUT_QUOTIENT,
+            out_rem: Self::OUT_REMAINDER,
+            done: Self::DONE
+        ];
+
+        if port_map[reset].as_bool().unwrap_or_default() {
+            self.output_quotient =
+                PortValue::new_cell(Value::zeroes(self.width()));
+            self.done_is_high = false;
+            self.pipeline.reset();
+        } else if port_map[go].as_bool().unwrap_or_default() {
+            let output = self
+                .pipeline
+                .shift(Some((port_map[left].clone(), port_map[right].clone())));
+            if let Some((l, r)) = output {
+                let out_val = l.as_option().and_then(|left| {
+                    r.as_option().map(|right| {
+                        (
+                            Value::from::<InputNumber, _>(
+                                if !SIGNED {
+                                    ((left.val().as_unsigned()
+                                        << self.frac_width as usize)
+                                        / right.val().as_unsigned())
+                                    .into()
+                                } else {
+                                    ((left.val().as_signed()
+                                        << self.frac_width as usize)
+                                        / right.val().as_signed())
+                                    .into()
+                                },
+                                self.width(),
+                            ),
+                            Value::from::<InputNumber, _>(
+                                if !SIGNED {
+                                    (left
+                                        .val()
+                                        .as_unsigned()
+                                        .rem_euclid(right.val().as_unsigned()))
+                                    .into()
+                                } else {
+                                    (left.val().as_signed()
+                                        - right.val().as_signed()
+                                            * floored_division(
+                                                &left.val().as_signed(),
+                                                &right.val().as_signed(),
+                                            ))
+                                    .into()
+                                },
+                                self.width(),
+                            ),
+                        )
+                    })
+                });
+                (self.output_quotient, self.output_remainder) = out_val.map_or(
+                    (PortValue::new_undef(), PortValue::new_undef()),
+                    |(q, r)| (PortValue::new_cell(q), PortValue::new_cell(r)),
+                );
+                self.done_is_high = true;
+            } else {
+                self.output_quotient =
+                    PortValue::new_cell(Value::zeroes(self.width()));
+                self.output_remainder =
+                    PortValue::new_cell(Value::zeroes(self.width()));
+                self.done_is_high = false;
+            }
+        } else {
+            self.pipeline.reset();
+            self.done_is_high = false;
+        }
+
+        let done_signal = port_map.set_done(done, self.done_is_high)?;
+        let quot_changed = port_map
+            .write_exact_unchecked(out_quot, self.output_quotient.clone());
+        let rem_changed = port_map
+            .write_exact_unchecked(out_rem, self.output_remainder.clone());
+
+        Ok(quot_changed | rem_changed | done_signal)
+    }
+}

--- a/interp/src/flatten/primitives/stateful/math.rs
+++ b/interp/src/flatten/primitives/stateful/math.rs
@@ -399,7 +399,7 @@ impl<const DEPTH: usize> Primitive for FxpMultPipe<DEPTH> {
                         )
                         .slice_out(
                             self.frac_width as usize,
-                            (2 * self.frac_width + self.int_width - 1) as usize,
+                            (2 * self.frac_width + self.int_width) as usize,
                         )
                     })
                 });
@@ -444,7 +444,7 @@ pub struct FxpDivPipe<const DEPTH: usize, const SIGNED: bool> {
 }
 
 impl<const DEPTH: usize, const SIGNED: bool> FxpDivPipe<DEPTH, SIGNED> {
-    declare_ports![_CLK: 0, RESET: 1, GO: 2, LEFT: 3, RIGHT: 4, OUT_QUOTIENT: 5, OUT_REMAINDER: 6, DONE: 7];
+    declare_ports![_CLK: 0, RESET: 1, GO: 2, LEFT: 3, RIGHT: 4, OUT_REMAINDER: 5, OUT_QUOTIENT: 6, DONE: 7];
     pub fn new(
         base_port: GlobalPortIdx,
         int_width: u32,

--- a/tools/cider-data-converter/src/main.rs
+++ b/tools/cider-data-converter/src/main.rs
@@ -72,6 +72,11 @@ struct Opts {
     /// "json". If not provided, the converter will try to guess based on file names
     #[argh(option, short = 't', long = "to")]
     action: Option<Action>,
+
+    /// whether to use quotes around floating point numbers in the output. This
+    /// exists solely for backwards compatibility with the old display format.
+    #[argh(switch, long = "legacy-quotes")]
+    use_quotes: bool,
 }
 
 fn main() -> Result<(), CiderDataConverterError> {
@@ -119,7 +124,10 @@ fn main() -> Result<(), CiderDataConverterError> {
             Action::ToJson => {
                 let data_dump =
                     serialization::DataDump::deserialize(&mut input)?;
-                let json_data = converter::convert_from_data_dump(&data_dump);
+                let json_data = converter::convert_from_data_dump(
+                    &data_dump,
+                    opts.use_quotes,
+                );
                 writeln!(
                     &mut output,
                     "{}",


### PR DESCRIPTION
Part of #1913. 

Adds the missing fixed point primitives from the std library. Dose a bit of extra work to make the printing compatible with the existing expects but it still doesn't match the printing in all cases since I'm currently using floats to print the values while the original fud printouts use `Decimal` with an aggressive 64 digits of precision. If we wanted to match that, I would probably switch to use `fraction::Decimal` since `BigRational` doesn't seem to offer a way to format things as decimals beyond just jumping to an `f64` as I currently am.

Also for reasons that escape me the current expect files want fixed point printouts to be surrounded by quotes so there's an extra flag `--legacy-quotes` for the data converter now to do this. Still need to adjust the `fud2` paths to allow for flags to be passed to the converter.