### PR TITLE
[Cider] Improve conflicting assignment error message

### DIFF
--- a/fud2/scripts/cider.rhai
+++ b/fud2/scripts/cider.rhai
@@ -22,13 +22,16 @@ fn cider_setup(e) {
     );
     e.arg("pool", "console");
 
+    e.config_var_or("converter-flags", "cider.converter-flags", "");
+    e.config_var_or("cider-flags", "cider.flags", "");
+
     e.rule(
         "run-cider",
-        "$cider-exe -l $calyx-base --data data.dump $in > $out",
+        "$cider-exe -l $calyx-base --data data.dump $cider-flags $in > $out",
     );
 
-    e.rule("dump-to-interp", "$cider-converter --to cider $in > $out");
-    e.rule("interp-to-dump", "$cider-converter --to json $in > $out");
+    e.rule("dump-to-interp", "$cider-converter --to cider $converter-flags $in > $out");
+    e.rule("interp-to-dump", "$cider-converter --to json $converter-flags $in > $out");
     e.build_cmd(
         ["data.dump"],
         "dump-to-interp",

--- a/fud2/tests/snapshots/tests__test@calyx_through_cider_to_dat.snap
+++ b/fud2/tests/snapshots/tests__test@calyx_through_cider_to_dat.snap
@@ -35,12 +35,14 @@ cider-converter = $calyx-base/target/debug/cider-data-converter
 rule run-cider-debug
   command = $cider-exe -l $calyx-base --data data.dump $in debug || true
   pool = console
+converter-flags = 
+cider-flags = 
 rule run-cider
-  command = $cider-exe -l $calyx-base --data data.dump $in > $out
+  command = $cider-exe -l $calyx-base --data data.dump $cider-flags $in > $out
 rule dump-to-interp
-  command = $cider-converter --to cider $in > $out
+  command = $cider-converter --to cider $converter-flags $in > $out
 rule interp-to-dump
-  command = $cider-converter --to json $in > $out
+  command = $cider-converter --to json $converter-flags $in > $out
 build data.dump: dump-to-interp $sim_data | $cider-converter
 
 build pseudo_cider: calyx-with-flags _from_stdin_calyx.futil

--- a/fud2/tests/snapshots/tests__test@calyx_to_cider-debug.snap
+++ b/fud2/tests/snapshots/tests__test@calyx_to_cider-debug.snap
@@ -37,12 +37,14 @@ cider-converter = $calyx-base/target/debug/cider-data-converter
 rule run-cider-debug
   command = $cider-exe -l $calyx-base --data data.dump $in debug || true
   pool = console
+converter-flags = 
+cider-flags = 
 rule run-cider
-  command = $cider-exe -l $calyx-base --data data.dump $in > $out
+  command = $cider-exe -l $calyx-base --data data.dump $cider-flags $in > $out
 rule dump-to-interp
-  command = $cider-converter --to cider $in > $out
+  command = $cider-converter --to cider $converter-flags $in > $out
 rule interp-to-dump
-  command = $cider-converter --to json $in > $out
+  command = $cider-converter --to json $converter-flags $in > $out
 build data.dump: dump-to-interp $sim_data | $cider-converter
 
 build pseudo_cider: calyx-with-flags _from_stdin_calyx.futil

--- a/fud2/tests/snapshots/tests__test@plan_cider.snap
+++ b/fud2/tests/snapshots/tests__test@plan_cider.snap
@@ -35,12 +35,14 @@ cider-converter = $calyx-base/target/debug/cider-data-converter
 rule run-cider-debug
   command = $cider-exe -l $calyx-base --data data.dump $in debug || true
   pool = console
+converter-flags = 
+cider-flags = 
 rule run-cider
-  command = $cider-exe -l $calyx-base --data data.dump $in > $out
+  command = $cider-exe -l $calyx-base --data data.dump $cider-flags $in > $out
 rule dump-to-interp
-  command = $cider-converter --to cider $in > $out
+  command = $cider-converter --to cider $converter-flags $in > $out
 rule interp-to-dump
-  command = $cider-converter --to json $in > $out
+  command = $cider-converter --to json $converter-flags $in > $out
 build data.dump: dump-to-interp $sim_data | $cider-converter
 
 build interp_out.dump: run-cider /input.ext | data.dump

--- a/fud2/tests/snapshots/tests__test@plan_debug.snap
+++ b/fud2/tests/snapshots/tests__test@plan_debug.snap
@@ -37,12 +37,14 @@ cider-converter = $calyx-base/target/debug/cider-data-converter
 rule run-cider-debug
   command = $cider-exe -l $calyx-base --data data.dump $in debug || true
   pool = console
+converter-flags = 
+cider-flags = 
 rule run-cider
-  command = $cider-exe -l $calyx-base --data data.dump $in > $out
+  command = $cider-exe -l $calyx-base --data data.dump $cider-flags $in > $out
 rule dump-to-interp
-  command = $cider-converter --to cider $in > $out
+  command = $cider-converter --to cider $converter-flags $in > $out
 rule interp-to-dump
-  command = $cider-converter --to json $in > $out
+  command = $cider-converter --to json $converter-flags $in > $out
 build data.dump: dump-to-interp $sim_data | $cider-converter
 
 build /output.ext: run-cider-debug /input.ext | data.dump

--- a/interp/src/errors.rs
+++ b/interp/src/errors.rs
@@ -1,6 +1,6 @@
 use crate::flatten::{
     flat_ir::{
-        base::{AssignmentWinner, ComponentIdx, GlobalPortIdx},
+        base::{AssignmentWinner, ComponentIdx, GlobalCellIdx, GlobalPortIdx},
         prelude::AssignedValue,
     },
     structures::environment::Environment,
@@ -174,24 +174,24 @@ pub enum InterpreterError {
     /// memory. Contains the name of the register or memory as a string
     //TODO Griffin: Make this more descriptive
     #[error(
-        "Attempted to write an undefined value to register or memory named \"{0}\""
+        "Attempted to write an undefined value to register or memory named \"{0:?}\""
     )]
-    UndefinedWrite(String),
+    UndefinedWrite(GlobalCellIdx),
 
     /// The error for attempting to write to an undefined memory address. This
     /// is distinct from writing to an out of bounds address.
     //TODO Griffin: Make this more descriptive
     #[error(
-        "Attempted to write an undefined memory address in memory named \"{0}\""
+        "Attempted to write an undefined memory address in memory named \"{0:?}\""
     )]
-    UndefinedWriteAddr(String),
+    UndefinedWriteAddr(GlobalCellIdx),
 
     /// The error for attempting to read from an undefined memory address. This
     /// is distinct from reading from an out of bounds address.
     #[error(
-        "Attempted to read an undefined memory address from memory named \"{0}\""
+        "Attempted to read an undefined memory address from memory named \"{0:?}\""
     )]
-    UndefinedReadAddr(String),
+    UndefinedReadAddr(GlobalCellIdx),
 
     /// A wrapper for serialization errors
     #[error(transparent)]
@@ -292,6 +292,9 @@ impl InterpreterError {
                     format!("conflicting assignments to port \"{target}\":\n 1. assigned {a1_v} by {a1_str}{a1_source}\n 2. assigned {a2_v} by {a2_str}{a2_source}")
                 )
             }
+            InterpreterError::UndefinedWrite(c) => InterpreterError::GenericError(format!("Attempted to write an undefined value to register or memory named \"{}\"", env.get_full_name(c))),
+            InterpreterError::UndefinedWriteAddr(c) => InterpreterError::GenericError(format!("Attempted to write to an undefined memory address in memory named \"{}\"", env.get_full_name(c))),
+            InterpreterError::UndefinedReadAddr(c) => InterpreterError::GenericError(format!("Attempted to read from an undefined memory address from memory named \"{}\"", env.get_full_name(c))),
             e => e,
         }
     }

--- a/interp/src/errors.rs
+++ b/interp/src/errors.rs
@@ -1,4 +1,10 @@
-use crate::flatten::flat_ir::prelude::AssignedValue;
+use crate::flatten::{
+    flat_ir::{
+        base::{AssignmentWinner, ComponentIdx, GlobalPortIdx},
+        prelude::AssignedValue,
+    },
+    structures::environment::Environment,
+};
 use crate::values::Value;
 use calyx_ir::Id;
 use calyx_utils::{Error as CalyxError, MultiError as CalyxMultiError};
@@ -16,6 +22,16 @@ impl BoxedInterpreterError {
     /// Get a mutable reference to the inner error
     pub fn inner_mut(&mut self) -> &mut InterpreterError {
         &mut self.0
+    }
+
+    pub fn prettify_message<
+        C: AsRef<crate::flatten::structures::context::Context> + Clone,
+    >(
+        mut self,
+        env: &Environment<C>,
+    ) -> Self {
+        self.0 = Box::new(self.0.prettify_message(env));
+        self
     }
 }
 
@@ -112,6 +128,7 @@ pub enum InterpreterError {
     "
     )]
     FlatConflictingAssignments {
+        target: GlobalPortIdx,
         a1: AssignedValue,
         a2: AssignedValue,
     },
@@ -179,6 +196,10 @@ pub enum InterpreterError {
     /// A wrapper for serialization errors
     #[error(transparent)]
     SerializationError(#[from] crate::serialization::SerializationError),
+
+    /// A nonspecific error, used for arbitrary messages
+    #[error("{0}")]
+    GenericError(String),
 }
 
 // this is silly but needed to make the program print something sensible when returning
@@ -204,5 +225,74 @@ impl From<CalyxMultiError> for InterpreterError {
 impl From<std::str::Utf8Error> for InterpreterError {
     fn from(err: std::str::Utf8Error) -> Self {
         CalyxError::invalid_file(err.to_string()).into()
+    }
+}
+
+impl InterpreterError {
+    pub fn prettify_message<
+        C: AsRef<crate::flatten::structures::context::Context> + Clone,
+    >(
+        self,
+        env: &Environment<C>,
+    ) -> Self {
+        fn assign_to_string<C: AsRef<crate::flatten::structures::context::Context> + Clone>(
+            assign: &AssignedValue,
+            env: &Environment<C>,
+        ) -> (
+            String,
+            Option<(ComponentIdx, crate::flatten::flat_ir::component::AssignmentDefinitionLocation)>,
+        ){
+            match assign.winner() {
+                AssignmentWinner::Cell => ("Cell".to_string(), None),
+                AssignmentWinner::Implicit => ("Implicit".to_string(), None),
+                AssignmentWinner::Assign(idx) => {
+                    let (comp, loc) =
+                        env.ctx().find_assignment_definition(*idx);
+
+                    let str = env.ctx().printer().print_assignment(comp, *idx);
+                    (str, Some((comp, loc)))
+                }
+            }
+        }
+
+        fn source_to_string<
+            C: AsRef<crate::flatten::structures::context::Context> + Clone,
+        >(
+            source: &crate::flatten::flat_ir::component::AssignmentDefinitionLocation,
+            comp: ComponentIdx,
+            env: &Environment<C>,
+        ) -> String {
+            let comp_name = env.ctx().lookup_name(comp);
+            match source {
+                crate::flatten::flat_ir::component::AssignmentDefinitionLocation::CombGroup(g) => format!(" in comb group {comp_name}::{}", env.ctx().lookup_name(*g)),
+                crate::flatten::flat_ir::component::AssignmentDefinitionLocation::Group(g) => format!(" in group {comp_name}::{}", env.ctx().lookup_name(*g)),
+                crate::flatten::flat_ir::component::AssignmentDefinitionLocation::ContinuousAssignment => format!(" in {comp_name}'s continuous assignments"),
+                //TODO Griffin: Improve the identification of the invoke
+                crate::flatten::flat_ir::component::AssignmentDefinitionLocation::Invoke(_) => format!(" in an invoke in {comp_name}"),
+            }
+        }
+
+        match self {
+            InterpreterError::FlatConflictingAssignments { target, a1, a2 } => {
+                let (a1_str, a1_source) = assign_to_string(&a1, env);
+                let (a2_str, a2_source) = assign_to_string(&a2, env);
+
+                let a1_v = a1.val();
+                let a2_v = a2.val();
+                let a1_source = a1_source
+                    .map(|(comp, s)| source_to_string(&s, comp, env))
+                    .unwrap_or_default();
+                let a2_source = a2_source
+                    .map(|(comp, s)| source_to_string(&s, comp, env))
+                    .unwrap_or_default();
+
+                let target = env.get_full_name(target);
+
+                InterpreterError::GenericError(
+                    format!("conflicting assignments to port \"{target}\":\n 1. assigned {a1_v} by {a1_str}{a1_source}\n 2. assigned {a2_v} by {a2_str}{a2_source}")
+                )
+            }
+            e => e,
+        }
     }
 }

--- a/interp/src/flatten/flat_ir/base.rs
+++ b/interp/src/flatten/flat_ir/base.rs
@@ -402,6 +402,17 @@ pub enum AssignmentWinner {
     Assign(AssignmentIdx),
 }
 
+impl AssignmentWinner {
+    #[must_use]
+    pub fn as_assign(&self) -> Option<&AssignmentIdx> {
+        if let Self::Assign(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
 impl From<AssignmentIdx> for AssignmentWinner {
     fn from(v: AssignmentIdx) -> Self {
         Self::Assign(v)

--- a/interp/src/flatten/primitives/builder.rs
+++ b/interp/src/flatten/primitives/builder.rs
@@ -4,6 +4,7 @@ use super::{combinational::*, stateful::*, Primitive};
 use crate::{
     flatten::{
         flat_ir::{
+            base::GlobalCellIdx,
             cell_prototype::{
                 CellPrototype, DoubleWidthType, FXType, MemType,
                 SingleWidthType, TripleWidthType,
@@ -19,6 +20,8 @@ use crate::{
 pub fn build_primitive(
     prim: &CellInfo,
     base_port: GlobalPortIdx,
+    // the global idx of the instantiated primitive
+    cell_idx: GlobalCellIdx,
     // extras for memory initialization
     ctx: &Context,
     dump: &Option<DataDump>,
@@ -38,7 +41,9 @@ pub fn build_primitive(
             "Build primitive erroneously called on a calyx component"
         ),
         CellPrototype::SingleWidth { op, width } => match op {
-            SingleWidthType::Reg => Box::new(StdReg::new(base_port, *width)),
+            SingleWidthType::Reg => {
+                Box::new(StdReg::new(base_port, cell_idx, *width))
+            }
             SingleWidthType::Not => Box::new(StdNot::new(base_port)),
             SingleWidthType::And => Box::new(StdAnd::new(base_port)),
             SingleWidthType::Or => Box::new(StdOr::new(base_port)),
@@ -171,16 +176,20 @@ pub fn build_primitive(
                 MemType::Seq => Box::new(if let Some(data) = data {
                     memories_initialized
                         .insert(ctx.resolve_id(prim.name).clone());
-                    SeqMem::new_with_init(base_port, *width, false, dims, data)
+                    SeqMem::new_with_init(
+                        base_port, cell_idx, *width, false, dims, data,
+                    )
                 } else {
-                    SeqMemD1::new(base_port, *width, false, dims)
+                    SeqMemD1::new(base_port, cell_idx, *width, false, dims)
                 }),
                 MemType::Std => Box::new(if let Some(data) = data {
                     memories_initialized
                         .insert(ctx.resolve_id(prim.name).clone());
-                    CombMem::new_with_init(base_port, *width, false, dims, data)
+                    CombMem::new_with_init(
+                        base_port, cell_idx, *width, false, dims, data,
+                    )
                 } else {
-                    CombMem::new(base_port, *width, false, dims)
+                    CombMem::new(base_port, cell_idx, *width, false, dims)
                 }),
             }
         }

--- a/interp/src/flatten/structures/context.rs
+++ b/interp/src/flatten/structures/context.rs
@@ -2,7 +2,10 @@ use std::ops::Index;
 
 use crate::flatten::flat_ir::{
     cell_prototype::CellPrototype,
-    component::{AuxillaryComponentInfo, ComponentCore, ComponentMap},
+    component::{
+        AssignmentDefinitionLocation, AuxillaryComponentInfo, ComponentCore,
+        ComponentMap,
+    },
     identifier::IdMap,
     prelude::{
         Assignment, AssignmentIdx, CellDefinitionIdx, CellInfo, CombGroup,
@@ -414,6 +417,26 @@ impl Context {
     pub fn lookup_name<T: LookupName>(&self, id: T) -> &String {
         id.lookup_name(self)
     }
+
+    /// Returns information about where an assignment is defined and the
+    /// component in which it is defined.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the given assignment is not defined in any
+    /// component.
+    pub fn find_assignment_definition(
+        &self,
+        target: AssignmentIdx,
+    ) -> (ComponentIdx, AssignmentDefinitionLocation) {
+        for (idx, comp) in self.primary.components.iter() {
+            let found = comp.contains_assignment(self, target);
+            if found.is_some() {
+                return (idx.clone(), found.unwrap());
+            }
+        }
+        unreachable!("Assignment does not belong to any component");
+    }
 }
 
 impl AsRef<Context> for &Context {
@@ -447,5 +470,12 @@ impl LookupName for Identifier {
     #[inline]
     fn lookup_name<'ctx>(&self, ctx: &'ctx Context) -> &'ctx String {
         ctx.resolve_id(*self)
+    }
+}
+
+impl LookupName for CombGroupIdx {
+    #[inline]
+    fn lookup_name<'ctx>(&self, ctx: &'ctx Context) -> &'ctx String {
+        ctx.resolve_id(ctx.primary[*self].name())
     }
 }

--- a/interp/src/flatten/structures/context.rs
+++ b/interp/src/flatten/structures/context.rs
@@ -431,8 +431,8 @@ impl Context {
     ) -> (ComponentIdx, AssignmentDefinitionLocation) {
         for (idx, comp) in self.primary.components.iter() {
             let found = comp.contains_assignment(self, target);
-            if found.is_some() {
-                return (idx.clone(), found.unwrap());
+            if let Some(found) = found {
+                return (idx, found);
             }
         }
         unreachable!("Assignment does not belong to any component");

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -100,6 +100,7 @@ impl PortMap {
             // TODO: Fix to make the error more helpful
             Some(t) if t.has_conflict_with(&val) => InterpreterResult::Err(
                 InterpreterError::FlatConflictingAssignments {
+                    target,
                     a1: t.clone(),
                     a2: val,
                 }
@@ -1618,6 +1619,7 @@ impl<C: AsRef<Context> + Clone> Simulator<C> {
         let assigns_bundle = self.get_assignments(self.env.pc.node_slice());
 
         self.simulate_combinational(&assigns_bundle)
+            .map_err(|e| e.prettify_message(&self.env))
     }
 
     pub fn step(&mut self) -> InterpreterResult<()> {

--- a/interp/src/serialization/data_dump.rs
+++ b/interp/src/serialization/data_dump.rs
@@ -466,7 +466,7 @@ mod tests {
     }
 
     use crate::flatten::{
-        flat_ir::prelude::GlobalPortIdx,
+        flat_ir::{base::GlobalCellIdx, prelude::GlobalPortIdx},
         primitives::stateful::{CombMemD1, SeqMemD1},
         structures::index_trait::IndexRef,
     };
@@ -475,7 +475,7 @@ mod tests {
         #[test]
         fn comb_roundtrip(dump in arb_data_dump()) {
             for mem in &dump.header.memories {
-                let memory_prim = CombMemD1::new_with_init(GlobalPortIdx::new(0), mem.width(), false, mem.size(), dump.get_data(&mem.name).unwrap());
+                let memory_prim = CombMemD1::new_with_init(GlobalPortIdx::new(0), GlobalCellIdx::new(0), mem.width(), false, mem.size(), dump.get_data(&mem.name).unwrap());
                 let data = memory_prim.dump_data();
                 prop_assert_eq!(dump.get_data(&mem.name).unwrap(), data);
             }
@@ -484,7 +484,7 @@ mod tests {
         #[test]
         fn seq_roundtrip(dump in arb_data_dump()) {
             for mem in &dump.header.memories {
-                let memory_prim = SeqMemD1::new_with_init(GlobalPortIdx::new(0), mem.width(), false, mem.size(), dump.get_data(&mem.name).unwrap());
+                let memory_prim = SeqMemD1::new_with_init(GlobalPortIdx::new(0), GlobalCellIdx::new(0), mem.width(), false, mem.size(), dump.get_data(&mem.name).unwrap());
                 let data = memory_prim.dump_data();
                 prop_assert_eq!(dump.get_data(&mem.name).unwrap(), data);
             }

--- a/interp/tests/runt.toml
+++ b/interp/tests/runt.toml
@@ -143,6 +143,7 @@ fud2 --from calyx --to dat \
          --through cider \
          -s sim.data={}.data \
          -s calyx.args="--log off" \
+         -s cider.converter-flags="-r --legacy-quotes" \
          {} | jq --sort-keys
 """
 


### PR DESCRIPTION
Small tweak for cider which modifies the way errors are processed and improves the error message for conflicting assignments to print both assignments and their origin.

Also adds the data converter flags to the `fud2` flow.