### PR TITLE
[fud2] improve error message for parser errors

### DIFF
--- a/fud2/fud-core/src/exec/driver.rs
+++ b/fud2/fud-core/src/exec/driver.rs
@@ -439,7 +439,10 @@ impl DriverBuilder {
     }
 
     /// Load any plugin scripts specified in the configuration file.
-    pub fn load_plugins(mut self, config_data: &figment::Figment) -> Self {
+    pub fn load_plugins(
+        mut self,
+        config_data: &figment::Figment,
+    ) -> anyhow::Result<Self> {
         // pull out things from self that we need
         let plugin_dir = self.scripts_dir.take();
         let plugin_files = self.script_files.take();
@@ -455,7 +458,7 @@ impl DriverBuilder {
                     .filter_map(|dir_entry| dir_entry.map(|p| p.path()).ok())
                     // filter out paths that don't have `.rhai` extension
                     .filter(|p| p.extension() == Some(OsStr::new("rhai"))),
-            );
+            )?;
         }
 
         // add static plugins (where string is included in binary)
@@ -467,10 +470,10 @@ impl DriverBuilder {
         if let Ok(plugins) =
             config_data.extract_inner::<Vec<std::path::PathBuf>>("plugins")
         {
-            runner.add_files(plugins.into_iter());
+            runner.add_files(plugins.into_iter())?;
         }
 
-        runner.run()
+        Ok(runner.run())
     }
 
     pub fn build(self) -> Driver {

--- a/fud2/src/main.rs
+++ b/fud2/src/main.rs
@@ -41,7 +41,7 @@ fn main() -> anyhow::Result<()> {
 
     #[cfg(feature = "migrate_to_scripts")]
     {
-        bld = bld.load_plugins(&config);
+        bld = bld.load_plugins(&config)?;
     }
 
     let driver = bld.build();

--- a/fud2/tests/tests.rs
+++ b/fud2/tests/tests.rs
@@ -22,7 +22,7 @@ fn test_driver() -> Driver {
     let mut bld = DriverBuilder::new("fud2-plugins");
     let config = figment::Figment::new();
     bld.scripts_dir(manifest_dir_macros::directory_path!("scripts"));
-    bld.load_plugins(&config).build()
+    bld.load_plugins(&config).unwrap().build()
 }
 
 fn driver_from_path_with_config(
@@ -36,7 +36,7 @@ fn driver_from_path_with_config(
         path
     );
     bld.scripts_dir(&path);
-    bld.load_plugins(&config).build()
+    bld.load_plugins(&config).unwrap().build()
 }
 
 fn driver_from_path(path: &str) -> Driver {


### PR DESCRIPTION
It does what it says on the tin. The error messages for the parser won't be good, but they are better than rust panics and I think become functional enough.

One interesting thing to note is I chose to print full paths when referencing files. This is because the directory of scripts is often not where `fud2` was run from and pretty unrelated to that dir.