### PR TITLE
bump fst-writer version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "fst-writer"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17dac4299fb4b037b8ce0d68b9e0ce7c61e5fbb038251f8f28148528f925b69"
+checksum = "d70529890a0a27d43374a430d7faf7634ef8df0ae775bb2836d92468eb74d61f"
 dependencies = [
  "lz4_flex",
  "thiserror",

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -47,7 +47,7 @@ btor2i = { path = "../tools/btor2/btor2i" }
 
 ciborium = "0.2.2"
 baa = { version = "0.6.0", features = ["bigint", "serde1", "fraction1"] }
-fst-writer = "0.2.0"
+fst-writer = "0.2.1"
 
 [dev-dependencies]
 proptest = "1.0.0"


### PR DESCRIPTION
This upgrades to the latest fst-writer which produces FST files that (generally) do not crash gtkwave.

Before this change, most FSTs generated by cider would crash GTKWave :cry: .