### PR TITLE
Testbench toplevel module

### DIFF
--- a/fud/fud/stages/verilator/stage.py
+++ b/fud/fud/stages/verilator/stage.py
@@ -167,7 +167,7 @@ class VerilatorStage(Stage):
                 testbench_sv,
                 "--binary",
                 "--top-module",
-                "TOP",  # The wrapper module name from `tb.sv`.
+                "toplevel",  # The wrapper module name from `tb.sv`.
                 "--Mdir",
                 "{tmpdir_name}",
                 "-fno-inline",
@@ -192,7 +192,7 @@ class VerilatorStage(Stage):
             cycle_limit = config["stages", self.name, "cycle_limit"]
             return shell(
                 [
-                    f"{tmpdir.name}/VTOP",
+                    f"{tmpdir.name}/Vtoplevel",
                     f"+DATA={tmpdir.name}",
                     f"+CYCLE_LIMIT={str(cycle_limit)}",
                     f"+OUT={tmpdir.name}/output.vcd",

--- a/fud/icarus/tb.sv
+++ b/fud/icarus/tb.sv
@@ -1,4 +1,4 @@
-module TOP;
+module toplevel;
 
 // Signals for the main module.
 logic go, done, clk, reset;

--- a/fud2/rsrc/tb.sv
+++ b/fud2/rsrc/tb.sv
@@ -1,4 +1,4 @@
-module TOP;
+module toplevel;
 
 // Signals for the main module.
 logic go, done, clk, reset;

--- a/fud2/scripts/icarus.rhai
+++ b/fud2/scripts/icarus.rhai
@@ -7,11 +7,11 @@ fn icarus_setup(e) {
     e.var_("iverilog", "iverilog");
     e.rule(
         "icarus-compile-standalone-tb",
-        "$iverilog -g2012 -o $out tb.sv $in",
+        "$iverilog -g2012 -s toplevel -o $out tb.sv $in",
     );
     e.rule(
         "icarus-compile-custom-tb",
-        "$iverilog -g2012 -o $out tb.sv memories.sv $in",
+        "$iverilog -g2012 -s toplevel -o $out tb.sv memories.sv $in",
     );
 }
 

--- a/fud2/scripts/verilator.rhai
+++ b/fud2/scripts/verilator.rhai
@@ -8,11 +8,11 @@ fn verilator_setup(e) {
    e.config_var_or("cycle-limit", "sim.cycle_limit", "500000000");
    e.rule(
         "verilator-compile-standalone-tb",
-        "$verilator $in tb.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir",
+        "$verilator $in tb.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir",
    );
    e.rule(
         "verilator-compile-custom-tb",
-        "$verilator $in tb.sv memories.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir",
+        "$verilator $in tb.sv memories.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir",
    );
    e.rule("cp", "cp $in $out");
 }
@@ -20,7 +20,7 @@ fn verilator_setup(e) {
 export const verilator_build = verilator_build;
 fn verilator_build(e, input, output, standalone_tb) {
    let out_dir = "verilator-out";
-   let sim_bin = `${out_dir}/VTOP`;
+   let sim_bin = `${out_dir}/Vtoplevel`;
    if standalone_tb {
       e.build_cmd(
         [sim_bin],

--- a/fud2/src/lib.rs
+++ b/fud2/src/lib.rs
@@ -288,7 +288,7 @@ pub fn build_driver(bld: &mut DriverBuilder) {
         standalone_testbench: bool,
     ) -> EmitResult {
         let out_dir = "verilator-out";
-        let sim_bin = format!("{}/VTOP", out_dir);
+        let sim_bin = format!("{}/Vtoplevel", out_dir);
         if standalone_testbench {
             e.build_cmd(
                 &[&sim_bin],

--- a/fud2/src/lib.rs
+++ b/fud2/src/lib.rs
@@ -272,11 +272,11 @@ pub fn build_driver(bld: &mut DriverBuilder) {
         e.config_var_or("cycle-limit", "sim.cycle_limit", "500000000")?;
         e.rule(
             "verilator-compile-standalone-tb",
-            "$verilator $in tb.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir",
+            "$verilator $in tb.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir",
         )?;
         e.rule(
             "verilator-compile-custom-tb",
-            "$verilator $in tb.sv memories.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir",
+            "$verilator $in tb.sv memories.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir",
         )?;
         e.rule("cp", "cp $in $out")?;
         Ok(())

--- a/fud2/tests/snapshots/tests__test@calyx_through_icarus_to_dat.snap
+++ b/fud2/tests/snapshots/tests__test@calyx_through_icarus_to_dat.snap
@@ -34,9 +34,9 @@ build tb.sv: get-rsrc
 
 iverilog = iverilog
 rule icarus-compile-standalone-tb
-  command = $iverilog -g2012 -o $out tb.sv $in
+  command = $iverilog -g2012 -s toplevel -o $out tb.sv $in
 rule icarus-compile-custom-tb
-  command = $iverilog -g2012 -o $out tb.sv memories.sv $in
+  command = $iverilog -g2012 -s toplevel -o $out tb.sv memories.sv $in
 
 build verilog-noverify.sv: calyx _from_stdin_calyx.futil
   backend = verilog

--- a/fud2/tests/snapshots/tests__test@calyx_through_icarus_to_vcd.snap
+++ b/fud2/tests/snapshots/tests__test@calyx_through_icarus_to_vcd.snap
@@ -34,9 +34,9 @@ build tb.sv: get-rsrc
 
 iverilog = iverilog
 rule icarus-compile-standalone-tb
-  command = $iverilog -g2012 -o $out tb.sv $in
+  command = $iverilog -g2012 -s toplevel -o $out tb.sv $in
 rule icarus-compile-custom-tb
-  command = $iverilog -g2012 -o $out tb.sv memories.sv $in
+  command = $iverilog -g2012 -s toplevel -o $out tb.sv memories.sv $in
 
 build verilog-noverify.sv: calyx _from_stdin_calyx.futil
   backend = verilog

--- a/fud2/tests/snapshots/tests__test@calyx_through_verilator_to_dat.snap
+++ b/fud2/tests/snapshots/tests__test@calyx_through_verilator_to_dat.snap
@@ -35,17 +35,17 @@ build tb.sv: get-rsrc
 verilator = verilator
 cycle-limit = 500000000
 rule verilator-compile-standalone-tb
-  command = $verilator $in tb.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir
+  command = $verilator $in tb.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir
 rule verilator-compile-custom-tb
-  command = $verilator $in tb.sv memories.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir
+  command = $verilator $in tb.sv memories.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir
 rule cp
   command = cp $in $out
 
 build verilog.sv: calyx _from_stdin_calyx.futil
   backend = verilog
-build verilator-out/VTOP: verilator-compile-standalone-tb verilog.sv | tb.sv
+build verilator-out/Vtoplevel: verilator-compile-standalone-tb verilog.sv | tb.sv
   out-dir = verilator-out
-build sim.exe: cp verilator-out/VTOP
+build sim.exe: cp verilator-out/Vtoplevel
 build sim.log: sim-run sim.exe $datadir
   bin = sim.exe
   args = +NOTRACE=1

--- a/fud2/tests/snapshots/tests__test@calyx_through_verilator_to_vcd.snap
+++ b/fud2/tests/snapshots/tests__test@calyx_through_verilator_to_vcd.snap
@@ -35,17 +35,17 @@ build tb.sv: get-rsrc
 verilator = verilator
 cycle-limit = 500000000
 rule verilator-compile-standalone-tb
-  command = $verilator $in tb.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir
+  command = $verilator $in tb.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir
 rule verilator-compile-custom-tb
-  command = $verilator $in tb.sv memories.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir
+  command = $verilator $in tb.sv memories.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir
 rule cp
   command = cp $in $out
 
 build verilog.sv: calyx _from_stdin_calyx.futil
   backend = verilog
-build verilator-out/VTOP: verilator-compile-standalone-tb verilog.sv | tb.sv
+build verilator-out/Vtoplevel: verilator-compile-standalone-tb verilog.sv | tb.sv
   out-dir = verilator-out
-build sim.exe: cp verilator-out/VTOP
+build sim.exe: cp verilator-out/Vtoplevel
 build sim.log _to_stdout_vcd.vcd: sim-run sim.exe $datadir
   bin = sim.exe
   args = +NOTRACE=0 +OUT=_to_stdout_vcd.vcd

--- a/fud2/tests/snapshots/tests__test@calyx_verilator_dat.snap
+++ b/fud2/tests/snapshots/tests__test@calyx_verilator_dat.snap
@@ -35,17 +35,17 @@ build tb.sv: get-rsrc
 verilator = verilator
 cycle-limit = 500000000
 rule verilator-compile-standalone-tb
-  command = $verilator $in tb.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir
+  command = $verilator $in tb.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir
 rule verilator-compile-custom-tb
-  command = $verilator $in tb.sv memories.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir
+  command = $verilator $in tb.sv memories.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir
 rule cp
   command = cp $in $out
 
 build verilog.sv: calyx _from_stdin_calyx.futil
   backend = verilog
-build verilator-out/VTOP: verilator-compile-standalone-tb verilog.sv | tb.sv
+build verilator-out/Vtoplevel: verilator-compile-standalone-tb verilog.sv | tb.sv
   out-dir = verilator-out
-build sim.exe: cp verilator-out/VTOP
+build sim.exe: cp verilator-out/Vtoplevel
 build sim.log: sim-run sim.exe $datadir
   bin = sim.exe
   args = +NOTRACE=1

--- a/fud2/tests/snapshots/tests__test@calyx_verilator_vcd.snap
+++ b/fud2/tests/snapshots/tests__test@calyx_verilator_vcd.snap
@@ -35,17 +35,17 @@ build tb.sv: get-rsrc
 verilator = verilator
 cycle-limit = 500000000
 rule verilator-compile-standalone-tb
-  command = $verilator $in tb.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir
+  command = $verilator $in tb.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir
 rule verilator-compile-custom-tb
-  command = $verilator $in tb.sv memories.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir
+  command = $verilator $in tb.sv memories.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir
 rule cp
   command = cp $in $out
 
 build verilog.sv: calyx _from_stdin_calyx.futil
   backend = verilog
-build verilator-out/VTOP: verilator-compile-standalone-tb verilog.sv | tb.sv
+build verilator-out/Vtoplevel: verilator-compile-standalone-tb verilog.sv | tb.sv
   out-dir = verilator-out
-build sim.exe: cp verilator-out/VTOP
+build sim.exe: cp verilator-out/Vtoplevel
 build sim.log _to_stdout_vcd.vcd: sim-run sim.exe $datadir
   bin = sim.exe
   args = +NOTRACE=0 +OUT=_to_stdout_vcd.vcd

--- a/fud2/tests/snapshots/tests__test@plan_icarus-refmem.snap
+++ b/fud2/tests/snapshots/tests__test@plan_icarus-refmem.snap
@@ -21,9 +21,9 @@ cycle-limit = 500000000
 
 iverilog = iverilog
 rule icarus-compile-standalone-tb
-  command = $iverilog -g2012 -o $out tb.sv $in
+  command = $iverilog -g2012 -s toplevel -o $out tb.sv $in
 rule icarus-compile-custom-tb
-  command = $iverilog -g2012 -o $out tb.sv memories.sv $in
+  command = $iverilog -g2012 -s toplevel -o $out tb.sv memories.sv $in
 
 build /output.ext: icarus-compile-custom-tb /input.ext | tb.sv memories.sv
 

--- a/fud2/tests/snapshots/tests__test@plan_icarus.snap
+++ b/fud2/tests/snapshots/tests__test@plan_icarus.snap
@@ -23,9 +23,9 @@ build tb.sv: get-rsrc
 
 iverilog = iverilog
 rule icarus-compile-standalone-tb
-  command = $iverilog -g2012 -o $out tb.sv $in
+  command = $iverilog -g2012 -s toplevel -o $out tb.sv $in
 rule icarus-compile-custom-tb
-  command = $iverilog -g2012 -o $out tb.sv memories.sv $in
+  command = $iverilog -g2012 -s toplevel -o $out tb.sv memories.sv $in
 
 build /output.ext: icarus-compile-standalone-tb /input.ext | tb.sv
 

--- a/fud2/tests/snapshots/tests__test@plan_verilator-refmem.snap
+++ b/fud2/tests/snapshots/tests__test@plan_verilator-refmem.snap
@@ -33,14 +33,14 @@ rule dummy
 verilator = verilator
 cycle-limit = 500000000
 rule verilator-compile-standalone-tb
-  command = $verilator $in tb.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir
+  command = $verilator $in tb.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir
 rule verilator-compile-custom-tb
-  command = $verilator $in tb.sv memories.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir
+  command = $verilator $in tb.sv memories.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir
 rule cp
   command = cp $in $out
 
-build verilator-out/VTOP: verilator-compile-custom-tb /input.ext | tb.sv memories.sv
+build verilator-out/Vtoplevel: verilator-compile-custom-tb /input.ext | tb.sv memories.sv
   out-dir = verilator-out
-build /output.ext: cp verilator-out/VTOP
+build /output.ext: cp verilator-out/Vtoplevel
 
 default /output.ext

--- a/fud2/tests/snapshots/tests__test@plan_verilator.snap
+++ b/fud2/tests/snapshots/tests__test@plan_verilator.snap
@@ -24,14 +24,14 @@ build tb.sv: get-rsrc
 verilator = verilator
 cycle-limit = 500000000
 rule verilator-compile-standalone-tb
-  command = $verilator $in tb.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir
+  command = $verilator $in tb.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir
 rule verilator-compile-custom-tb
-  command = $verilator $in tb.sv memories.sv --trace --binary --top-module TOP -fno-inline -Mdir $out-dir
+  command = $verilator $in tb.sv memories.sv --trace --binary --top-module toplevel -fno-inline -Mdir $out-dir
 rule cp
   command = cp $in $out
 
-build verilator-out/VTOP: verilator-compile-standalone-tb /input.ext | tb.sv
+build verilator-out/Vtoplevel: verilator-compile-standalone-tb /input.ext | tb.sv
   out-dir = verilator-out
-build /output.ext: cp verilator-out/VTOP
+build /output.ext: cp verilator-out/Vtoplevel
 
 default /output.ext

--- a/tests/correctness/systolic/pe/array-1.systolic.jq
+++ b/tests/correctness/systolic/pe/array-1.systolic.jq
@@ -1,4 +1,4 @@
-.TOP.TOP.main.systolic_array_component | ({
+.TOP.toplevel.main.systolic_array_component | ({
   "cycles":.clk | add,
   "pe_00": .pe_0_0.acc.out | unique,
 })

--- a/tests/correctness/systolic/pe/array-2.systolic.jq
+++ b/tests/correctness/systolic/pe/array-2.systolic.jq
@@ -1,4 +1,4 @@
-.TOP.TOP.main.systolic_array_component | ({
+.TOP.toplevel.main.systolic_array_component | ({
   "cycles":.clk | add,
   "pe_00": .pe_0_0.acc.out | unique,
   "pe_01": .pe_0_1.acc.out | unique,

--- a/tests/correctness/systolic/pe/array-3.systolic.jq
+++ b/tests/correctness/systolic/pe/array-3.systolic.jq
@@ -1,4 +1,4 @@
-.TOP.TOP.main.systolic_array_component | ({
+.TOP.toplevel.main.systolic_array_component | ({
   "cycles":.clk | add,
 
   "pe_00": .pe_0_0.acc.out | unique,

--- a/tests/errors/runtime/multiple-drivers.expect
+++ b/tests/errors/runtime/multiple-drivers.expect
@@ -1,2 +1,2 @@
-[70] %Error: Assertion failed in TOP.main: Multiple assignment to port `r.in'.
+[70] %Error: Assertion failed in TOP.toplevel.main: Multiple assignment to port `r.in'.
 %Error: Verilog $stop

--- a/tools/firrtl/custom_tb_template.sv
+++ b/tools/firrtl/custom_tb_template.sv
@@ -1,4 +1,4 @@
-module TOP;
+module toplevel;
 
 // Signals for the main module.
 logic go, done, clk, reset;


### PR DESCRIPTION
This PR updates the name of the top level module in the Verilog testbench (`tb.sv`) to `toplevel` to avoid the Verilator error:
```
tb.sv:1:8: Module cannot be named 'TOP' as conflicts with Verilator top-level internals
```