### PR TITLE
[Cider2] Watchpoint fixes

### DIFF
--- a/interp/src/debugger/commands/command_parser.rs
+++ b/interp/src/debugger/commands/command_parser.rs
@@ -203,6 +203,18 @@ impl CommandParser {
         ))
     }
 
+    fn enable_watch(input: Node) -> ParseResult<Command> {
+        Ok(match_nodes!(input.into_children();
+                [brk_id(br)..] => Command::EnableWatch(br.collect())
+        ))
+    }
+
+    fn disable_watch(input: Node) -> ParseResult<Command> {
+        Ok(match_nodes!(input.into_children();
+                [brk_id(br)..] => Command::DisableWatch(br.collect())
+        ))
+    }
+
     fn explain(_input: Node) -> ParseResult<Command> {
         Ok(Command::Explain)
     }
@@ -261,6 +273,8 @@ impl CommandParser {
             [info_watch(iw), EOI(_)] => iw,
             [delete(del), EOI(_)] => del,
             [delete_watch(del), EOI(_)] => del,
+            [enable_watch(ew), EOI(_)] => ew,
+            [disable_watch(dw), EOI(_)] => dw,
             [enable(e), EOI(_)] => e,
             [disable(dis), EOI(_)] => dis,
             [exit(exit), EOI(_)] => exit,

--- a/interp/src/debugger/commands/commands.pest
+++ b/interp/src/debugger/commands/commands.pest
@@ -59,8 +59,11 @@ delete = { (^"delete" | ^"del") ~ brk_id+ }
 
 delete_watch = { (^"delete-watch" | ^"del-watch") ~ brk_id+ }
 
-enable  = { (^"enable") ~ brk_id+ }
-disable = { (^"disable") ~ brk_id+ }
+enable  = { (^"enable" | ^"en") ~ brk_id+ }
+disable = { (^"disable" | ^"dis") ~ brk_id+ }
+
+enable_watch  = { (^"enable-watch" | ^"enw") ~ brk_id+ }
+disable_watch = { (^"disable-watch" | ^"disw") ~ brk_id+ }
 
 exit = { ^"exit" | ^"quit" }
 
@@ -71,6 +74,6 @@ explain = { ^"explain" }
 restart = { ^"restart" }
 
 command = {
-    SOI ~ (watch | comm_where | print_state | print | print_fail | delete_watch | delete | brk | enable | disable | step_over | step // commands without input
+    SOI ~ (watch | comm_where | print_state | print | print_fail | delete_watch | delete | brk | enable_watch | disable_watch | enable | disable | step_over | step // commands without input
   | cont | help | info_break | info_watch | display | exit | explain | restart)? ~ EOI
 }

--- a/interp/src/debugger/commands/core.rs
+++ b/interp/src/debugger/commands/core.rs
@@ -291,6 +291,8 @@ pub enum Command {
     Disable(Vec<ParsedBreakPointID>),
     Enable(Vec<ParsedBreakPointID>),
     Delete(Vec<ParsedBreakPointID>),
+    EnableWatch(Vec<ParsedBreakPointID>),
+    DisableWatch(Vec<ParsedBreakPointID>),
     DeleteWatch(Vec<ParsedBreakPointID>),
     StepOver(ParsedGroupName),
     Watch(

--- a/interp/src/debugger/commands/core.rs
+++ b/interp/src/debugger/commands/core.rs
@@ -263,7 +263,7 @@ impl PrintTuple {
         write!(
             string,
             " {}",
-            &self.0.iter().map(|x| dbg!(x).as_string(env)).join(" "),
+            &self.0.iter().map(|x| x.as_string(env)).join(" "),
         )
         .unwrap();
 

--- a/interp/src/debugger/commands/core.rs
+++ b/interp/src/debugger/commands/core.rs
@@ -263,7 +263,7 @@ impl PrintTuple {
         write!(
             string,
             " {}",
-            &self.0.iter().map(|x| x.as_string(env)).join(" "),
+            &self.0.iter().map(|x| dbg!(x).as_string(env)).join(" "),
         )
         .unwrap();
 

--- a/interp/src/debugger/debugger_core.rs
+++ b/interp/src/debugger/debugger_core.rs
@@ -288,6 +288,24 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
                     }
                 }
 
+                Command::EnableWatch(targets) => {
+                    for target in targets {
+                        let target = target
+                            .parse_to_watch_ids(self.program_context.as_ref());
+                        unwrap_error_message!(target);
+                        self.debugging_context.enable_watchpoint(target)
+                    }
+                }
+
+                Command::DisableWatch(targets) => {
+                    for target in targets {
+                        let target = target
+                            .parse_to_watch_ids(self.program_context.as_ref());
+                        unwrap_error_message!(target);
+                        self.debugging_context.disable_watchpoint(target)
+                    }
+                }
+
                 Command::Watch(
                     group,
                     watch_pos,

--- a/interp/src/debugger/debugging_context/context.rs
+++ b/interp/src/debugger/debugging_context/context.rs
@@ -254,7 +254,7 @@ impl WatchPointIndices {
     fn get_before(&self) -> Option<&[WatchpointIdx]> {
         match self {
             Self::Before(idx) => Some(idx),
-            Self::Both { after, .. } => Some(after),
+            Self::Both { before, .. } => Some(before),
             Self::After(_) => None,
         }
     }
@@ -263,7 +263,7 @@ impl WatchPointIndices {
         match self {
             Self::Before(_) => None,
             Self::After(idx) => Some(idx),
-            Self::Both { before, .. } => Some(before),
+            Self::Both { after, .. } => Some(after),
         }
     }
 

--- a/interp/src/debugger/debugging_context/context.rs
+++ b/interp/src/debugger/debugging_context/context.rs
@@ -74,11 +74,11 @@ pub struct WatchPoint {
 }
 
 impl WatchPoint {
-    pub fn _enable(&mut self) {
+    pub fn enable(&mut self) {
         self.state = PointStatus::Enabled;
     }
 
-    pub fn _disable(&mut self) {
+    pub fn disable(&mut self) {
         self.state = PointStatus::Disabled;
     }
 
@@ -531,14 +531,22 @@ impl DebuggingContext {
         self.watchpoints.delete_by_idx(target)
     }
 
-    fn _act_watchpoint(&mut self, target: WatchID, action: PointAction) {
+    pub fn enable_watchpoint(&mut self, target: WatchID) {
+        self.act_watchpoint(target, PointAction::Enable)
+    }
+
+    pub fn disable_watchpoint(&mut self, target: WatchID) {
+        self.act_watchpoint(target, PointAction::Disable)
+    }
+
+    fn act_watchpoint(&mut self, target: WatchID, action: PointAction) {
         fn act(target: &mut WatchPoint, action: PointAction) {
             match action {
                 PointAction::Enable => {
-                    target._enable();
+                    target.enable();
                 }
                 PointAction::Disable => {
-                    target._disable();
+                    target.disable();
                 }
             }
         }
@@ -582,11 +590,11 @@ impl DebuggingContext {
     }
 
     pub fn _enable_watchpoint(&mut self, target: WatchID) {
-        self._act_watchpoint(target, PointAction::Enable)
+        self.act_watchpoint(target, PointAction::Enable)
     }
 
     pub fn _disable_watchpoint(&mut self, target: WatchID) {
-        self._act_watchpoint(target, PointAction::Disable)
+        self.act_watchpoint(target, PointAction::Disable)
     }
 
     pub fn hit_breakpoints(&self) -> impl Iterator<Item = GroupIdx> + '_ {

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -2155,9 +2155,9 @@ impl<C: AsRef<Context> + Clone> Simulator<C> {
 
         if state.has_state() {
             if let Some(name_override) = name {
-                write!(output, "{name_override}:").unwrap();
+                write!(output, "{name_override}: ").unwrap();
             } else {
-                write!(output, "{}:", self.get_full_name(cell_idx)).unwrap();
+                write!(output, "{}: ", self.get_full_name(cell_idx)).unwrap();
             }
 
             writeln!(output, "{state}").unwrap();

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -10,6 +10,10 @@ use crate::{
     errors::{BoxedInterpreterError, InterpreterError, InterpreterResult},
     flatten::{
         flat_ir::{
+            base::{
+                LocalCellOffset, LocalPortOffset, LocalRefCellOffset,
+                LocalRefPortOffset,
+            },
             cell_prototype::{CellPrototype, SingleWidthType},
             prelude::{
                 AssignedValue, AssignmentIdx, BaseIndices,
@@ -23,7 +27,7 @@ use crate::{
         },
         primitives::{self, prim_trait::UpdateStatus, Primitive},
         structures::{
-            context::LookupName,
+            context::{LookupName, PortDefinitionInfo},
             environment::{
                 program_counter::ControlPoint, traverser::Traverser,
             },
@@ -691,8 +695,15 @@ impl<C: AsRef<Context> + Clone> Environment<C> {
                             &self.cells[point.comp].unwrap_comp().index_bases
                                 + l,
                         ),
-                        CellRef::Ref(_) => {
-                            "<REF CELLS NOT YET SUPPORTED>".to_string()
+                        CellRef::Ref(r) => {
+                            let ref_global_offset = &self.cells[point.comp]
+                                .unwrap_comp()
+                                .index_bases
+                                + r;
+                            let ref_actual =
+                                self.ref_cells[ref_global_offset].unwrap();
+
+                            self.get_full_name(ref_actual)
                         }
                     };
 
@@ -843,12 +854,12 @@ impl<C: AsRef<Context> + Clone> Environment<C> {
                                         break;
                                     }
                                 }
+                            }
 
-                                if let Some(highest_found) = highest_found {
-                                    path.push(highest_found);
-                                } else {
-                                    return None;
-                                }
+                            if let Some(highest_found) = highest_found {
+                                path.push(highest_found);
+                            } else {
+                                return None;
                             }
                         }
                     }
@@ -1123,6 +1134,48 @@ impl<C: AsRef<Context> + Clone> Environment<C> {
     pub fn unpin_value<S: AsRef<str>>(&mut self, port: S) {
         let port = self.get_root_input_port(port);
         self.pinned_ports.remove(port);
+    }
+
+    pub fn get_def_info(
+        &self,
+        comp_idx: ComponentIdx,
+        cell: LocalCellOffset,
+    ) -> &crate::flatten::flat_ir::base::CellDefinitionInfo<LocalPortOffset>
+    {
+        let comp = &self.ctx.as_ref().secondary[comp_idx];
+        let idx = comp.cell_offset_map[cell];
+        &self.ctx.as_ref().secondary[idx]
+    }
+
+    pub fn get_def_info_ref(
+        &self,
+        comp_idx: ComponentIdx,
+        cell: LocalRefCellOffset,
+    ) -> &crate::flatten::flat_ir::base::CellDefinitionInfo<LocalRefPortOffset>
+    {
+        let comp = &self.ctx.as_ref().secondary[comp_idx];
+        let idx = comp.ref_cell_offset_map[cell];
+        &self.ctx.as_ref().secondary[idx]
+    }
+
+    pub fn get_port_def_info(
+        &self,
+        comp_idx: ComponentIdx,
+        port: LocalPortOffset,
+    ) -> &PortDefinitionInfo {
+        let comp = &self.ctx.as_ref().secondary[comp_idx];
+        let idx = comp.port_offset_map[port];
+        &self.ctx.as_ref().secondary[idx]
+    }
+
+    pub fn get_port_def_info_ref(
+        &self,
+        comp_idx: ComponentIdx,
+        port: LocalRefPortOffset,
+    ) -> Identifier {
+        let comp = &self.ctx.as_ref().secondary[comp_idx];
+        let idx = comp.ref_port_offset_map[port];
+        self.ctx.as_ref().secondary[idx]
     }
 }
 
@@ -2210,6 +2263,31 @@ impl<C: AsRef<Context> + Clone> GetFullName<C> for GlobalPortIdx {
         let port_def_idx = &comp_def.port_offset_map[local_offset];
         let port_def = &env.ctx().secondary[*port_def_idx];
         let name = env.ctx().lookup_name(port_def.name);
+
+        format!("{path_str}.{name}")
+    }
+}
+
+impl<C: AsRef<Context> + Clone> GetFullName<C> for GlobalRefCellIdx {
+    fn get_full_name(&self, env: &Environment<C>) -> String {
+        let parent_path = env.get_parent_path_from_cell(*self).unwrap();
+        let path_str = env.format_path(&parent_path);
+
+        let immediate_parent = parent_path.last().unwrap();
+        let comp = if env.cells[*immediate_parent].as_comp().is_some() {
+            *immediate_parent
+        } else {
+            // get second-to-last parent
+            parent_path[parent_path.len() - 2]
+        };
+
+        let ledger = env.cells[comp].as_comp().unwrap();
+
+        let local_offset = *self - &ledger.index_bases;
+        let comp_def = &env.ctx().secondary[ledger.comp_id];
+        let ref_cell_def_idx = &comp_def.ref_cell_offset_map[local_offset];
+        let ref_cell_def = &env.ctx().secondary[*ref_cell_def_idx];
+        let name = env.ctx().lookup_name(ref_cell_def.name);
 
         format!("{path_str}.{name}")
     }

--- a/interp/src/flatten/structures/environment/traverser.rs
+++ b/interp/src/flatten/structures/environment/traverser.rs
@@ -447,15 +447,15 @@ impl LazyCellPath {
         env: &Environment<C>,
     ) -> String {
         let last = self.concrete_prefix.last().unwrap();
-        let mut path = dbg!(env.get_full_name(last));
+        let mut path = env.get_full_name(last);
         let ledger = env.cells[*last].as_comp().unwrap();
         let offset = self.first_ref - &ledger.index_bases;
         let cell_idx =
             env.ctx().secondary[ledger.comp_id].ref_cell_offset_map[offset];
         path.push('.');
-        path.push_str(dbg!(env
-            .ctx()
-            .lookup_name(env.ctx().secondary[cell_idx].name)));
+        path.push_str(
+            env.ctx().lookup_name(env.ctx().secondary[cell_idx].name),
+        );
 
         let mut current_comp = *env.ctx().secondary[cell_idx]
             .prototype
@@ -595,7 +595,6 @@ impl Path {
             Path::Port(p) => env.get_full_name(p),
             Path::AbstractCell(path) => path.as_string(env),
             Path::AbstractPort { cell, port } => {
-                dbg!("confusion");
                 let mut path = cell.as_string(env);
                 let comp = cell.terminal_comp(env);
                 match port {


### PR DESCRIPTION
Part of #1913.

Adds the ability to enable/disable watchpoints. Also corrects some issues with the name traversals and adds better name printing to debugger outputs.