### PR TITLE
Multidimensional Memory in calyx-py

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -447,7 +447,7 @@ class ComponentBuilder:
             is_ref,
         )
     
-    def comb_mem_d1(
+    def comb_mem_dn(
         self,
         name: str,
         bitwidth: int,
@@ -456,7 +456,7 @@ class ComponentBuilder:
         is_external: bool = False,
         is_ref: bool = False,
     ) -> CellBuilder:
-        """Generate a StdMemD1 cell."""
+        """Generate a StdMemD1 cell that abstracts to an n-dimensional memory."""
         self.prog.import_("primitives/memories/comb.futil")
         prod = 1
         for l in lens:
@@ -509,7 +509,7 @@ class ComponentBuilder:
         is_external: bool = False,
         is_ref: bool=False
     ) -> CellBuilder:
-        """Generate a SeqMemD1 cell that abstracts to a memory block of n dimensions"""
+        """Generate a SeqMemD1 cell that abstracts to an n-dimensional memory."""
         self.prog.import_("primitives/memories/seq.futil")
         prod = 1
         for l in lens:

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -515,7 +515,7 @@ class ComponentBuilder:
         for l in lens:
             prod *= l
         return self.cell(
-            name, ast.Stdlib.seq_mem_d1(bitwidth, lens, idx_size), is_external, is_ref
+            name, ast.Stdlib.seq_mem_d1(bitwidth, prod, idx_size), is_external, is_ref
         )
 
     def binary(
@@ -935,7 +935,7 @@ class ComponentBuilder:
         return latch_grp
 
     def flatten_idx(self, dims, indices):
-        """Translate an n-dimensional index into a corresponding"""
+        """Translate an n-dimensional index into a corresponding 1d index"""
         assert len(dims) == len(indices)
         i = len(indices) - 1
         prod = 1


### PR DESCRIPTION
This is a little abstraction that I thought could prove useful for the eDSL.

We have 1D memory and 2D memory, both in pure Calyx and in calyx-py. However, I thoguht it may be interesting to integrate multidimensional memories, provided there was a clean way to represent them in Calyx. 

This version represents any 'n-d memory block' as a 1-dimensional memory cell, and introduces a simple Python function for translating a series of indices (e.g. `mem_rep[i][j][k]`) into a corresponding index into the 1d representation. This support extends to both sequential and combinational memory.