### PR TITLE
`fud2` Migrate main test suite

### DIFF
--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -339,7 +339,12 @@ impl<'a> Run<'a> {
     /// Emit `build.ninja` to a temporary directory and then actually execute Ninja.
     ///
     /// If `print_cmds` is true, Ninja will print commands it is to run instead of executing them.
-    pub fn emit_and_run(&self, dir: &Utf8Path, print_cmds: bool) -> EmitResult {
+    pub fn emit_and_run(
+        &self,
+        dir: &Utf8Path,
+        print_cmds: bool,
+        quiet_mode: bool,
+    ) -> EmitResult {
         // Emit the Ninja file.
         let dir = self.emit_to_dir(dir)?;
 
@@ -375,7 +380,11 @@ impl<'a> Run<'a> {
             cmd.arg("-tcommands");
         }
 
-        cmd.stdout(std::io::stderr()); // Send Ninja's stdout to our stderr.
+        if !quiet_mode {
+            cmd.stdout(std::io::stderr()); // Send Ninja's stdout to our stderr.
+        } else {
+            cmd.stdout(std::process::Stdio::null());
+        }
         let status = cmd.status().map_err(ninja_cmd_io_error)?;
 
         // Emit to stdout, only when Ninja succeeded.

--- a/runt.toml
+++ b/runt.toml
@@ -216,14 +216,13 @@ paths = [
   "tests/correctness/ieee754-float/*.futil",
 ]
 cmd = """
-fud exec --from calyx --to jq \
-         --through verilog \
-         --through dat \
-         -s verilog.data {}.data \
-         -s calyx.exec './target/debug/calyx' \
-         -s verilog.cycle_limit 500 \
-         -s jq.expr ".memories" \
-         {} -q
+fud2 --from calyx --to jq \
+     --through verilator \
+     -s sim.data={}.data \
+     -s calyx.exec='./target/debug/calyx' \
+     -s verilog.cycle_limit=500 \
+     -s jq.expr=".memories" \
+     {} -q
 """
 timeout = 120
 
@@ -236,15 +235,14 @@ paths = [
   "tests/correctness/static-interface/*.futil",
 ]
 cmd = """
-fud exec --from calyx --to jq \
-         --through verilog \
-         --through dat \
-         -s calyx.exec './target/debug/calyx' \
-         -s calyx.flags '-x tdcc:one-hot-cutoff=500 -d static-promotion' \
-         -s verilog.cycle_limit 500 \
-         -s verilog.data {}.data \
-         -s jq.expr ".memories" \
-         {} -q
+fud2 --from calyx --to jq \
+     --through icarus \
+     -s calyx.exec='./target/debug/calyx' \
+     -s calyx.flags='-x tdcc:one-hot-cutoff=500 -d static-promotion' \
+     -s verilog.cycle_limit=500 \
+     -s sim.data={}.data \
+     -s jq.expr=".memories" \
+     {} -q
 """
 timeout = 120
 
@@ -257,15 +255,14 @@ paths = [
   "tests/correctness/static-interface/*.futil",
 ]
 cmd = """
-fud exec --from calyx --to jq \
-         --through verilog \
-         --through dat \
-         -s calyx.exec './target/debug/calyx' \
-         -s calyx.flags '-x tdcc:duplicate-cutoff=0 -d static-promotion' \
-         -s verilog.cycle_limit 500 \
-         -s verilog.data {}.data \
-         -s jq.expr ".memories" \
-         {} -q
+fud2 --from calyx --to jq \
+     --through icarus \
+     -s calyx.exec='./target/debug/calyx' \
+     -s calyx.flags='-x tdcc:duplicate-cutoff=0 -d static-promotion' \
+     -s verilog.cycle_limit=500 \
+     -s sim.data={}.data \
+     -s jq.expr=".memories" \
+     {} -q
 """
 timeout = 120
 
@@ -278,14 +275,13 @@ paths = [
   "tests/correctness/static-interface/*.futil",
 ]
 cmd = """
-fud exec --from calyx --to jq \
-         --through verilog \
-         --through dat \
-         -s calyx.exec './target/debug/calyx' \
-         -s verilog.cycle_limit 500 \
-         -s verilog.data {}.data \
-         -s jq.expr ".memories" \
-         {} -q
+fud2 --from calyx --to jq \
+     --through icarus \
+     -s calyx.exec='./target/debug/calyx' \
+     -s verilog.cycle_limit=500 \
+     -s sim.data={}.data \
+     -s jq.expr=".memories" \
+     {} -q
 """
 timeout = 120
 
@@ -293,15 +289,14 @@ timeout = 120
 name = "correctness static timing one-hot encoding"
 paths = ["tests/correctness/static-interface/*.futil"]
 cmd = """
-fud exec --from calyx --to jq \
-         --through verilog \
-         --through dat \
-         -s calyx.exec './target/debug/calyx' \
-         -s calyx.flags '-x static-fsm-opts:one-hot-cutoff=500' \
-         -s verilog.cycle_limit 500 \
-         -s verilog.data {}.data \
-         -s jq.expr ".memories" \
-         {} -q
+fud2 --from calyx --to jq \
+     --through icarus \
+     -s calyx.exec='./target/debug/calyx' \
+     -s calyx.flags='-x static-fsm-opts:one-hot-cutoff=500' \
+     -s verilog.cycle_limit=500 \
+     -s sim.data={}.data \
+     -s jq.expr=".memories" \
+     {} -q
 """
 timeout = 120
 
@@ -310,15 +305,14 @@ timeout = 120
 name = "correctness nested"
 paths = ["tests/correctness/*.futil"]
 cmd = """
-fud exec --from calyx --to jq \
-         --through verilog \
-         --through dat \
-         -s verilog.data {}.data \
-         -s calyx.exec './target/debug/calyx' \
-         -s calyx.flags ' --nested' \
-         -s verilog.cycle_limit 500 \
-         -s jq.expr ".memories" \
-         {} -q
+fud2 --from calyx --to jq \
+     --through icarus \
+     -s sim.data={}.data \
+     -s calyx.exec='./target/debug/calyx' \
+     -s calyx.flags=' --nested' \
+     -s verilog.cycle_limit=500 \
+     -s jq.expr=".memories" \
+     {} -q
 """
 timeout = 120
 
@@ -332,14 +326,13 @@ paths = [
   "tests/correctness/group-static-promotion/*.futil",
 ]
 cmd = """
-fud exec --from calyx --to jq \
-         --through verilog \
-         --through dat \
-         -s calyx.exec './target/debug/calyx' \
-         -s calyx.flags '-p all -d group2invoke' \
-         -s verilog.cycle_limit 500 \
-         -s verilog.data {}.data \
-         {} -q
+fud2 --from calyx --to jq \
+     --through icarus \
+     -s calyx.exec='./target/debug/calyx' \
+     -s calyx.flags='-p all -d group2invoke' \
+     -s verilog.cycle_limit=500 \
+     -s sim.data={}.data \
+     {} -q
 """
 timeout = 120
 
@@ -352,14 +345,13 @@ paths = [
   "tests/correctness/group-static-promotion/*.futil",
 ]
 cmd = """
-fud exec --from calyx --to jq \
-         --through verilog \
-         --through dat \
-         -s calyx.exec './target/debug/calyx' \
-         -s calyx.flags '-p all -d group2invoke -x compile-static:one-hot-cutoff=500' \
-         -s verilog.cycle_limit 500 \
-         -s verilog.data {}.data \
-         {} -q
+fud2 --from calyx --to jq \
+     --through icarus \
+     -s calyx.exec='./target/debug/calyx' \
+     -s calyx.flags='-p all -d group2invoke -x compile-static:one-hot-cutoff=500' \
+     -s verilog.cycle_limit=500 \
+     -s sim.data={}.data \
+     {} -q
 """
 timeout = 120
 
@@ -371,37 +363,34 @@ paths = [
   "tests/correctness/numeric-types/fixed-point/*.futil",
 ]
 cmd = """
-fud exec --from calyx --to jq \
-         --through dat \
-         --through verilog \
-         -s verilog.data {}.data \
-         -s jq.expr ".memories" \
-         {} -q
+fud2 --from calyx --to jq \
+     --through icarus \
+     -s sim.data={}.data \
+     -s jq.expr=".memories" \
+     {} -q
 """
 
 [[tests]]
 name = "correctness test of static islands without static promotion"
 paths = ["tests/correctness/static-islands/*.futil"]
 cmd = """
-fud exec --from calyx --to jq \
-         --through dat \
-         --through verilog \
-         -s verilog.data {}.data \
-         -s calyx.flags "-d static-promotion" \
-         -s jq.expr ".memories" \
-         {} -q
+fud2 --from calyx --to jq \
+    --through icarus \
+    -s sim.data={}.data \
+    -s calyx.flags="-d static-promotion" \
+    -s jq.expr=".memories" \
+    {} -q
 """
 
 [[tests]]
 name = "[frontend] tcam testing"
 paths = ["tests/correctness/tcam/*.futil"]
 cmd = """
-fud exec --from calyx --to jq \
-      --through verilog \
-      --through dat \
-      -s verilog.data {}.data \
-      -s jq.expr ".memories" \
-      {} -q
+fud2 --from calyx --to jq \
+     --through icarus \
+     -s sim.data={}.data \
+     -s jq.expr=".memories" \
+     {} -q
 """
 
 [[tests]]


### PR DESCRIPTION
Moving all tests in the root `runt.toml` to use `fud2`.