### PR TITLE
[fud2] Make Empty Ops an Error

### DIFF
--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -183,6 +183,11 @@ impl EmitBuild for RulesOp {
             )?;
         }
 
+        // If the sequences of rules was empty, output a phoney rule creating the desired output.
+        if self.cmds.is_empty() {
+            emitter.build_cmd(outputs, "phony", inputs, &[])?;
+        }
+
         Ok(())
     }
 }

--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -388,7 +388,15 @@ impl<'a> Run<'a> {
                 }
             }) {
                 let stdout_files =
-                    std::fs::File::open(self.plan.workdir.join(filename))?;
+                    std::fs::File::open(self.plan.workdir.join(filename))
+                        .map_err(|e| if let std::io::ErrorKind::NotFound = e.kind() {
+                            std::io::Error::new(
+                                e.kind(),
+                                format!("{}\nHint: Check ops actually generate all of their targets.", e)
+                            )
+                        } else {
+                            e
+                })?;
                 std::io::copy(
                     &mut std::io::BufReader::new(stdout_files),
                     &mut std::io::stdout(),

--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -384,6 +384,8 @@ impl<'a> Run<'a> {
             }) {
                 let stdout_files =
                     std::fs::File::open(self.plan.workdir.join(filename))
+                        // The output file we're emitting to stdout should exist. If it doesn't,
+                        // some op didn't produce the output file it claimed to.
                         .map_err(|e| if let std::io::ErrorKind::NotFound = e.kind() {
                             std::io::Error::new(
                                 e.kind(),

--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -183,11 +183,6 @@ impl EmitBuild for RulesOp {
             )?;
         }
 
-        // If the sequences of rules was empty, output a phoney rule creating the desired output.
-        if self.cmds.is_empty() {
-            emitter.build_cmd(outputs, "phony", inputs, &[])?;
-        }
-
         Ok(())
     }
 }

--- a/fud2/fud-core/src/script/error.rs
+++ b/fud2/fud-core/src/script/error.rs
@@ -21,6 +21,7 @@ pub(super) enum RhaiSystemErrorKind {
     ExpectedString(String),
     ExpectedShell,
     ExpectedShellDeps,
+    EmptyOp,
 }
 
 impl RhaiSystemError {
@@ -90,6 +91,13 @@ impl RhaiSystemError {
         }
     }
 
+    pub(super) fn empty_op() -> Self {
+        Self {
+            kind: RhaiSystemErrorKind::EmptyOp,
+            position: rhai::Position::NONE,
+        }
+    }
+
     pub(super) fn with_pos(mut self, p: rhai::Position) -> Self {
         self.position = p;
         self
@@ -125,6 +133,9 @@ impl Display for RhaiSystemError {
             }
             RhaiSystemErrorKind::ExpectedShellDeps => {
                 write!(f, "Expected `shell_deps`, got shell. Ops may contain only one of `shell` or `shell_deps` calls, not calls to both")
+            }
+            RhaiSystemErrorKind::EmptyOp => {
+                write!(f, "Error: Op must contain at least one call to `shell` or `shell_deps`.")
             }
         }
     }

--- a/fud2/fud-core/src/script/plugin.rs
+++ b/fud2/fud-core/src/script/plugin.rs
@@ -352,8 +352,16 @@ impl ScriptContext {
                         c
                     }
                     Some(ShellCommands::Cmds(c)) => c.clone(),
-                    None => vec![],
+
+                    None => {
+                        // If cmds is empty, then the op doesn't do anything and should be considered
+                        // erroneous.
+                        return Err(RhaiSystemError::empty_op()
+                            .with_pos(pos)
+                            .into());
+                    }
                 };
+
                 let op_name = name.clone();
                 let config_vars = config_vars.clone();
                 let op_emitter = crate::run::RulesOp {

--- a/fud2/fud-core/src/script/plugin.rs
+++ b/fud2/fud-core/src/script/plugin.rs
@@ -354,8 +354,8 @@ impl ScriptContext {
                     Some(ShellCommands::Cmds(c)) => c.clone(),
 
                     None => {
-                        // If cmds is empty, then the op doesn't do anything and should be considered
-                        // erroneous.
+                        // If cmds is empty, then the op doesn't create any of it's targets and
+                        // should be considered erroneous.
                         return Err(RhaiSystemError::empty_op()
                             .with_pos(pos)
                             .into());


### PR DESCRIPTION
Empty ops currently can be created in the new DSL. When exported, this creates broken ninja code. This is an error of the user, not creating the desired target, but this class of error can never create the desired target. Therefore a helpful error was inserted when this happens.