### PR TITLE
Write docs for `calyx-pass-explorer`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,15 +17,17 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: 'latest'
+          mdbook-version: "latest"
+      - name: Install callouts preprocessor
+        run: cargo install --git https://github.com/ToolmanP/rs-mdbook-callout
       - name: mdbook
         run: mdbook build
       - name: Install Rust stable
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.66.0
-            override: true
-            components: rustfmt, clippy
+          toolchain: 1.66.0
+          override: true
+          components: rustfmt, clippy
       - name: Build source documentation
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           mdbook-version: "latest"
       - name: Install callouts preprocessor
-        run: cargo install --git https://github.com/ToolmanP/rs-mdbook-callout
+        run: cargo install --git https://github.com/ToolmanP/rs-mdbook-callouts --rev 83898e352a961fc65044e04c864141c8b5481722
       - name: mdbook
         run: mdbook build
       - name: Install Rust stable

--- a/book.toml
+++ b/book.toml
@@ -6,3 +6,5 @@ src = "docs"
 title = "Calyx Documentation"
 [output.html]
 mathjax-support = true
+[preprocessor.callouts] # https://github.com/ToolmanP/rs-mdbook-callouts
+

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -31,7 +31,6 @@
 # Compiler Development Guide
 
 - [The Calyx Compiler](./compiler.md)
-- [Visualizing Compiler Passes](./dev/calyx-pass-explorer.md)
 - [Adding a New Pass](./new-pass.md)
 - [Primitive Library](./libraries/core.md)
 - [The `calyx` Library](./compiler-as-library.md)
@@ -61,6 +60,7 @@
 - [`exp` Generator](./tools/exp-generator.md)
 - [Editor Highlighting](./tools/editor-highlighting.md)
 - [Language Server](./tools/language-server.md)
+- [Visualizing Compiler Passes](./dev/calyx-pass-explorer.md)
 
 ----
 [Contributors](./contributors.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -31,6 +31,7 @@
 # Compiler Development Guide
 
 - [The Calyx Compiler](./compiler.md)
+- [Visualizing Compiler Passes](./dev/calyx-pass-explorer.md)
 - [Adding a New Pass](./new-pass.md)
 - [Primitive Library](./libraries/core.md)
 - [The `calyx` Library](./compiler-as-library.md)

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -15,6 +15,7 @@ Here is a list of all the people who have worked on Calyx:
 - Andrew Butt
 - [Anshuman Mohan](https://www.cs.cornell.edu/~amohan/)
 - [Ayaka Yorihiro](https://ayakayorihiro.github.io/)
+- [Ethan Uppal](https://www.ethanuppal.com)
 
 **Previous Contributors**
 

--- a/docs/dev/calyx-pass-explorer.md
+++ b/docs/dev/calyx-pass-explorer.md
@@ -1,0 +1,121 @@
+# Visualizing Compiler Passes
+
+Working on the compiler can be daunting, especially when there are lots of
+complicated (and simple) passes that turn your original calyx source into
+something hardly recognizable.
+Sometimes the best way to learn how a pass works (or to debug an existing pass)
+is just to run it on code and see what happens.
+
+Enter [`calyx-pass-explorer`](https://github.com/calyxir/calyx/tree/main/tools/calyx-pass-explorer).
+It's a command line tool that provides an interactive interface for visualizing
+how different passes affect the source code.
+
+> ![Example running of the tool](https://raw.githubusercontent.com/calyxir/calyx/main/tools/calyx-pass-explorer/example_v0.0.0.png)
+> _The above image depicts the tool's interface in v0.0.0.
+> As of writing this documentation, it's on v0.2.1._
+
+Check out the [source code](https://github.com/calyxir/calyx/tree/main/tools/calyx-pass-explorer/src) if you're interested.
+
+## Usage
+
+> Take a look at the [user manual](https://github.com/calyxir/calyx/blob/main/tools/calyx-pass-explorer/manual.md) for detailed information.
+> This section will serve as a basic overview.
+
+First, we have to get a calyx file to work with.
+Let's use this one:
+
+```
+import "primitives/core.futil";
+import "primitives/memories/comb.futil";
+
+component main(@go go: 1) -> (@done done: 1) {
+  cells {
+    @external(1) in_mem = comb_mem_d1(32, 1, 32);
+    @external(1) out_mem = comb_mem_d1(32, 1, 32);
+    i0 = std_reg(32);
+  }
+  wires {
+    group d1 {
+      in_mem.addr0 = 32'd0;
+      i0.in = in_mem.read_data;
+      i0.write_en = 1'b1;
+      d1[done] = i0.done;
+    }
+    static<1> group s2 {
+      in_mem.addr0 = 32'd0;
+      out_mem.write_data = i0.out;
+      out_mem.write_en = 1'b1;
+    }
+  }
+  control {
+    seq {
+      seq {
+        d1;
+        s2;
+      }
+    }
+  }
+}
+```
+
+It's a simple program that reads in a value from the memory `in_mem` into the register
+`i0`, and then from `i0` into the memory `out_mem`.
+Incidentally, I used this file to test my implementation of the
+[`@fast` attribute](https://github.com/calyxir/calyx/pull/2118); I wrote this
+tool to help develop it!
+
+We'll first run `calyx-pass-explorer example0.futil`.
+You should get something horrific like
+
+![Lots of random text output that doesn't make sense](./assets/horrific-interface.png)
+
+> [!TIP]
+> If you get this message:
+> ![Calyx executable could not be found](./assets/calyx-missing.png)
+> You should setup `fud` or pass the path explicitly with `-e`, as suggested.
+> However, we're going to update this later to look at `fud2` as well because
+> `fud` is now officially deprecated.
+
+The first few lines are readable, but after that, there's a lot of calyx
+standard library components we don't really care too much about.
+What we really want is to focus on what happens to, _e.g._, the `main` component.
+To do that, we just pass `-c main` (or `--component main`) as a flag:
+
+![Running the tool and visualizing how the well-formed pass affects the main
+component](./assets/well-formed.png)
+
+That's a lot better, but it's still quite a bit of information.
+Let's break it down.
+
+- At the top, we have the instructions.
+  You primary use the keyboard to interact with the tool (but you can scroll through the
+text with a mouse if there's a lot of it).
+- Then, we have the list of passes.
+  Yellow passes are incoming passes: these are the ones for which the diff is
+shown.
+  In other words, we're seeing the result of applying the `well-formed` pass to
+  the original input.
+  Purple passes are upcoming -- they can be applied after we apply the current
+one.
+  Green passes are those we've already applied, and gray ones are those we've
+skipped.
+- Finally, we have the diff of the incoming pass applied to the current code.
+  In particular, the code hasn't been edited yet -- it won't be, until we press
+  `a` to accept.
+
+### Breakpoints
+
+Often, you're interested in one pass that is far into the set of passes.
+There are two options to help you do that:
+
+1. `-b` or `--breakpoint` takes in a pass name and lets you automatically accept
+   (see next option) passes until you arrive at the specified pass.
+2. `-d` or `--disable-pass` skips a pass when reaching a breakpoint.
+   You can pass this option multiple times.
+
+## How it works
+
+The tool creates a temporary directory where it stores the results of applying
+passes.
+The [`PassExplorer`](https://github.com/calyxir/calyx/blob/main/tools/calyx-pass-explorer/src/pass_explorer.rs) `struct` handles how passes are applied and updates this directory's contents.
+I wrote a custom [scrollback buffer](https://github.com/calyxir/calyx/blob/main/tools/calyx-pass-explorer/src/scrollback_buffer.rs) to accommodate the specific its TUI needs.

--- a/docs/github.md
+++ b/docs/github.md
@@ -22,6 +22,10 @@ there will be extensive merge conflicts due to the squash and merge tactic. For
 this reason we always recommend creating branches off of the main branch if you
 intend to have them merged into it.
 
+## Local Development
+
+Once you've [setup a local installation](./intro.md) for contributing, you can setup git hooks with `/bin/sh setup_hooks.sh`.
+
 ### CI Behavior
 
 The CI runs a number of tests including ensuring that Rust and Python code has
@@ -35,10 +39,6 @@ within Rust to suppress the lint.
 
 If changes are made to the `Dockerfile` then the CI will automatically rebuild
 the Docker image and run your tests on it.
-
-## Local Development
-
-You can setup git hooks with `/bin/sh setup_hooks.sh`.
 
 [calyx_repo]: https://github.com/calyxir/calyx
 [clippy]: https://github.com/rust-lang/rust-clippy

--- a/docs/github.md
+++ b/docs/github.md
@@ -1,9 +1,11 @@
 # Contributing to Calyx
 
 ## Github Workflow
+
 The current home of the Calyx repo can be found [here][calyx_repo]. As with many
 large projects, we protect the main branch of the repo so that updates can only
 be made via pull requests. So the development cycle tends to look like:
+
 ```
 checkout main -> develop code -> open PR -> revise -> merge PR
 ```
@@ -21,6 +23,7 @@ this reason we always recommend creating branches off of the main branch if you
 intend to have them merged into it.
 
 ### CI Behavior
+
 The CI runs a number of tests including ensuring that Rust and Python code has
 been formatted. For Python we use the [Black](https://github.com/psf/black) formatter and for Rust we use the
 standard `cargo fmt`.
@@ -33,6 +36,9 @@ within Rust to suppress the lint.
 If changes are made to the `Dockerfile` then the CI will automatically rebuild
 the Docker image and run your tests on it.
 
+## Local Development
+
+You can setup git hooks with `/bin/sh setup_hooks.sh`.
 
 [calyx_repo]: https://github.com/calyxir/calyx
 [clippy]: https://github.com/rust-lang/rust-clippy

--- a/docs/install_tools.sh
+++ b/docs/install_tools.sh
@@ -1,0 +1,4 @@
+#/bin/sh
+
+cargo install mdbook
+cargo install --git https://github.com/ToolmanP/rs-mdbook-callouts --rev 83898e352a961fc65044e04c864141c8b5481722

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -71,8 +71,7 @@ We recommend installing the git hooks to run linting and formatting checks befor
 You can build the docs by installing `mdbook` and the callouts preprocessor:
 
 ```sh
-cargo install mdbook 
-cargo install --git https://github.com/ToolmanP/rs-mdbook-callout
+/bin/sh docs/install_tools.sh
 ```
 
 Then, run `mdbook serve` from the project root.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -31,9 +31,11 @@ First, install [Rust][rust].
 This should automatically install `cargo`.
 
 If you want just to play with the compiler, install the [`calyx` crate][calyx-crate]:
+
 ```
 cargo install calyx
 ```
+
 This will install the `calyx` binary which can optimize and compile Calyx programs. You will still need the [`primitives/core.futil`][core-lib] and [its accompanying Verilog file](https://github.com/calyxir/calyx/blob/master/primitives/core.sv) library to compile most programs.
 
 ### Installing from Source (to use and extend Calyx)
@@ -42,29 +44,44 @@ First, install [Rust][rust].
 This should automatically install `cargo`.
 
 Clone the repository:
+
 ```
 git clone https://github.com/calyxir/calyx.git
 ```
+
 Then build the compiler:
+
 ```
 cargo build
 ```
 
 You can build and run the compiler with:
+
 ```
 cargo build # Builds the compiler
 ./target/debug/calyx --help # Executes the compiler binary
 ```
 
 We recommend installing the git hooks to run linting and formatting checks before each commit:
+
 ```shell
 /bin/sh setup_hooks.sh
 ```
+
+You can build the docs by installing `mdbook` and the callouts preprocessor:
+
+```sh
+cargo install mdbook 
+cargo install --git https://github.com/ToolmanP/rs-mdbook-callout
+```
+
+Then, run `mdbook serve` from the project root.
 
 ## Running Core Tests
 
 The core test suite tests the Calyx compiler's various passes.
 Install the following tools:
+
   1. [runt][] hosts our testing infrastructure. Install with:
   `cargo install runt`
   2. [jq][] is a command-line JSON processor. Install with:
@@ -73,10 +90,13 @@ Install the following tools:
      * Other platforms: [JQ installation][jq-install]
 
 Build the compiler:
+
 ```
 cargo build
 ```
+
 Then run the core tests with:
+
 ```
 runt -i core
 ```
@@ -91,24 +111,31 @@ backends to simplify running Calyx programs.
 Start at the root of the repository.
 
 Install [Flit][]:
+
 ```
 pip3 install flit
 ```
 
 Install [`calyx-py`](builder/calyx-py.md):
+
 ```
 cd calyx-py && flit install -s && cd -
 ```
 
 Install `fud`:
+
 ```
 flit -f fud/pyproject.toml install -s --deps production
 ```
+
 Configure `fud`:
+
 ```
 fud config --create global.root <full path to Calyx repository>
 ```
+
 Check the `fud` configuration:
+
 ```
 fud check
 ```
@@ -133,12 +160,14 @@ Some missing tools are again expected; just pay attention to the report for `sta
 
 It is worth saying a little about the alternatives.
 You could consider:
+
 1. [Setting up Verilator][fud-verilator] for faster performance, which is good for long-running simulations.
 2. Using the [interpreter][] to avoid RTL simulation altogether.
 
 ## Running a Hardware Design
 
 You're all set to run a Calyx hardware design now. Run the following command:
+
 ```
 fud e examples/tutorial/language-tutorial-iterate.futil \
   -s verilog.data examples/tutorial/data.json \
@@ -155,28 +184,19 @@ Congratulations! You've simulated your first hardware design with Calyx.
 
 ## Where to go next?
 
-- [How can I setup syntax highlighting in my editor?](./tools/editor-highlighting.md)
-- [How does the language work?](./tutorial/language-tut.md)
-- [How do I install Calyx frontends?](./running-calyx/fud/index.html#dahlia-fronted)
-- [Where can I see further examples with `fud`?](./running-calyx/fud/examples.md)
-- [How do I write a frontend for Calyx?](./tutorial/frontend-tut.md)
-
+* [How can I setup syntax highlighting in my editor?](./tools/editor-highlighting.md)
+* [How does the language work?](./tutorial/language-tut.md)
+* [How do I install Calyx frontends?](./running-calyx/fud/index.html#dahlia-fronted)
+* [Where can I see further examples with `fud`?](./running-calyx/fud/examples.md)
+* [How do I write a frontend for Calyx?](./tutorial/frontend-tut.md)
 
 [rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html
 [runt]: https://github.com/rachitnigam/runt
-[vcdump]: https://github.com/sgpthomas/vcdump
 [verilator]: https://www.veripool.org/wiki/verilator
-[verilator-install]: https://www.veripool.org/projects/verilator/wiki/Installing
 [icarus verilog]: http://iverilog.icarus.com
 [jq]: https://stedolan.github.io/jq/
 [jq-install]: https://stedolan.github.io/jq/
-[frontends]: ./frontends/index.md
-[calyx-py]: ./calyx-py.md
 [flit]: https://flit.readthedocs.io/en/latest/
-[vcd]: https://en.wikipedia.org/wiki/Value_change_dump
-[dahlia]: https://github.com/cucapra/dahlia
-[dahlia-install]: https://github.com/cucapra/dahlia#set-it-up
-[sbt]: https://www.scala-sbt.org/download.html
 [interpreter]: ./running-calyx/interpreter.md
 [homebrew]: https://brew.sh
 [fud-icarus]: ./running-calyx/fud/index.md#icarus-verilog

--- a/docs/new-pass.md
+++ b/docs/new-pass.md
@@ -2,6 +2,7 @@
 
 All passes in the compiler are stored in the `calyx/src/passes` directory.
 To add a new pass, we need to do a couple of things:
+
 1. Define a pass struct and implement the required traits.
 2. Expose the pass using in the `passes` module.
 3. Register the pass in the compiler.
@@ -11,6 +12,7 @@ To add a new pass, we need to do a couple of things:
 ## Defining a Pass Struct
 
 We first define a [Rust structure][struct] that will manage the state of the pass:
+
 ```rust
 pub struct NewPass;
 ```
@@ -37,6 +39,7 @@ Furthermore, it also allows us to control the order in which components are visi
 ### Component Iteration Order
 
 The [`Order`][order] struct allows us to control the order in which components are visited:
+
 - `Post`: Iterate the subcomponents of a component before the component itself.
 - `Pre`: Iterate the subcomponents of a component after the component itself.
 - `No`: Iterate the components in any order.
@@ -47,6 +50,7 @@ Most passes will attempt to transform the structural part of the program (`wires
 The `Visitor` trait is flexible enough to allow all of these patterns and efficiently traverse the program.
 
 For a control program like this:
+
 ```
 seq {
     one;
@@ -56,6 +60,7 @@ seq {
 ```
 
 The following sequence of `Visitor` methods are called:
+
 ```
 - start
 - start_seq
@@ -80,11 +85,13 @@ The final step is to register the pass in the compiler.
 We use the [`PassManager`][pass-manager] to register the pass defined in the `default_passes.rs` file.
 
 Registering a pass is as simple as calling the register pass:
+
 ```rust
 pm.register_pass::<NewPass>();
 ```
 
 Once done, the pass is accessible from the command line:
+
 ```bash
 cargo run -- -p new-pass <file>
 ```
@@ -97,10 +104,13 @@ For example, if `NewPass` needs to run before the compilation passes, we can add
 ## Some Useful Links
 
 The compiler has a ton of shared infrastructure that can be useful:
+
 - [`ir::Context`][context]: The top-level data structure that holds a complete Calyx program.
 - [Rewriter][]: Helps with consistent renaming of ports, cells, groups, and comb groups in a component.
 - [`analysis`][analysis]: Provides a number of useful analysis that can be used within a pass.
 - IR macros: Macros useful for adding cells ([`structure!`][structure]), guards ([`guard!`][guard]) and assignments ([`build_assignments!`][build-assigns]) to component.
+
+Also, check out how to [visualize passes](./dev/calyx-pass-explorer.md) for development and debugging.
 
 [pass-opts]: ./compiler.md#providing-pass-options
 [control]: ./lang/ref.md#the-control-operators
@@ -116,3 +126,4 @@ The compiler has a ton of shared infrastructure that can be useful:
 [guard]: https://docs.rs/calyx-ir/latest/calyx_ir/macro.guard.html
 [structure]: https://docs.rs/calyx-ir/latest/calyx_ir/macro.structure.html
 [context]: https://docs.rs/calyx-ir/latest/calyx_ir/struct.Context.html
+

--- a/interp/tests/runt.toml
+++ b/interp/tests/runt.toml
@@ -193,9 +193,9 @@ fud2 --from calyx --to jq \
 [[tests]]
 name = "numeric types correctness and parsing"
 paths = [
-    "../../tests/correctness/numeric-types/parsing/*.futil",
-    "../../tests/correctness/numeric-types/bitnum/*.futil",
-    "../../tests/correctness/numeric-types/fixed-point/*.futil",
+  "../../tests/correctness/numeric-types/parsing/*.futil",
+  "../../tests/correctness/numeric-types/bitnum/*.futil",
+  "../../tests/correctness/numeric-types/fixed-point/*.futil",
 ]
 cmd = """
 fud2 --from calyx --to jq \

--- a/interp/tests/runt.toml
+++ b/interp/tests/runt.toml
@@ -157,7 +157,7 @@ timeout = 60
 name = "correctness ieee754-float"
 paths = ["../../tests/correctness/ieee754-float/*.futil"]
 cmd = """
-fud2 --from calyx --to dat \
+fud2 --from calyx --to jq \
          --through cider \
          -s sim.data={}.data \
          -s calyx.args="--log off" \
@@ -193,9 +193,9 @@ fud2 --from calyx --to jq \
 [[tests]]
 name = "numeric types correctness and parsing"
 paths = [
-  "../../tests/correctness/numeric-types/parsing/*.futil",
-  "../../tests/correctness/numeric-types/bitnum/*.futil",
-  "../../tests/correctness/numeric-types/fixed-point/*.futil",
+    "../../tests/correctness/numeric-types/parsing/*.futil",
+    "../../tests/correctness/numeric-types/bitnum/*.futil",
+    "../../tests/correctness/numeric-types/fixed-point/*.futil",
 ]
 cmd = """
 fud2 --from calyx --to jq \

--- a/tools/calyx-pass-explorer/README.md
+++ b/tools/calyx-pass-explorer/README.md
@@ -1,4 +1,4 @@
-# calyx-pass
+# calyx-pass-explorer
 
 `calyx-pass-explorer` is a *pass transformation* explorer for calyx.
 You give it an input file and some options, and you can explore how [passes](https://crates.io/crates/calyx-opt) transform the file over time.
@@ -19,14 +19,17 @@ It's been immensely useful for me, and I hope it is for you too!
 
 Navigate to the `calyx-pass-explorer` directory (e.g., `cd tools/calyx-pass-explorer` from the repository root).
 Check the version with
+
 ```shell
 cargo run -- --version
 ```
 
 Then, run
+
 ```shell
 cargo install --path .
 ```
+
 from the current directory.
 
 ## Usage


### PR DESCRIPTION
This PR adds a documentation page for the `calyx-pass-explorer` tool, serving as a gentle introduction to its usage as well as an overview of its code.

- I've added `mdbook-callouts` as a way to get Obsidian-style quote blocks. Specifically, I'm using this for the `[!TIP]` environment. I can remove this if we don't want another dependency.
- I did some unrelated things (to `docs/contributors.md`, `docs/github.md`, and `docs/intro.md`) that I can move into another PR if that would be better.