### PR TITLE
add floating point support to cider

### DIFF
--- a/interp/src/flatten/flat_ir/cell_prototype.rs
+++ b/interp/src/flatten/flat_ir/cell_prototype.rs
@@ -403,6 +403,30 @@ impl CellPrototype {
                         c_type: ConstantType::Primitive,
                     }
                 }
+                "std_float_const" => {
+                    get_params![params;
+                        value: "VALUE",
+                        width: "WIDTH",
+                        rep: "REP"
+                    ];
+
+                    debug_assert_eq!(
+                        rep, 0,
+                        "Only supported floating point representation is IEEE."
+                    );
+                    debug_assert!(
+                        width == 32 || width == 64,
+                        "Only 32 and 64 bit floats are supported."
+                    );
+
+                    // we can treat floating point constants like any other constant since the
+                    // frontend already converts the number to bits for us
+                    Self::Constant {
+                        value,
+                        width: width.try_into().unwrap(),
+                        c_type: ConstantType::Primitive,
+                    }
+                }
                 n @ ("std_add" | "std_sadd") => {
                     get_params![params; width: "WIDTH"];
 

--- a/interp/src/serialization/data_dump.rs
+++ b/interp/src/serialization/data_dump.rs
@@ -55,6 +55,10 @@ pub enum FormatInfo {
         int_width: u32,
         frac_width: u32,
     },
+    IEEFloat {
+        signed: bool,
+        width: u32,
+    },
 }
 
 impl FormatInfo {
@@ -62,6 +66,7 @@ impl FormatInfo {
         match self {
             FormatInfo::Bitnum { signed, .. } => *signed,
             FormatInfo::Fixed { signed, .. } => *signed,
+            FormatInfo::IEEFloat { signed, .. } => *signed,
         }
     }
 
@@ -73,6 +78,7 @@ impl FormatInfo {
                 frac_width,
                 ..
             } => *int_width + *frac_width,
+            FormatInfo::IEEFloat { width, .. } => *width,
         }
     }
 }

--- a/interp/tests/runt.toml
+++ b/interp/tests/runt.toml
@@ -153,6 +153,16 @@ fud2 --from calyx --to jq \
 """
 timeout = 60
 
+[[tests]]
+name = "correctness ieee754-float"
+paths = ["../../tests/correctness/ieee754-float/*.futil"]
+cmd = """
+fud2 --from calyx --to dat \
+         --through cider \
+         -s sim.data={}.data \
+         -s calyx.args="--log off" \
+         {} | jq --sort-keys
+"""
 
 [[tests]]
 name = "correctness ref cells"

--- a/tools/cider-data-converter/src/converter.rs
+++ b/tools/cider-data-converter/src/converter.rs
@@ -418,7 +418,6 @@ mod tests {
         };
 
         let result = unroll_float(float, &format, true);
-        let result = result.collect_vec();
         BigInt::from_signed_bytes_le(&result);
         let parsed_res =
             parse_bytes_fixed(&result, int_width, frac_width, signed);

--- a/tools/cider-data-converter/src/converter.rs
+++ b/tools/cider-data-converter/src/converter.rs
@@ -296,15 +296,16 @@ fn format_data(declaration: &MemoryDeclaration, data: &[u8]) -> ParseVec {
                     let value = match width {
                         32 => {
                             debug_assert_eq!(chunk.len(), 4);
-                            f32::from_le_bytes(chunk.try_into().unwrap()) as f64
+                            format!("{}", f32::from_le_bytes(chunk.try_into().unwrap()))
                         }
                         64 => {
                             debug_assert_eq!(chunk.len(), 8);
-                            f64::from_le_bytes(chunk.try_into().unwrap())
+                            format!("{}", f64::from_le_bytes(chunk.try_into().unwrap()))
                         }
                         _ => unreachable!("Unsupported width {width}. Only 32 and 64 bit floats are supported.")
                     };
-                    Number::from_f64(value).unwrap()
+                    // we need to inject the string directly in order to maintain the correct rounding
+                    Number::from_string_unchecked(value)
                 }
             }
         });


### PR DESCRIPTION
Somewhere, things still get messed up.

I get:
```
{
  "out": [
    15.123900413513184,
    0.5600000023841858
  ],
  "inp": [
    15.123900413513184
  ]
}
```

But the expected output is:
```
{
  "inp": [
    15.12
  ],
  "out": [
    15.12,
    0.56
  ]
}
```