### PR TITLE
[Cider | Fud2 stage] Make `sim.data` optional for the Cider fud2 flow

### DIFF
--- a/fud2/scripts/cider.rhai
+++ b/fud2/scripts/cider.rhai
@@ -16,33 +16,50 @@ fn cider_setup(e) {
         "cider-converter.exe",
         "$calyx-base/target/debug/cider-data-converter",
     );
-    e.rule(
-        "run-cider-debug",
-        "$cider-exe -l $calyx-base --data data.dump $cider-flags $in debug || true",
-    );
-    e.arg("pool", "console");
-
     e.config_var_or("converter-flags", "cider.converter-flags", "");
     e.config_var_or("cider-flags", "cider.flags", "");
 
+    let has_data = !e.config_or("sim.data", "").is_empty();
+
+    if has_data {
+        e.var_("data", "--data data.dump");
+
+        // copied from rtl_sim.rhai, we only want to do this when the sim.data
+        // flag is present
+        let data_name = e.config_val("sim.data");
+        let data_path = e.external_path(data_name);
+        e.var_("sim_data", data_path);
+    } else {
+        e.var_("data", "")
+    }
+
+    e.rule(
+        "run-cider-debug",
+        "$cider-exe -l $calyx-base $data $cider-flags $in debug || true",
+    );
+    e.arg("pool", "console");
+
     e.rule(
         "run-cider",
-        "$cider-exe -l $calyx-base --data data.dump $cider-flags $in > $out",
+        "$cider-exe -l $calyx-base $data $cider-flags $in > $out",
     );
 
-    e.rule("dump-to-interp", "$cider-converter --to cider $converter-flags $in > $out");
     e.rule("interp-to-dump", "$cider-converter --to json $converter-flags $in > $out");
-    e.build_cmd(
-        ["data.dump"],
-        "dump-to-interp",
-        ["$sim_data"],
-        ["$cider-converter"],
-    );
+
+    if has_data {
+        e.rule("dump-to-interp", "$cider-converter --to cider $converter-flags $in > $out");
+        e.build_cmd(
+            ["data.dump"],
+            "dump-to-interp",
+            ["$sim_data"],
+            ["$cider-converter"],
+        );
+    }
 }
 
 op(
     "calyx-to-cider",
-    [sim::sim_setup, c::calyx_setup],
+    [c::calyx_setup],
     c::calyx_state,
     cider_state,
     |e, input, output| {
@@ -58,22 +75,23 @@ op(
 
 op(
     "cider",
-    [sim::sim_setup, c::calyx_setup, cider_setup],
+    [c::calyx_setup, cider_setup],
     cider_state,
     sim::dat,
     |e, input, output| {
         let out_file = "interp_out.dump";
+        let dependencies = if e.config_or("sim.data", "").is_empty() { [] } else { ["data.dump"] };
         e.build_cmd(
             [out_file],
             "run-cider",
             [input],
-            ["data.dump"],
+            dependencies,
         );
         e.build_cmd(
             [output],
             "interp-to-dump",
             [out_file],
-            ["$sim_data", "$cider-converter"],
+            ["$cider-converter"],
         );
     },
 );
@@ -81,7 +99,6 @@ op(
 op(
     "debug",
     [
-        sim::sim_setup,
         tb::standalone_setup,
         c::calyx_setup,
         cider_setup,
@@ -89,6 +106,7 @@ op(
     cider_state,
     dbg,
     |e, input, output| {
-        e.build_cmd([output], "run-cider-debug", [input], ["data.dump"]);
+        let dependencies = if e.config_or("sim.data", "").is_empty() { [] } else { ["data.dump"] };
+        e.build_cmd([output], "run-cider-debug", [input], dependencies);
     },
 );

--- a/fud2/tests/snapshots/tests__test@calyx_through_cider_to_dat.snap
+++ b/fud2/tests/snapshots/tests__test@calyx_through_cider_to_dat.snap
@@ -6,19 +6,6 @@ build-tool = fud2
 rule get-rsrc
   command = $build-tool get-rsrc $out
 
-python = python3
-build json-dat.py: get-rsrc
-rule hex-data
-  command = $python json-dat.py --from-json $in $out
-rule json-data
-  command = $python json-dat.py --to-json $out $in
-sim_data = /test/data.json
-datadir = sim_data
-build $datadir: hex-data $sim_data | json-dat.py
-rule sim-run
-  command = ./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle-limit $args > $out
-cycle-limit = 500000000
-
 calyx-base = /test/calyx
 calyx-exe = $calyx-base/target/debug/calyx
 args = 
@@ -32,21 +19,23 @@ rule calyx-with-flags
 
 cider-exe = $calyx-base/target/debug/cider
 cider-converter = $calyx-base/target/debug/cider-data-converter
-rule run-cider-debug
-  command = $cider-exe -l $calyx-base --data data.dump $cider-flags $in debug || true
-  pool = console
 converter-flags = 
 cider-flags = 
+data = --data data.dump
+sim_data = /test/data.json
+rule run-cider-debug
+  command = $cider-exe -l $calyx-base $data $cider-flags $in debug || true
+  pool = console
 rule run-cider
-  command = $cider-exe -l $calyx-base --data data.dump $cider-flags $in > $out
-rule dump-to-interp
-  command = $cider-converter --to cider $converter-flags $in > $out
+  command = $cider-exe -l $calyx-base $data $cider-flags $in > $out
 rule interp-to-dump
   command = $cider-converter --to json $converter-flags $in > $out
+rule dump-to-interp
+  command = $cider-converter --to cider $converter-flags $in > $out
 build data.dump: dump-to-interp $sim_data | $cider-converter
 
 build pseudo_cider: calyx-with-flags _from_stdin_calyx.futil
 build interp_out.dump: run-cider pseudo_cider | data.dump
-build _to_stdout_dat.json: interp-to-dump interp_out.dump | $sim_data $cider-converter
+build _to_stdout_dat.json: interp-to-dump interp_out.dump | $cider-converter
 
 default _to_stdout_dat.json

--- a/fud2/tests/snapshots/tests__test@calyx_to_cider-debug.snap
+++ b/fud2/tests/snapshots/tests__test@calyx_to_cider-debug.snap
@@ -6,19 +6,6 @@ build-tool = fud2
 rule get-rsrc
   command = $build-tool get-rsrc $out
 
-python = python3
-build json-dat.py: get-rsrc
-rule hex-data
-  command = $python json-dat.py --from-json $in $out
-rule json-data
-  command = $python json-dat.py --to-json $out $in
-sim_data = /test/data.json
-datadir = sim_data
-build $datadir: hex-data $sim_data | json-dat.py
-rule sim-run
-  command = ./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle-limit $args > $out
-cycle-limit = 500000000
-
 calyx-base = /test/calyx
 calyx-exe = $calyx-base/target/debug/calyx
 args = 
@@ -34,17 +21,19 @@ build tb.sv: get-rsrc
 
 cider-exe = $calyx-base/target/debug/cider
 cider-converter = $calyx-base/target/debug/cider-data-converter
-rule run-cider-debug
-  command = $cider-exe -l $calyx-base --data data.dump $cider-flags $in debug || true
-  pool = console
 converter-flags = 
 cider-flags = 
+data = --data data.dump
+sim_data = /test/data.json
+rule run-cider-debug
+  command = $cider-exe -l $calyx-base $data $cider-flags $in debug || true
+  pool = console
 rule run-cider
-  command = $cider-exe -l $calyx-base --data data.dump $cider-flags $in > $out
-rule dump-to-interp
-  command = $cider-converter --to cider $converter-flags $in > $out
+  command = $cider-exe -l $calyx-base $data $cider-flags $in > $out
 rule interp-to-dump
   command = $cider-converter --to json $converter-flags $in > $out
+rule dump-to-interp
+  command = $cider-converter --to cider $converter-flags $in > $out
 build data.dump: dump-to-interp $sim_data | $cider-converter
 
 build pseudo_cider: calyx-with-flags _from_stdin_calyx.futil

--- a/fud2/tests/snapshots/tests__test@plan_calyx-to-cider.snap
+++ b/fud2/tests/snapshots/tests__test@plan_calyx-to-cider.snap
@@ -6,19 +6,6 @@ build-tool = fud2
 rule get-rsrc
   command = $build-tool get-rsrc $out
 
-python = python3
-build json-dat.py: get-rsrc
-rule hex-data
-  command = $python json-dat.py --from-json $in $out
-rule json-data
-  command = $python json-dat.py --to-json $out $in
-sim_data = /test/data.json
-datadir = sim_data
-build $datadir: hex-data $sim_data | json-dat.py
-rule sim-run
-  command = ./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle-limit $args > $out
-cycle-limit = 500000000
-
 calyx-base = /test/calyx
 calyx-exe = $calyx-base/target/debug/calyx
 args = 

--- a/fud2/tests/snapshots/tests__test@plan_cider.snap
+++ b/fud2/tests/snapshots/tests__test@plan_cider.snap
@@ -6,19 +6,6 @@ build-tool = fud2
 rule get-rsrc
   command = $build-tool get-rsrc $out
 
-python = python3
-build json-dat.py: get-rsrc
-rule hex-data
-  command = $python json-dat.py --from-json $in $out
-rule json-data
-  command = $python json-dat.py --to-json $out $in
-sim_data = /test/data.json
-datadir = sim_data
-build $datadir: hex-data $sim_data | json-dat.py
-rule sim-run
-  command = ./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle-limit $args > $out
-cycle-limit = 500000000
-
 calyx-base = /test/calyx
 calyx-exe = $calyx-base/target/debug/calyx
 args = 
@@ -32,20 +19,22 @@ rule calyx-with-flags
 
 cider-exe = $calyx-base/target/debug/cider
 cider-converter = $calyx-base/target/debug/cider-data-converter
-rule run-cider-debug
-  command = $cider-exe -l $calyx-base --data data.dump $cider-flags $in debug || true
-  pool = console
 converter-flags = 
 cider-flags = 
+data = --data data.dump
+sim_data = /test/data.json
+rule run-cider-debug
+  command = $cider-exe -l $calyx-base $data $cider-flags $in debug || true
+  pool = console
 rule run-cider
-  command = $cider-exe -l $calyx-base --data data.dump $cider-flags $in > $out
-rule dump-to-interp
-  command = $cider-converter --to cider $converter-flags $in > $out
+  command = $cider-exe -l $calyx-base $data $cider-flags $in > $out
 rule interp-to-dump
   command = $cider-converter --to json $converter-flags $in > $out
+rule dump-to-interp
+  command = $cider-converter --to cider $converter-flags $in > $out
 build data.dump: dump-to-interp $sim_data | $cider-converter
 
 build interp_out.dump: run-cider /input.ext | data.dump
-build /output.ext: interp-to-dump interp_out.dump | $sim_data $cider-converter
+build /output.ext: interp-to-dump interp_out.dump | $cider-converter
 
 default /output.ext

--- a/fud2/tests/snapshots/tests__test@plan_debug.snap
+++ b/fud2/tests/snapshots/tests__test@plan_debug.snap
@@ -6,19 +6,6 @@ build-tool = fud2
 rule get-rsrc
   command = $build-tool get-rsrc $out
 
-python = python3
-build json-dat.py: get-rsrc
-rule hex-data
-  command = $python json-dat.py --from-json $in $out
-rule json-data
-  command = $python json-dat.py --to-json $out $in
-sim_data = /test/data.json
-datadir = sim_data
-build $datadir: hex-data $sim_data | json-dat.py
-rule sim-run
-  command = ./$bin +DATA=$datadir +CYCLE_LIMIT=$cycle-limit $args > $out
-cycle-limit = 500000000
-
 build tb.sv: get-rsrc
 
 calyx-base = /test/calyx
@@ -34,17 +21,19 @@ rule calyx-with-flags
 
 cider-exe = $calyx-base/target/debug/cider
 cider-converter = $calyx-base/target/debug/cider-data-converter
-rule run-cider-debug
-  command = $cider-exe -l $calyx-base --data data.dump $cider-flags $in debug || true
-  pool = console
 converter-flags = 
 cider-flags = 
+data = --data data.dump
+sim_data = /test/data.json
+rule run-cider-debug
+  command = $cider-exe -l $calyx-base $data $cider-flags $in debug || true
+  pool = console
 rule run-cider
-  command = $cider-exe -l $calyx-base --data data.dump $cider-flags $in > $out
-rule dump-to-interp
-  command = $cider-converter --to cider $converter-flags $in > $out
+  command = $cider-exe -l $calyx-base $data $cider-flags $in > $out
 rule interp-to-dump
   command = $cider-converter --to json $converter-flags $in > $out
+rule dump-to-interp
+  command = $cider-converter --to cider $converter-flags $in > $out
 build data.dump: dump-to-interp $sim_data | $cider-converter
 
 build /output.ext: run-cider-debug /input.ext | data.dump

--- a/interp/tests/complex/unsigned-dot-product.futil
+++ b/interp/tests/complex/unsigned-dot-product.futil
@@ -17,7 +17,7 @@ component main() -> () {
     @external mult = std_mult_pipe(32);
   }
   wires {
-    comb group is_less_than<"static"=0> {
+    comb group is_less_than {
       lt0.left = counter.out;
       lt0.right = 3'd4;
     } // Control segment for `counter` < `4`.
@@ -70,13 +70,13 @@ component main() -> () {
       initialize_mem_3[done] = mem0.done & mem1.done ? 1'd1;
     }
 
-    group initialize_counter<"static"=1> {
+    group initialize_counter {
       counter.in = 3'd0;
       counter.write_en = 1'd1;
       initialize_counter[done] = counter.done;
     }
 
-    group incr_counter<"static"=1> {
+    group incr_counter {
       counter.write_en = 1'd1;
       add0.left = counter.out;
       add0.right = 3'd1; // Increment by 1.
@@ -100,7 +100,7 @@ component main() -> () {
       mul[done] = t.done;
     }
 
-    group add<"static"=1> {
+    group add {
       add1.left = t.out;
       add1.right = r_2.out;
       r_2.write_en = 1'd1;

--- a/interp/tests/control/while.futil
+++ b/interp/tests/control/while.futil
@@ -19,7 +19,7 @@ component main() -> () {
       cond[done] = lt_reg.done;
     }
 
-    group incr<"static"=1> {
+    group incr {
       i.write_en = 1'b1;
       i.write_data = add.out;
       i.addr0 = 1'd0;

--- a/interp/tests/primitives/mem.futil
+++ b/interp/tests/primitives/mem.futil
@@ -8,14 +8,14 @@ component main() -> () {
   }
 
   wires {
-    group write<"static"=1> {
+    group write {
       mem.write_en = 1'd1;
       mem.addr0 = 1'd0;
       mem.write_data = 32'd9;
       write[done] = mem.done;
     }
 
-    group read<"static"=1> {
+    group read{
       mem.addr0 = 1'd0;
       reg0.write_en = 1'd1;
       reg0.in = mem.read_data;

--- a/interp/tests/runt.toml
+++ b/interp/tests/runt.toml
@@ -1,6 +1,8 @@
 ver = "0.4.1"
 
 # Check basic functionality of the interpreter
+# note that due to error printing in fud2 we can't run the error tests on CI
+# through it, so this suite has direct invocations instead
 [[tests]]
 name = "unit"
 paths = ["unit/*.futil"]
@@ -14,7 +16,10 @@ expect_dir = "unit"
 name = "multi-comp"
 paths = ["multi-comp/*.futil"]
 cmd = """
-../../target/debug/cider {} -l ../../ --dump-registers | ../../target/debug/cider-data-converter --to json | jq --sort-keys
+fud2 --from calyx --to dat \
+         --through cider \
+         -s cider.flags="--dump-registers" \
+         {} | jq --sort-keys
 """
 timeout = 10
 
@@ -32,7 +37,10 @@ name = "complex"
 paths = ["complex/*.futil"]
 
 cmd = """
-../../target/debug/cider {} -l ../../  --dump-registers | ../../target/debug/cider-data-converter --to json | jq --sort-keys
+fud2 --from calyx --to dat \
+         --through cider \
+         -s cider.flags="--dump-registers" \
+         {} | jq --sort-keys
 """
 timeout = 10
 expect_dir = "complex"
@@ -41,7 +49,11 @@ expect_dir = "complex"
 name = "primitives"
 paths = ["primitives/*.futil"]
 cmd = """
-../../target/debug/cider {} -l ../../  --dump-registers | ../../target/debug/cider-data-converter --to json | jq  --sort-keys
+fud2 --from calyx --to dat \
+         --through cider \
+         -s calyx.args="--log off" \
+         -s cider.flags="--dump-registers" \
+         {} | jq --sort-keys
 """
 timeout = 10
 expect_dir = "primitives"
@@ -59,7 +71,10 @@ expect_dir = "par-to-seq"
 name = "control"
 paths = ["control/*.futil", "control/iteration/*.futil"]
 cmd = """
-../../target/debug/cider {} -l ../../  --dump-registers | ../../target/debug/cider-data-converter --to json | jq --sort-keys
+fud2 --from calyx --to dat \
+         --through cider \
+         -s cider.flags="--dump-registers" \
+         {} | jq --sort-keys
 """
 timeout = 10
 expect_dir = "control"


### PR DESCRIPTION
A quick patch for the `fud2` flow which makes it possible to run without supplying a `sim.data` value which would otherwise block things. This hopefully makes testing small programs more straightforward as it no longer requires generating an empty data file or using direct invocations of the tools.

