### PR TITLE
bump baa to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,14 +217,13 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "baa"
-version = "0.6.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfafaa7f46ae31982d3e55dad223ebb884a5da626aba403c66673ce9d1831f53"
+checksum = "9aca4f2e283a3de6f3c40834fc27668303e33662676e90254b5168271209ef95"
 dependencies = [
  "fraction",
  "num-bigint",
  "serde",
- "smallvec",
 ]
 
 [[package]]

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -46,7 +46,7 @@ calyx-frontend = { path = "../calyx-frontend" }
 btor2i = { path = "../tools/btor2/btor2i" }
 
 ciborium = "0.2.2"
-baa = { version = "0.6.0", features = ["bigint", "serde1", "fraction1"] }
+baa = { version = "0.14.0", features = ["bigint", "serde1", "fraction1"] }
 fst-writer = "0.2.1"
 bon = "2.3"
 


### PR DESCRIPTION
This reduces the size of BitVecValue from 32 bytes to 24 bytes.