### PR TITLE
[Cider] Replace `ibig` with `num-bigint`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,12 +232,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -1530,19 +1524,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ibig"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fcc7f316b2c079dde77564a1360639c1a956a23fa96122732e416cb10717bb"
-dependencies = [
- "cfg-if",
- "num-traits",
- "rand 0.8.5",
- "serde",
- "static_assertions",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,7 +1608,6 @@ version = "0.1.1"
 dependencies = [
  "ahash 0.8.10",
  "argh",
- "base64 0.13.1",
  "bitvec",
  "btor2i",
  "calyx-frontend",
@@ -1636,9 +1616,10 @@ dependencies = [
  "calyx-utils",
  "ciborium",
  "fraction",
- "ibig",
  "itertools 0.11.0",
  "lazy_static",
+ "num-bigint",
+ "num-traits",
  "once_cell",
  "owo-colors",
  "pest",
@@ -2658,7 +2639,7 @@ version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -24,16 +24,16 @@ pest_consume.workspace = true
 argh.workspace = true
 owo-colors = "^3.5"
 bitvec = "1.0"
-base64 = "0.13.0"
 serde_json = "1.0"
 rustyline = "=10.0.0"
 fraction = { version = "0.11.0", features = ["with-serde-support"] }
 thiserror = "1.0.26"
-ibig = { version = "0.3.4", features = ["serde"] }
 slog = "2.7.0"
 slog-term = "2.8.0"
 slog-async = "2.7.0"
 ahash = "0.8.3"
+num-bigint = "0.4.6"
+num-traits = "0.2.19"
 
 once_cell = "1.9.0"
 petgraph = "0.6.3"

--- a/interp/src/flatten/flat_ir/base.rs
+++ b/interp/src/flatten/flat_ir/base.rs
@@ -85,18 +85,21 @@ impl_index!(GlobalRefPortIdx);
 
 // Offset indices
 
-/// A local port offset for a component. These are used in the definition of
-/// assignments and can only be understood in the context of the component they
-/// are defined under. Combined with a base index from a component instance this
-/// can be resolved to a [`GlobalPortIdx`].
+/// A local port offset for a component.
+///
+/// These are used in the definition of assignments and can only be understood
+/// in the context of the component they are defined under. Combined with a base
+/// index from a component instance this can be resolved to a [`GlobalPortIdx`].
 #[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
 pub struct LocalPortOffset(u32);
 impl_index!(LocalPortOffset);
 
-/// A local ref port offset for a component. These are used in the definition of
-/// assignments and can only be understood in the context of the component they
-/// are defined under. Combined with a base index from a component instance this
-/// can be resolved to a [`GlobalRefPortIdx`].
+/// A local ref port offset for a component.
+///
+/// These are used in the definition of assignments and can only be understood
+/// in the context of the component they are defined under. Combined with a base
+/// index from a component instance this can be resolved to a
+/// [`GlobalRefPortIdx`].
 #[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
 pub struct LocalRefPortOffset(u32);
 impl_index!(LocalRefPortOffset);
@@ -380,9 +383,11 @@ impl From<CellDefinitionIdx> for CellDefinitionRef {
 pub struct AssignmentIdx(u32);
 impl_index!(AssignmentIdx);
 
-/// An enum representing the "winner" of an assignment. This tells us how the
-/// value was assigned to the port. For standard assignments, this is also used
-/// to detect conflicts where there are multiple driving assignments.
+/// An enum representing the "winner" of an assignment.
+///
+/// This tells us how the value was assigned to the port. For standard
+/// assignments, this is also used to detect conflicts where there are multiple
+/// driving assignments.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AssignmentWinner {
     /// Indicates that the "winning" assignment for this port was produced by a

--- a/interp/src/flatten/flat_ir/identifier.rs
+++ b/interp/src/flatten/flat_ir/identifier.rs
@@ -3,10 +3,12 @@ use std::hash::Hash;
 
 use crate::flatten::structures::index_trait::{impl_index, IndexRef};
 
-/// An index type corresponding to a string. Similar to [calyx_ir::Id] but
-/// cannot be turned into a string directly. Strings are stored in the
-/// interpretation context [crate::flatten::structures::context::Context] and
-/// can be looked up via [crate::flatten::structures::context::Context::lookup_name]
+/// An index type corresponding to a string.
+///
+/// Similar to [calyx_ir::Id] but cannot be turned into a string directly.
+/// Strings are stored in the interpretation context
+/// [crate::flatten::structures::context::Context] and can be looked up via
+/// [crate::flatten::structures::context::Context::lookup_name]
 #[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
 pub struct Identifier(u32);
 

--- a/interp/src/flatten/primitives/stateful/math.rs
+++ b/interp/src/flatten/primitives/stateful/math.rs
@@ -1,22 +1,16 @@
-use ibig::ops::RemEuclid;
-
 use crate::{
     flatten::{
         flat_ir::prelude::*,
         primitives::{
-            declare_ports,
+            declare_ports, ports,
+            prim_trait::*,
             utils::{floored_division, int_sqrt, ShiftBuffer},
         },
-    },
-    values::InputNumber,
-};
-use crate::{
-    flatten::{
-        primitives::{ports, prim_trait::*},
         structures::environment::PortMap,
     },
-    values::Value,
+    values::{InputNumber, Value},
 };
+use num_traits::Euclid;
 
 pub struct StdMultPipe<const DEPTH: usize> {
     base_port: GlobalPortIdx,
@@ -199,7 +193,7 @@ impl<const DEPTH: usize, const SIGNED: bool> Primitive
                                     (left
                                         .val()
                                         .as_unsigned()
-                                        .rem_euclid(right.val().as_unsigned()))
+                                        .rem_euclid(&right.val().as_unsigned()))
                                     .into()
                                 } else {
                                     (left.val().as_signed()
@@ -530,7 +524,7 @@ impl<const DEPTH: usize, const SIGNED: bool> Primitive
                                     (left
                                         .val()
                                         .as_unsigned()
-                                        .rem_euclid(right.val().as_unsigned()))
+                                        .rem_euclid(&right.val().as_unsigned()))
                                     .into()
                                 } else {
                                     (left.val().as_signed()

--- a/interp/src/flatten/primitives/utils.rs
+++ b/interp/src/flatten/primitives/utils.rs
@@ -1,14 +1,13 @@
+use num_bigint::{BigInt, BigUint, Sign};
 use std::collections::VecDeque;
 
-use ibig::{ibig, UBig};
-use ibig::{ubig, IBig};
-
-pub(crate) fn floored_division(left: &IBig, right: &IBig) -> IBig {
+/// There's probably a better way to do this but I'm not fixing it right now
+pub(crate) fn floored_division(left: &BigInt, right: &BigInt) -> BigInt {
     let div = left / right;
 
-    if left.signum() != ibig!(-1) && right.signum() != ibig!(-1) {
+    if left.sign() != Sign::Minus && right.sign() != Sign::Minus {
         div
-    } else if (div.signum() == (-1).into() || div.signum() == 0.into())
+    } else if (div.sign() == Sign::Minus || div.sign() == Sign::NoSign)
         && (left != &(&div * right))
     {
         div - 1_i32
@@ -18,14 +17,17 @@ pub(crate) fn floored_division(left: &IBig, right: &IBig) -> IBig {
 }
 
 /// Implementation of integer square root via a basic binary search algorithm
-/// based on wikipedia psuedocode
-pub(crate) fn int_sqrt(i: &UBig) -> UBig {
-    let mut lower: UBig = ubig!(0);
-    let mut upper: UBig = i + ubig!(1);
-    let mut temp: UBig;
+/// based on wikipedia pseudocode.
+///
+/// TODO griffin: See if this can be replaced with a `sqrt` function in the
+/// `num-bigint` crate
+pub(crate) fn int_sqrt(i: &BigUint) -> BigUint {
+    let mut lower: BigUint = BigUint::from(0_u32);
+    let mut upper: BigUint = i + BigUint::from(1_u32);
+    let mut temp: BigUint;
 
-    while lower != (&upper - ubig!(1)) {
-        temp = (&lower + &upper) / ubig!(2);
+    while lower != (&upper - BigUint::from(1_u32)) {
+        temp = (&lower + &upper) / BigUint::from(2_u32);
         if &(&temp * &temp) <= i {
             lower = temp
         } else {

--- a/interp/src/flatten/setup.rs
+++ b/interp/src/flatten/setup.rs
@@ -49,6 +49,9 @@ fn do_setup(
     Ok((crate::flatten::flat_ir::translate(&ctx), mapping))
 }
 
+/// This function sets up the simulation context for the given program. This is
+/// meant to be used in contexts where calyx metadata is not required. For other
+/// cases, use [setup_simulation_with_metadata]
 pub fn setup_simulation(
     file: &Option<PathBuf>,
     lib_path: &Path,
@@ -58,6 +61,11 @@ pub fn setup_simulation(
     Ok(ctx)
 }
 
+/// Constructs the simulation context for the given program. Additionally
+/// attempts to construct the metadata table for the program.
+///
+/// For cases where the metadata is not required, use [setup_simulation], which
+/// has less of a performance impact.
 pub fn setup_simulation_with_metadata(
     file: &Option<PathBuf>,
     lib_path: &Path,

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -1188,8 +1188,10 @@ impl<C: AsRef<Context> + Clone> Environment<C> {
 }
 
 /// A wrapper struct for the environment that provides the functions used to
-/// simulate the actual program. This is just to keep the simulation logic under
-/// a different namespace than the environment to avoid confusion
+/// simulate the actual program.
+///
+/// This is just to keep the simulation logic under a different namespace than
+/// the environment to avoid confusion
 pub struct Simulator<C: AsRef<Context> + Clone> {
     env: Environment<C>,
 }

--- a/interp/src/flatten/structures/index_trait.rs
+++ b/interp/src/flatten/structures/index_trait.rs
@@ -242,7 +242,8 @@ where
         (size, Some(size))
     }
 }
-
+/// An iterator over a range of indices but without
+///
 /// Because I really played myself by making the [IndexRangeIterator] have a
 /// lifetime attached to it. This one doesn't do that. As with it's sibling, the
 /// range is half open, meaning that the start is inclusive, but the end is

--- a/interp/src/serialization/formatting.rs
+++ b/interp/src/serialization/formatting.rs
@@ -96,9 +96,11 @@ impl From<&MemoryDimensions> for Shape {
     }
 }
 
-/// A wrapper enum used during serialization. It represents either an unsigned integer,
-/// or a signed integer and is serialized as the underlying integer. This also allows
-/// mixed serialization of signed and unsigned values
+/// A wrapper enum used during serialization.
+///
+/// It represents either an unsigned integer, or a signed integer and is
+/// serialized as the underlying integer. This also allows mixed serialization
+/// of signed and unsigned values
 #[derive(Serialize, Clone)]
 #[serde(untagged)]
 pub enum Entry {

--- a/interp/src/tests/values.rs
+++ b/interp/src/tests/values.rs
@@ -239,89 +239,111 @@ mod signed_fixed_point_tests {
 #[cfg(test)]
 mod property_tests {
     use crate::values::Value;
-    use ibig::{ops::UnsignedAbs, IBig, UBig};
+    use num_bigint::{BigInt, BigUint};
     use proptest::prelude::*;
 
     proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1000))]
+
+
         #[test]
         fn u8_round_trip(input: u8) {
-            assert_eq!(input as u64, Value::from(input, 8).as_u64())
+            prop_assert_eq!(input as u64, Value::from(input, 8).as_u64())
         }
 
         #[test]
         fn u16_round_trip(input: u16) {
-            assert_eq!(input as u64, Value::from(input, 16).as_u64())
+            prop_assert_eq!(input as u64, Value::from(input, 16).as_u64())
         }
 
         #[test]
         fn u32_round_trip(input: u32) {
-            assert_eq!(input as u64, Value::from(input, 32).as_u64())
+            prop_assert_eq!(input as u64, Value::from(input, 32).as_u64())
         }
 
         #[test]
         fn u64_round_trip(input: u64) {
-            assert_eq!(input, Value::from(input, 64).as_u64())
+            prop_assert_eq!(input, Value::from(input, 64).as_u64())
         }
 
         #[test]
         fn u128_round_trip(input: u128) {
-            assert_eq!(input, Value::from(input, 128).as_u128())
+            prop_assert_eq!(input, Value::from(input, 128).as_u128())
         }
 
         #[test]
         fn i8_round_trip(input: i8) {
-            assert_eq!(input as i64, Value::from(input, 8).as_i64())
+            prop_assert_eq!(input as i64, Value::from(input, 8).as_i64())
         }
 
         #[test]
         fn i16_round_trip(input: i16) {
-            assert_eq!(input as i64, Value::from(input, 16).as_i64())
+            prop_assert_eq!(input as i64, Value::from(input, 16).as_i64())
         }
 
         #[test]
         fn i32_round_trip(input: i32) {
-            assert_eq!(input as i64, Value::from(input, 32).as_i64())
+            prop_assert_eq!(input as i64, Value::from(input, 32).as_i64())
         }
 
         #[test]
         fn i64_round_trip(input: i64) {
-            assert_eq!(input, Value::from(input, 64).as_i64())
+            prop_assert_eq!(input, Value::from(input, 64).as_i64())
         }
 
         #[test]
         fn i128_round_trip(input: i128) {
-            assert_eq!(input, Value::from(input, 128).as_i128())
+            prop_assert_eq!(input, Value::from(input, 128).as_i128())
         }
 
         #[test]
         fn i128_to_ibig(input: i128) {
             let val = Value::from(input, 128);
-            assert_eq!(val.as_signed(), input.into())
+            prop_assert_eq!(val.as_signed(), input.into())
         }
 
         #[test]
         fn u128_to_ubig(input: u128) {
             let val = Value::from(input, 128);
-            assert_eq!(val.as_unsigned(), input.into())
+            prop_assert_eq!(val.as_unsigned(), input.into())
+        }
+
+
+        #[test]
+        fn u32_to_ubig(input: u32) {
+            let val = Value::from(input, 32);
+            prop_assert_eq!(val.as_unsigned(), input.into())
+        }
+
+        #[test]
+        fn i32_to_ibig(input: i32) {
+            let val = Value::from(input, 32);
+            prop_assert_eq!(val.as_signed(), input.into())
+        }
+          #[test]
+        fn ibig_to_ibig_neg(input in -350_i32..350_i32) {
+            dbg!(input);
+            let val = Value::from(BigInt::from(input), 32);
+            prop_assert_eq!(val.as_signed(), BigInt::from(input))
         }
 
         #[test]
         fn ubig_roundtrip(input: u128, mul: u128) {
-            let in_big: UBig = input.into();
-            let mul_big: UBig = mul.into();
-            let target: UBig = in_big * mul_big;
-            let val = Value::from(target.clone(), target.bit_len());
-            assert_eq!(val.as_unsigned(), target)
+            let in_big: BigUint = input.into();
+            let mul_big: BigUint = mul.into();
+            let target: BigUint = in_big * mul_big;
+            let val = Value::from(target.clone(), target.bits());
+            prop_assert_eq!(val.as_unsigned(), target)
         }
 
         #[test]
         fn ibig_roundtrip(input: i128, mul: i128) {
-            let in_big: IBig = input.into();
-            let mul_big: IBig = mul.into();
-            let target: IBig = in_big * mul_big;
-            let val = Value::from(target.clone(), (&target).unsigned_abs().bit_len()+1);
+            let in_big: BigInt = input.into();
+            let mul_big: BigInt = mul.into();
+            let target: BigInt = in_big * mul_big;
+            let val = Value::from(target.clone(), target.magnitude().bits() + 1);
             println!("{}", val);
-            assert_eq!(val.as_signed(), target)
+            prop_assert_eq!(val.as_signed(), target)
         }
     }
 }


### PR DESCRIPTION
A relatively minor set of documentation changes and some changes to the arbitrary precision numbers. Deceptively frustrating to implement but should be more compatible with future changes to `Value`. 