### PR TITLE
Queues: remove duplicate components

### DIFF
--- a/frontends/queues/queues/binheap/stable_binheap.py
+++ b/frontends/queues/queues/binheap/stable_binheap.py
@@ -33,7 +33,8 @@ def insert_stable_binheap(prog, name, queue_len_factor=FACTOR):
 
     comp = prog.component(name)
 
-    below = comp.cell("below", insert_binheap(prog, "below", queue_len_factor, 64, 32))
+    heap = insert_binheap(prog, "heap", queue_len_factor, 64, 32)
+    below = comp.cell("below", heap)
 
     cmd = comp.input("cmd", 1)
     rank = comp.input("rank", 32)

--- a/frontends/queues/queues/strict_or_rr.py
+++ b/frontends/queues/queues/strict_or_rr.py
@@ -214,10 +214,8 @@ def generate(prog, numflows, roundrobin):
     else:
         raise ValueError("Unsupported number of flows")
 
-    subqueues = [
-        fifo.insert_fifo(prog, f"subqueue{i}", QUEUE_LEN_FACTOR)
-        for i in range(numflows)
-    ]
+    f = fifo.insert_fifo(prog, "fifo", QUEUE_LEN_FACTOR)
+    subqueues = [f] * numflows
     pifo = insert_queue(
         prog, "pifo", subqueues, boundaries, numflows, order, roundrobin
     )

--- a/frontends/queues/queues/strict_or_rr.py
+++ b/frontends/queues/queues/strict_or_rr.py
@@ -214,8 +214,8 @@ def generate(prog, numflows, roundrobin):
     else:
         raise ValueError("Unsupported number of flows")
 
-    f = fifo.insert_fifo(prog, "fifo", QUEUE_LEN_FACTOR)
-    subqueues = [f] * numflows
+    fifo_queue = fifo.insert_fifo(prog, "fifo", QUEUE_LEN_FACTOR)
+    subqueues = [fifo_queue] * numflows
     pifo = insert_queue(
         prog, "pifo", subqueues, boundaries, numflows, order, roundrobin
     )

--- a/frontends/queues/tests/binheap/stable_binheap_test.py
+++ b/frontends/queues/tests/binheap/stable_binheap_test.py
@@ -10,7 +10,7 @@ def build():
     num_cmds = int(sys.argv[1])
     keepgoing = "--keepgoing" in sys.argv
     prog = cb.Builder()
-    binheap = stable_binheap.insert_stable_binheap(prog, "binheap")
+    binheap = stable_binheap.insert_stable_binheap(prog, "stable_binheap")
     qc.insert_main(prog, binheap, num_cmds, keepgoing=keepgoing, use_ranks=True)
     return prog.program
 

--- a/frontends/queues/tests/complex_tree_test.py
+++ b/frontends/queues/tests/complex_tree_test.py
@@ -14,19 +14,12 @@ def build():
     keepgoing = "--keepgoing" in sys.argv
     prog = cb.Builder()
 
-    fifo_A = fifo.insert_fifo(prog, "fifo_A")
-    fifo_B = fifo.insert_fifo(prog, "fifo_B")
-    fifo_C = fifo.insert_fifo(prog, "fifo_C")
-    fifo_D = fifo.insert_fifo(prog, "fifo_D")
-    fifo_E = fifo.insert_fifo(prog, "fifo_E")
-    fifo_F = fifo.insert_fifo(prog, "fifo_F")
-    fifo_G = fifo.insert_fifo(prog, "fifo_G")
-    fifo_H = fifo.insert_fifo(prog, "fifo_H")
+    f = fifo.insert_fifo(prog, "fifo")
 
     pifo_strict1 = strict_or_rr.insert_queue(
         prog,
         "pifo_strict1",
-        [fifo_A, fifo_B, fifo_C],
+        [f, f, f],
         [0, 44, 88, 133],
         3,
         [0, 1, 2],
@@ -35,14 +28,14 @@ def build():
     pifo_rr = strict_or_rr.insert_queue(
         prog,
         "pifo_rr",
-        [fifo_D, fifo_E, fifo_F],
+        [f, f, f],
         [133, 177, 221, 266],
         3,
         [0, 1, 2],
         True,
     )
     pifo_strict2 = strict_or_rr.insert_queue(
-        prog, "pifo_strict2", [fifo_G, fifo_H], [266, 333, 400], 2, [0, 1], False
+        prog, "pifo_strict2", [f, f], [266, 333, 400], 2, [0, 1], False
     )
     pifo_root = strict_or_rr.insert_queue(
         prog,

--- a/frontends/queues/tests/complex_tree_test.py
+++ b/frontends/queues/tests/complex_tree_test.py
@@ -14,12 +14,12 @@ def build():
     keepgoing = "--keepgoing" in sys.argv
     prog = cb.Builder()
 
-    f = fifo.insert_fifo(prog, "fifo")
+    fifo_queue = fifo.insert_fifo(prog, "fifo")
 
     pifo_strict1 = strict_or_rr.insert_queue(
         prog,
         "pifo_strict1",
-        [f, f, f],
+        [fifo_queue, fifo_queue, fifo_queue],
         [0, 44, 88, 133],
         3,
         [0, 1, 2],
@@ -28,14 +28,20 @@ def build():
     pifo_rr = strict_or_rr.insert_queue(
         prog,
         "pifo_rr",
-        [f, f, f],
+        [fifo_queue, fifo_queue, fifo_queue],
         [133, 177, 221, 266],
         3,
         [0, 1, 2],
         True,
     )
     pifo_strict2 = strict_or_rr.insert_queue(
-        prog, "pifo_strict2", [f, f], [266, 333, 400], 2, [0, 1], False
+        prog,
+        "pifo_strict2",
+        [fifo_queue, fifo_queue],
+        [266, 333, 400],
+        2,
+        [0, 1],
+        False,
     )
     pifo_root = strict_or_rr.insert_queue(
         prog,

--- a/frontends/queues/tests/pifo_tree_test.py
+++ b/frontends/queues/tests/pifo_tree_test.py
@@ -11,14 +11,12 @@ def build():
     num_cmds = int(sys.argv[1])
     keepgoing = "--keepgoing" in sys.argv
     prog = cb.Builder()
-    fifo_purple = fifo.insert_fifo(prog, "fifo_purple")
-    fifo_tangerine = fifo.insert_fifo(prog, "fifo_tangerine")
+    f = fifo.insert_fifo(prog, "fifo")
     pifo_red = strict_or_rr.insert_queue(
-        prog, "pifo_red", [fifo_purple, fifo_tangerine], [0, 100, 200], 2, [], True
+        prog, "pifo_red", [f, f], [0, 100, 200], 2, [], True
     )
-    fifo_blue = fifo.insert_fifo(prog, "fifo_blue")
     pifo_root = strict_or_rr.insert_queue(
-        prog, "pifo_root", [pifo_red, fifo_blue], [0, 200, 400], 2, [], True
+        prog, "pifo_root", [pifo_red, f], [0, 200, 400], 2, [], True
     )
     qc.insert_main(prog, pifo_root, num_cmds, keepgoing=keepgoing)
     return prog.program

--- a/frontends/queues/tests/pifo_tree_test.py
+++ b/frontends/queues/tests/pifo_tree_test.py
@@ -11,12 +11,12 @@ def build():
     num_cmds = int(sys.argv[1])
     keepgoing = "--keepgoing" in sys.argv
     prog = cb.Builder()
-    f = fifo.insert_fifo(prog, "fifo")
+    fifo_queue = fifo.insert_fifo(prog, "fifo")
     pifo_red = strict_or_rr.insert_queue(
-        prog, "pifo_red", [f, f], [0, 100, 200], 2, [], True
+        prog, "pifo_red", [fifo_queue, fifo_queue], [0, 100, 200], 2, [], True
     )
     pifo_root = strict_or_rr.insert_queue(
-        prog, "pifo_root", [pifo_red, f], [0, 200, 400], 2, [], True
+        prog, "pifo_root", [pifo_red, fifo_queue], [0, 200, 400], 2, [], True
     )
     qc.insert_main(prog, pifo_root, num_cmds, keepgoing=keepgoing)
     return prog.program

--- a/frontends/queues/tests/sdn_test.py
+++ b/frontends/queues/tests/sdn_test.py
@@ -108,14 +108,12 @@ def build(static=False):
     stats_component = insert_stats(prog, "stats", static)
     controller = insert_controller(prog, "controller", stats_component)
 
-    fifo_purple = fifo.insert_fifo(prog, "fifo_purple")
-    fifo_tangerine = fifo.insert_fifo(prog, "fifo_tangerine")
+    f = fifo.insert_fifo(prog, "fifo")
     pifo_red = strict_or_rr.insert_queue(
-        prog, "pifo_red", [fifo_purple, fifo_tangerine], [0, 100, 200], 2, [], True
+        prog, "pifo_red", [f, f], [0, 100, 200], 2, [], True
     )
-    fifo_blue = fifo.insert_fifo(prog, "fifo_blue")
     pifo_root = strict_or_rr.insert_queue(
-        prog, "pifo_root", [pifo_red, fifo_blue], [0, 200, 400], 2, [], True
+        prog, "pifo_root", [pifo_red, f], [0, 200, 400], 2, [], True
     )
 
     qc.insert_main(prog, pifo_root, num_cmds, keepgoing=keepgoing)

--- a/frontends/queues/tests/sdn_test.py
+++ b/frontends/queues/tests/sdn_test.py
@@ -108,12 +108,12 @@ def build(static=False):
     stats_component = insert_stats(prog, "stats", static)
     controller = insert_controller(prog, "controller", stats_component)
 
-    f = fifo.insert_fifo(prog, "fifo")
+    fifo_queue = fifo.insert_fifo(prog, "fifo")
     pifo_red = strict_or_rr.insert_queue(
-        prog, "pifo_red", [f, f], [0, 100, 200], 2, [], True
+        prog, "pifo_red", [fifo_queue, fifo_queue], [0, 100, 200], 2, [], True
     )
     pifo_root = strict_or_rr.insert_queue(
-        prog, "pifo_root", [pifo_red, f], [0, 200, 400], 2, [], True
+        prog, "pifo_root", [pifo_red, fifo_queue], [0, 200, 400], 2, [], True
     )
 
     qc.insert_main(prog, pifo_root, num_cmds, keepgoing=keepgoing)


### PR DESCRIPTION
Here's a snippet from [`complex_tree_test.py`](https://github.com/calyxir/calyx/blob/49fbc2a2e5a962b33380a6d7f2c339b841e7bd2f/frontends/queues/tests/complex_tree_test.py)
```python
def build():
    """Top-level function to build the program."""
    num_cmds = int(sys.argv[1])
    keepgoing = "--keepgoing" in sys.argv
    prog = cb.Builder()

    fifo_A = fifo.insert_fifo(prog, "fifo_A")
    fifo_B = fifo.insert_fifo(prog, "fifo_B")
    fifo_C = fifo.insert_fifo(prog, "fifo_C")
    fifo_D = fifo.insert_fifo(prog, "fifo_D")
    fifo_E = fifo.insert_fifo(prog, "fifo_E")
    fifo_F = fifo.insert_fifo(prog, "fifo_F")
    fifo_G = fifo.insert_fifo(prog, "fifo_G")
    fifo_H = fifo.insert_fifo(prog, "fifo_H")

    pifo_strict1 = strict_or_rr.insert_queue(
        prog,
        "pifo_strict1",
        [fifo_A, fifo_B, fifo_C],
        [0, 44, 88, 133],
        3,
        [0, 1, 2],
        False,
    )
   ...
```
In particular, notice our eight calls to `insert_fifo`; this puts eight identical fifo components into our `.futil` file:


```
import "primitives/core.futil";
import "primitives/memories/seq.futil";
import "primitives/binary_operators.futil";
component fifo_A(cmd: 1, value: 32) -> () {
...
}
component fifo_B(cmd: 1, value: 32) -> () {
...
}
component fifo_C(cmd: 1, value: 32) -> () {
...
}
component fifo_D(cmd: 1, value: 32) -> () {
...
}
...
```

At first, this sounds like the right idea since our PIFO tree has eight FIFOs at the leaves. However, remember merely declaring non-main components in Calyx doesn't insert anything into hardware! Instead, these act more like blueprints. To put them into hardware, we use these blueprints by instantiating cells of these components. This means we should have one FIFO blueprint (component) and build eight different cells from it: these eights cells would be completely separate, with no shared state, as desired.
 
This PR makes this change across `complex_tree_test`, `strict_or_rr` related tests, `pifo_tree_test`, and `sdn_test`.

All credit to @ayakayorihiro for noticing this issue!
