### PR TITLE
Mark std_bit_slice and more std_ops as combinational; std_bit_slice bug fixed.

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -1439,8 +1439,21 @@ class CellBuilder(CellLikeBuilder):
 
     def is_comb(self) -> bool:
         return self._cell.comp.id in (
+            # Numerical Operators
+            "std_lsh",
+            "std_rsh",
+            "std_cat",
             "std_add",
             "std_sub",
+            "std_slice",
+            "std_bit_slice",
+            "std_pad",
+            # Logical Operators
+            "std_not",
+            "std_and",
+            "std_or",
+            "std_xor",
+            # Comparison Operators
             "std_lt",
             "std_le",
             "std_ge",

--- a/docs/libraries/core.md
+++ b/docs/libraries/core.md
@@ -136,7 +136,7 @@ Slice out the lower OUT_WIDTH bits of an IN_WIDTH-bit value. Computes
 ---
 ### `std_bit_slice<IN_WIDTH, START_IDX, END_IDX, OUT_WIDTH>`
 Extract the bit-string starting at `START_IDX` and ending at `END_IDX - 1` from `in`.
-This is computed as `in[END_IDX:START_IDX]`.`OUT_WIDTH` must be specified to
+This is computed as `in[END_IDX-1:START_IDX]`.`OUT_WIDTH` must be specified to
 be `END_WIDTH - START_WITH` wide when instantiating the module.
 
 

--- a/primitives/core.sv
+++ b/primitives/core.sv
@@ -215,7 +215,7 @@ module std_bit_slice #(
    input wire logic [IN_WIDTH-1:0] in,
    output logic [OUT_WIDTH-1:0] out
 );
-    assign out = in[END_IDX:START_IDX];
+    assign out = in[END_IDX-1:START_IDX];
 
   `ifdef VERILATOR
     always_comb begin


### PR DESCRIPTION
This pull request has two contributions.

1. As #2292 mentioned, some ops are combinational but are not marked in Python is_comb() function.

2. Fixed bugs in std_bit_slice verilog template and doc, since in verilog a signal's slice [a:b] contains both a-th bit and b-th bit.