### PR TITLE
[Profiler] Instrumentation attempt; need help on errors

### DIFF
--- a/calyx-frontend/src/attribute.rs
+++ b/calyx-frontend/src/attribute.rs
@@ -76,6 +76,9 @@ pub enum BoolAttr {
     #[strum(serialize = "fast")]
     /// https://github.com/calyxir/calyx/issues/1828
     Fast,
+    #[strum(serialize = "protected")]
+    /// Do I preserve cells of this component during optimization?
+    Protected,
 }
 
 impl From<BoolAttr> for Attribute {

--- a/calyx-opt/src/passes/dead_cell_removal.rs
+++ b/calyx-opt/src/passes/dead_cell_removal.rs
@@ -129,13 +129,17 @@ impl Visitor for DeadCellRemoval {
         _sigs: &ir::LibrarySignatures,
         _comps: &[ir::Component],
     ) -> VisResult {
-        // Add @external cells and ref cells.
+        // Add @external cells, @protected cells and ref cells.
         self.all_reads.extend(
             comp.cells
                 .iter()
                 .filter(|c| {
                     let cell = c.borrow();
                     cell.attributes.get(ir::BoolAttr::External).is_some()
+                        || cell
+                            .attributes
+                            .get(ir::BoolAttr::Protected)
+                            .is_some()
                         || cell.is_reference()
                 })
                 .map(|c| c.borrow().name()),

--- a/primitives/compile.futil
+++ b/primitives/compile.futil
@@ -13,6 +13,11 @@ comb primitive std_wire<"share"=1>[WIDTH](@data in: WIDTH) -> (out: WIDTH) {
     assign out = in;
 }
 
+/// Wire for instrumentation
+primitive std_protected_wire[WIDTH](in: WIDTH) -> (out: WIDTH) {
+    assign out = in;
+}
+
 /// Add two numbers.
 comb primitive std_add<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) -> (out: WIDTH) {
   assign out = left + right;


### PR DESCRIPTION
I'm currently working on a first attempt at using instrumentation, specifically looking into ways to avoid compiler optimizations from removing any instrumentation wires/cells/tbd. This draft PR contains some small changes:

1. Adding a `@protected` attribute to be placed on cells that should not be optimized.
2. Modifying `dead-cell-removal`, which was removing my "instrumentation cells", to not remove cells with `@protected`.

This works with my [toy instrumented program](https://github.com/calyxir/calyx-profiler-sketches/blob/main/instrumentation/while-sandbox.futil), where `cond_inst` and `incr_inst` are my "instrumentation primitives", if `static-inference` and `static-promotion` are disabled.

However, when I don't disable those two passes, I get the following error message:
```
ayaka@ayaka-ThinkPad-T14s-Gen-4:~/projects/calyx$ cargo run -- ~/projects/calyx-profiler-sketches/instrumentation/while-sandbox.futil
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/calyx /home/ayaka/projects/calyx-profiler-sketches/instrumentation/while-sandbox.futil`
thread 'main' panicked at calyx-ir/src/common.rs:35:13:
internal error: entered unreachable code: weak reference points to a dropped value. Original object's name: `incr'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I've figured out that the error is happening during `dead-group-removal`, and right before `dead-group-removal` the wires and control in the compiled program look like the below (the original program only has groups `cond` and `incr`):
```
  wires {
    group cond<"promotable"=1> {
      cond_inst.in = !cond[done] ? 1'd1;
      lt_reg.write_en = 1'd1;
      lt.right = 32'd8;
      i.addr0 = 1'd0;
      lt.left = i.read_data;
      lt_reg.in = lt.out;
      cond[done] = lt_reg.done;
    }
    group incr<"promotable"=1> {
      incr_inst.in = !incr[done] ? 1'd1;
      i.write_en = 1'd1;
      i.addr0 = 1'd0;
      add.left = 32'd1;
      add.right = i.read_data;
      i.write_data = add.out;
      incr[done] = i.done;
    }
    static<1> group incr0 {
      incr_inst.in = !incr[done] ? 1'd1;
      i.write_en = 1'd1;
      i.addr0 = 1'd0;
      add.left = 32'd1;
      add.right = i.read_data;
      i.write_data = add.out;
    }
    static<1> group cond0 {
      cond_inst.in = !cond[done] ? 1'd1;
      lt_reg.write_en = 1'd1;
      lt.right = 32'd8;
      i.addr0 = 1'd0;
      lt.left = i.read_data;
      lt_reg.in = lt.out;
    }
  }
  control {
    seq {
      @NODE_ID cond;
      @NODE_ID(2) while lt_reg.out {
        static<3> seq  {
          @NODE_ID(4) incr0;
          @NODE_ID(5) incr0;
          @NODE_ID(6) cond0;
        }
      }
    }
  }
```
So, my hypothesis is that `static-inference` and `static-promotion` creates "static versions" of the two groups, and `dead-group-removal` removes `incr` (the group), but the `incr_inst` within the (newly created static) group `incr0` panicks because the `incr` group is now gone.

Does anyone have any insights or suggestions wrt this problem? Thank you so much in advance! (I'll keep it as a draft until I fix the problem, unless if anyone thinks otherwise)