### PR TITLE
Fix comment in ref docs

### DIFF
--- a/docs/lang/memories-by-reference.md
+++ b/docs/lang/memories-by-reference.md
@@ -47,7 +47,7 @@ Next, to pass the memory to the component, we use the `invoke` syntax:
 component add_one() -> () { ... }
 component main() -> () {
   cells {
-    A = comb_mem_d1(32, 4, 3); // A memory passed by reference.
+    A = comb_mem_d1(32, 4, 3); // A memory that will be passed by reference.
     one = add_one();
     ...
   }


### PR DESCRIPTION
This PR fixes a bug in a comment in a code snippet in a doc that I noticed during @EclecticGriffin's Cider2 talk