### PR TITLE
[cider2] Make minimally-sized clonable simulator

### DIFF
--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -48,8 +48,6 @@ baa = { version = "0.14.0", features = ["bigint", "serde1", "fraction1"] }
 fst-writer = "0.2.1"
 bon = "2.3"
 
-# derivative = "2.2.0"
-
 [dev-dependencies]
 proptest = "1.0.0"
 

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -48,6 +48,7 @@ baa = { version = "0.14.0", features = ["bigint", "serde1", "fraction1"] }
 fst-writer = "0.2.1"
 bon = "2.3"
 
+# derivative = "2.2.0"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/interp/src/flatten/primitives/combinational.rs
+++ b/interp/src/flatten/primitives/combinational.rs
@@ -11,6 +11,7 @@ use baa::{BitVecOps, BitVecValue};
 
 use super::prim_trait::UpdateResult;
 
+#[derive(Clone)]
 pub struct StdConst {
     value: BitVecValue,
     out: GlobalPortIdx,
@@ -44,8 +45,13 @@ impl Primitive for StdConst {
     fn has_stateful(&self) -> bool {
         false
     }
+
+    fn clone_boxed(&self) -> Box<dyn Primitive> {
+        Box::new(self.clone())
+    }
 }
 
+#[derive(Clone)]
 pub struct StdMux {
     base: GlobalPortIdx,
 }
@@ -79,6 +85,10 @@ impl Primitive for StdMux {
 
     fn has_stateful(&self) -> bool {
         false
+    }
+
+    fn clone_boxed(&self) -> Box<dyn Primitive> {
+        Box::new(self.clone())
     }
 }
 
@@ -275,6 +285,7 @@ comb_primitive!(StdUnsynSmod[WIDTH](left [0], right [1]) -> (out [2]) {
     Ok(Some(BitVecValue::from_big_int(&res, WIDTH)))
 });
 
+#[derive(Clone)]
 pub struct StdUndef(GlobalPortIdx);
 
 impl StdUndef {
@@ -287,5 +298,9 @@ impl Primitive for StdUndef {
     fn exec_comb(&self, port_map: &mut PortMap) -> UpdateResult {
         port_map.write_undef(self.0)?;
         Ok(UpdateStatus::Unchanged)
+    }
+
+    fn clone_boxed(&self) -> Box<dyn Primitive> {
+        Box::new(self.clone())
     }
 }

--- a/interp/src/flatten/primitives/macros.rs
+++ b/interp/src/flatten/primitives/macros.rs
@@ -102,6 +102,12 @@ macro_rules! comb_primitive {
                 false
             }
 
+            fn clone_boxed(&self) -> Box<dyn $crate::flatten::primitives::Primitive> {
+                Box::new(Self {
+                    base_port: self.base_port,
+                    $($($param: self.$param,)+)?
+                })
+            }
         }
     };
 

--- a/interp/src/flatten/primitives/prim_trait.rs
+++ b/interp/src/flatten/primitives/prim_trait.rs
@@ -1,5 +1,3 @@
-use std::mem;
-
 use crate::{
     errors::RuntimeResult,
     flatten::{

--- a/interp/src/flatten/primitives/prim_trait.rs
+++ b/interp/src/flatten/primitives/prim_trait.rs
@@ -161,7 +161,7 @@ pub trait RaceDetectionPrimitive: Primitive {
     /// optional default implementation due to size rules
     fn as_primitive(&self) -> &dyn Primitive;
 
-    fn clone_boxed(&self) -> Box<dyn RaceDetectionPrimitive>;
+    fn clone_boxed_rd(&self) -> Box<dyn RaceDetectionPrimitive>;
 }
 
 /// An empty primitive implementation used for testing. It does not do anything

--- a/interp/src/flatten/primitives/prim_trait.rs
+++ b/interp/src/flatten/primitives/prim_trait.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 use crate::{
     errors::RuntimeResult,
     flatten::{
@@ -134,6 +136,8 @@ pub trait Primitive {
     fn dump_memory_state(&self) -> Option<Vec<u8>> {
         None
     }
+
+    fn clone_boxed(&self) -> Box<dyn Primitive>;
 }
 
 pub trait RaceDetectionPrimitive: Primitive {
@@ -158,10 +162,13 @@ pub trait RaceDetectionPrimitive: Primitive {
     /// Get a reference to the underlying primitive. Unfortunately cannot add an
     /// optional default implementation due to size rules
     fn as_primitive(&self) -> &dyn Primitive;
+
+    fn clone_boxed(&self) -> Box<dyn RaceDetectionPrimitive>;
 }
 
 /// An empty primitive implementation used for testing. It does not do anything
 /// and has no ports of any kind
+#[derive(Clone, Copy)]
 pub struct DummyPrimitive;
 
 impl DummyPrimitive {
@@ -170,4 +177,8 @@ impl DummyPrimitive {
     }
 }
 
-impl Primitive for DummyPrimitive {}
+impl Primitive for DummyPrimitive {
+    fn clone_boxed(&self) -> Box<dyn Primitive> {
+        Box::new(*self)
+    }
+}

--- a/interp/src/flatten/primitives/stateful/math.rs
+++ b/interp/src/flatten/primitives/stateful/math.rs
@@ -10,6 +10,7 @@ use crate::flatten::{
 use baa::{BitVecOps, BitVecValue, WidthInt};
 use num_traits::Euclid;
 
+#[derive(Clone)]
 pub struct StdMultPipe<const DEPTH: usize> {
     base_port: GlobalPortIdx,
     pipeline: ShiftBuffer<(PortValue, PortValue), DEPTH>,
@@ -32,6 +33,10 @@ impl<const DEPTH: usize> StdMultPipe<DEPTH> {
 }
 
 impl<const DEPTH: usize> Primitive for StdMultPipe<DEPTH> {
+    fn clone_boxed(&self) -> Box<dyn Primitive> {
+        Box::new(self.clone())
+    }
+
     fn exec_comb(&self, port_map: &mut PortMap) -> UpdateResult {
         ports![&self.base_port; out: Self::OUT, done: Self::DONE];
 
@@ -106,6 +111,7 @@ impl<const DEPTH: usize> Primitive for StdMultPipe<DEPTH> {
     }
 }
 
+#[derive(Clone)]
 pub struct StdDivPipe<const DEPTH: usize, const SIGNED: bool> {
     base_port: GlobalPortIdx,
     pipeline: ShiftBuffer<(PortValue, PortValue), DEPTH>,
@@ -132,6 +138,10 @@ impl<const DEPTH: usize, const SIGNED: bool> StdDivPipe<DEPTH, SIGNED> {
 impl<const DEPTH: usize, const SIGNED: bool> Primitive
     for StdDivPipe<DEPTH, SIGNED>
 {
+    fn clone_boxed(&self) -> Box<dyn Primitive> {
+        Box::new(self.clone())
+    }
+
     fn exec_comb(&self, port_map: &mut PortMap) -> UpdateResult {
         ports![&self.base_port;
                out_quot: Self::OUT_QUOTIENT,
@@ -253,6 +263,10 @@ impl<const IS_FIXED_POINT: bool> Sqrt<IS_FIXED_POINT> {
 }
 
 impl<const IS_FIXED_POINT: bool> Primitive for Sqrt<IS_FIXED_POINT> {
+    fn clone_boxed(&self) -> Box<dyn Primitive> {
+        Box::new(self.clone())
+    }
+
     fn exec_comb(&self, port_map: &mut PortMap) -> UpdateResult {
         ports![&self.base_port; out: Self::OUT, done: Self::DONE];
 
@@ -309,6 +323,7 @@ impl<const IS_FIXED_POINT: bool> Primitive for Sqrt<IS_FIXED_POINT> {
     }
 }
 
+#[derive(Clone)]
 pub struct FxpMultPipe<const DEPTH: usize> {
     base_port: GlobalPortIdx,
     pipeline: ShiftBuffer<(PortValue, PortValue), DEPTH>,
@@ -339,6 +354,10 @@ impl<const DEPTH: usize> FxpMultPipe<DEPTH> {
 }
 
 impl<const DEPTH: usize> Primitive for FxpMultPipe<DEPTH> {
+    fn clone_boxed(&self) -> Box<dyn Primitive> {
+        Box::new(self.clone())
+    }
+
     fn exec_comb(&self, port_map: &mut PortMap) -> UpdateResult {
         ports![&self.base_port; out: Self::OUT, done: Self::DONE];
 
@@ -422,6 +441,7 @@ impl<const DEPTH: usize> Primitive for FxpMultPipe<DEPTH> {
     }
 }
 
+#[derive(Clone)]
 pub struct FxpDivPipe<const DEPTH: usize, const SIGNED: bool> {
     base_port: GlobalPortIdx,
     pipeline: ShiftBuffer<(PortValue, PortValue), DEPTH>,
@@ -460,6 +480,10 @@ impl<const DEPTH: usize, const SIGNED: bool> FxpDivPipe<DEPTH, SIGNED> {
 impl<const DEPTH: usize, const SIGNED: bool> Primitive
     for FxpDivPipe<DEPTH, SIGNED>
 {
+    fn clone_boxed(&self) -> Box<dyn Primitive> {
+        Box::new(self.clone())
+    }
+
     fn exec_comb(&self, port_map: &mut PortMap) -> UpdateResult {
         ports![&self.base_port;
                out_quot: Self::OUT_QUOTIENT,

--- a/interp/src/flatten/primitives/stateful/memories.rs
+++ b/interp/src/flatten/primitives/stateful/memories.rs
@@ -27,6 +27,7 @@ use crate::{
 
 use baa::{BitVecOps, BitVecValue, WidthInt};
 
+#[derive(Clone)]
 pub struct StdReg {
     base_port: GlobalPortIdx,
     internal_state: ValueWithClock,
@@ -55,6 +56,10 @@ impl StdReg {
 }
 
 impl Primitive for StdReg {
+    fn clone_boxed(&self) -> Box<dyn Primitive> {
+        Box::new(self.clone())
+    }
+
     fn exec_cycle(&mut self, port_map: &mut PortMap) -> UpdateResult {
         ports![&self.base_port;
             input: Self::IN,
@@ -139,6 +144,10 @@ impl Primitive for StdReg {
 }
 
 impl RaceDetectionPrimitive for StdReg {
+    fn clone_boxed(&self) -> Box<dyn RaceDetectionPrimitive> {
+        Box::new(self.clone())
+    }
+
     fn as_primitive(&self) -> &dyn Primitive {
         self
     }
@@ -176,6 +185,7 @@ impl RaceDetectionPrimitive for StdReg {
     }
 }
 
+#[derive(Clone)]
 pub struct MemDx<const SEQ: bool> {
     shape: Shape,
 }
@@ -389,6 +399,7 @@ impl<const SEQ: bool> MemDx<SEQ> {
     }
 }
 
+#[derive(Clone)]
 pub struct CombMem {
     base_port: GlobalPortIdx,
     internal_state: Vec<ValueWithClock>,
@@ -508,6 +519,10 @@ impl CombMem {
 }
 
 impl Primitive for CombMem {
+    fn clone_boxed(&self) -> Box<dyn Primitive> {
+        Box::new(self.clone())
+    }
+
     fn exec_comb(&self, port_map: &mut PortMap) -> UpdateResult {
         let addr: Option<usize> = self
             .addresser
@@ -609,6 +624,10 @@ impl Primitive for CombMem {
 }
 
 impl RaceDetectionPrimitive for CombMem {
+    fn clone_boxed(&self) -> Box<dyn RaceDetectionPrimitive> {
+        Box::new(self.clone())
+    }
+
     fn as_primitive(&self) -> &dyn Primitive {
         self
     }
@@ -674,6 +693,7 @@ impl RaceDetectionPrimitive for CombMem {
     }
 }
 
+#[derive(Clone)]
 pub struct SeqMem {
     base_port: GlobalPortIdx,
     internal_state: Vec<ValueWithClock>,
@@ -812,6 +832,10 @@ impl SeqMem {
 }
 
 impl Primitive for SeqMem {
+    fn clone_boxed(&self) -> Box<dyn Primitive> {
+        Box::new(self.clone())
+    }
+
     fn exec_comb(&self, port_map: &mut PortMap) -> UpdateResult {
         let done_signal = port_map.insert_val_general(
             self.done(),
@@ -915,6 +939,10 @@ impl Primitive for SeqMem {
 }
 
 impl RaceDetectionPrimitive for SeqMem {
+    fn clone_boxed(&self) -> Box<dyn RaceDetectionPrimitive> {
+        Box::new(self.clone())
+    }
+
     fn as_primitive(&self) -> &dyn Primitive {
         self
     }

--- a/interp/src/flatten/primitives/stateful/memories.rs
+++ b/interp/src/flatten/primitives/stateful/memories.rs
@@ -144,7 +144,7 @@ impl Primitive for StdReg {
 }
 
 impl RaceDetectionPrimitive for StdReg {
-    fn clone_boxed(&self) -> Box<dyn RaceDetectionPrimitive> {
+    fn clone_boxed_rd(&self) -> Box<dyn RaceDetectionPrimitive> {
         Box::new(self.clone())
     }
 
@@ -624,7 +624,7 @@ impl Primitive for CombMem {
 }
 
 impl RaceDetectionPrimitive for CombMem {
-    fn clone_boxed(&self) -> Box<dyn RaceDetectionPrimitive> {
+    fn clone_boxed_rd(&self) -> Box<dyn RaceDetectionPrimitive> {
         Box::new(self.clone())
     }
 
@@ -939,7 +939,7 @@ impl Primitive for SeqMem {
 }
 
 impl RaceDetectionPrimitive for SeqMem {
-    fn clone_boxed(&self) -> Box<dyn RaceDetectionPrimitive> {
+    fn clone_boxed_rd(&self) -> Box<dyn RaceDetectionPrimitive> {
         Box::new(self.clone())
     }
 

--- a/interp/src/flatten/primitives/utils.rs
+++ b/interp/src/flatten/primitives/utils.rs
@@ -38,6 +38,7 @@ pub(crate) fn int_sqrt(i: &BigUint) -> BigUint {
 }
 
 /// A shift buffer of a fixed size
+#[derive(Clone)]
 pub struct ShiftBuffer<T, const N: usize> {
     buffer: VecDeque<Option<T>>,
 }

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -49,8 +49,8 @@ use itertools::Itertools;
 use owo_colors::OwoColorize;
 
 use slog::{info, warn, Logger};
-use std::fmt::Debug;
 use std::fmt::Write;
+use std::{fmt::Debug, ops::Deref};
 
 pub type PortMap = IndexedMap<GlobalPortIdx, PortValue>;
 
@@ -156,6 +156,7 @@ pub(crate) type RefPortMap =
     IndexedMap<GlobalRefPortIdx, Option<GlobalPortIdx>>;
 pub(crate) type AssignmentRange = IndexRange<AssignmentIdx>;
 
+#[derive(Clone)]
 pub(crate) struct ComponentLedger {
     pub(crate) index_bases: BaseIndices,
     pub(crate) comp_id: ComponentIdx,
@@ -190,6 +191,26 @@ pub(crate) enum CellLedger {
         cell_dyn: Box<dyn RaceDetectionPrimitive>,
     },
     Component(ComponentLedger),
+}
+
+impl Clone for CellLedger {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Primitive { cell_dyn } => Self::Primitive {
+                cell_dyn: cell_dyn.clone_boxed(),
+            },
+            Self::RaceDetectionPrimitive { cell_dyn } => {
+                Self::RaceDetectionPrimitive {
+                    cell_dyn: RaceDetectionPrimitive::clone_boxed(
+                        cell_dyn.deref(),
+                    ),
+                }
+            }
+            Self::Component(component_ledger) => {
+                Self::Component(component_ledger.clone())
+            }
+        }
+    }
 }
 
 impl From<ComponentLedger> for CellLedger {
@@ -302,7 +323,7 @@ impl PinnedPorts {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Environment<C: AsRef<Context> + Clone> {
     /// A map from global port IDs to their current values.
     ports: PortMap,
@@ -1285,24 +1306,44 @@ impl<C: AsRef<Context> + Clone> Environment<C> {
     }
 }
 
+/// The core functionality of a simulator. Clonable.
+#[derive(Clone)]
+pub struct BaseSimulator<C: AsRef<Context> + Clone> {
+    env: Environment<C>,
+    conf: RuntimeConfig,
+}
+
 /// A wrapper struct for the environment that provides the functions used to
 /// simulate the actual program.
 ///
 /// This is just to keep the simulation logic under a different namespace than
 /// the environment to avoid confusion
 pub struct Simulator<C: AsRef<Context> + Clone> {
-    env: Environment<C>,
+    base: BaseSimulator<C>,
     wave: Option<WaveWriter>,
-    conf: RuntimeConfig,
 }
 
 impl<C: AsRef<Context> + Clone> Simulator<C> {
-    pub fn new(
-        env: Environment<C>,
+    pub fn build_simulator(
+        ctx: C,
+        data_file: &Option<std::path::PathBuf>,
         wave_file: &Option<std::path::PathBuf>,
-        conf: RuntimeConfig,
-    ) -> Self {
-        // open the wave form file and declare all signals
+        runtime_config: RuntimeConfig,
+    ) -> Result<Self, BoxedCiderError> {
+        let data_dump = data_file
+            .as_ref()
+            .map(|path| {
+                let mut file = std::fs::File::open(path)?;
+                DataDump::deserialize(&mut file)
+            })
+            // flip to a result of an option
+            .map_or(Ok(None), |res| res.map(Some))?;
+        let env = Environment::new(
+            ctx,
+            data_dump,
+            runtime_config.check_data_race,
+            runtime_config.get_logging_config(),
+        );
         let wave =
             wave_file.as_ref().map(|p| match WaveWriter::open(p, &env) {
                 Ok(w) => w,
@@ -1310,9 +1351,120 @@ impl<C: AsRef<Context> + Clone> Simulator<C> {
                     todo!("deal more gracefully with error: {err:?}")
                 }
             });
-        let mut output = Self { env, wave, conf };
-        output.set_root_go_high();
-        output
+        Ok(Self {
+            base: BaseSimulator::new(env, runtime_config),
+            wave,
+        })
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.base.is_done()
+    }
+
+    pub fn step(&mut self) -> CiderResult<()> {
+        self.base.step()
+    }
+
+    pub fn converge(&mut self) -> CiderResult<()> {
+        self.base.converge()
+    }
+
+    pub fn get_currently_running_groups(
+        &self,
+    ) -> impl Iterator<Item = GroupIdx> + '_ {
+        self.base.get_currently_running_groups()
+    }
+
+    pub fn is_group_running(&self, group_idx: GroupIdx) -> bool {
+        self.base.is_group_running(group_idx)
+    }
+
+    pub fn print_pc(&self) {
+        self.base.print_pc();
+    }
+
+    pub fn format_cell_state(
+        &self,
+        cell_idx: GlobalCellIdx,
+        print_code: PrintCode,
+        name: Option<&str>,
+    ) -> Option<String> {
+        self.base.format_cell_state(cell_idx, print_code, name)
+    }
+
+    pub fn format_cell_ports(
+        &self,
+        cell_idx: GlobalCellIdx,
+        print_code: PrintCode,
+        name: Option<&str>,
+    ) -> String {
+        self.base.format_cell_ports(cell_idx, print_code, name)
+    }
+
+    pub fn format_port_value(
+        &self,
+        port_idx: GlobalPortIdx,
+        print_code: PrintCode,
+    ) -> String {
+        self.base.format_port_value(port_idx, print_code)
+    }
+
+    pub fn traverse_name_vec(
+        &self,
+        name: &[String],
+    ) -> Result<Path, TraversalError> {
+        self.base.traverse_name_vec(name)
+    }
+
+    pub fn get_full_name<N>(&self, nameable: N) -> String
+    where
+        N: GetFullName<C>,
+    {
+        self.base.get_full_name(nameable)
+    }
+
+    pub(crate) fn env(&self) -> &Environment<C> {
+        self.base.env()
+    }
+
+    /// Evaluate the entire program
+    pub fn run_program(&mut self) -> CiderResult<()> {
+        if self.base.conf.debug_logging {
+            info!(self.base.env().logger, "Starting program execution");
+        }
+
+        match self.base.run_program_inner(self.wave.as_mut()) {
+            Ok(_) => {
+                if self.base.conf.debug_logging {
+                    info!(self.base.env().logger, "Finished program execution");
+                }
+                Ok(())
+            }
+            Err(e) => {
+                if self.base.conf.debug_logging {
+                    slog::error!(
+                        self.base.env().logger,
+                        "Program execution failed with error: {}",
+                        e.red()
+                    );
+                }
+                Err(e)
+            }
+        }
+    }
+
+    pub fn dump_memories(
+        &self,
+        dump_registers: bool,
+        all_mems: bool,
+    ) -> DataDump {
+        self.base.dump_memories(dump_registers, all_mems)
+    }
+}
+
+impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
+    pub fn new(env: Environment<C>, conf: RuntimeConfig) -> Self {
+        Self { env, conf }
     }
 
     pub(crate) fn env(&self) -> &Environment<C> {
@@ -1330,33 +1482,6 @@ impl<C: AsRef<Context> + Clone> Simulator<C> {
 
     pub fn _unpack_env(self) -> Environment<C> {
         self.env
-    }
-
-    pub fn build_simulator(
-        ctx: C,
-        data_file: &Option<std::path::PathBuf>,
-        wave_file: &Option<std::path::PathBuf>,
-        runtime_config: RuntimeConfig,
-    ) -> Result<Self, BoxedCiderError> {
-        let data_dump = data_file
-            .as_ref()
-            .map(|path| {
-                let mut file = std::fs::File::open(path)?;
-                DataDump::deserialize(&mut file)
-            })
-            // flip to a result of an option
-            .map_or(Ok(None), |res| res.map(Some))?;
-
-        Ok(Simulator::new(
-            Environment::new(
-                ctx,
-                data_dump,
-                runtime_config.check_data_race,
-                runtime_config.get_logging_config(),
-            ),
-            wave_file,
-            runtime_config,
-        ))
     }
 
     pub fn is_group_running(&self, group_idx: GroupIdx) -> bool {
@@ -1418,7 +1543,7 @@ impl<C: AsRef<Context> + Clone> Simulator<C> {
 }
 
 // =========================== simulation functions ===========================
-impl<C: AsRef<Context> + Clone> Simulator<C> {
+impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
     #[inline]
     fn lookup_global_port_id(&self, port: GlobalPortRef) -> GlobalPortIdx {
         match port {
@@ -2161,43 +2286,20 @@ impl<C: AsRef<Context> + Clone> Simulator<C> {
             .unwrap_or_default()
     }
 
-    /// Evaluate the entire program
-    pub fn run_program(&mut self) -> CiderResult<()> {
-        if self.conf.debug_logging {
-            info!(self.env.logger, "Starting program execution");
-        }
-
-        match self.run_program_inner() {
-            Ok(_) => {
-                if self.conf.debug_logging {
-                    info!(self.env.logger, "Finished program execution");
-                }
-                Ok(())
-            }
-            Err(e) => {
-                if self.conf.debug_logging {
-                    slog::error!(
-                        self.env.logger,
-                        "Program execution failed with error: {}",
-                        e.red()
-                    );
-                }
-                Err(e)
-            }
-        }
-    }
-
-    fn run_program_inner(&mut self) -> Result<(), BoxedCiderError> {
+    pub fn run_program_inner(
+        &mut self,
+        mut wave: Option<&mut WaveWriter>,
+    ) -> Result<(), BoxedCiderError> {
         let mut time = 0;
         while !self.is_done() {
-            if let Some(wave) = self.wave.as_mut() {
+            if let Some(wave) = wave.as_mut() {
                 wave.write_values(time, &self.env.ports)?;
             }
             // self.print_pc();
             self.step()?;
             time += 1;
         }
-        if let Some(wave) = self.wave.as_mut() {
+        if let Some(wave) = wave {
             wave.write_values(time, &self.env.ports)?;
         }
         Ok(())

--- a/interp/src/flatten/structures/environment/env.rs
+++ b/interp/src/flatten/structures/environment/env.rs
@@ -49,8 +49,8 @@ use itertools::Itertools;
 use owo_colors::OwoColorize;
 
 use slog::{info, warn, Logger};
+use std::fmt::Debug;
 use std::fmt::Write;
-use std::{fmt::Debug, ops::Deref};
 
 pub type PortMap = IndexedMap<GlobalPortIdx, PortValue>;
 
@@ -201,9 +201,7 @@ impl Clone for CellLedger {
             },
             Self::RaceDetectionPrimitive { cell_dyn } => {
                 Self::RaceDetectionPrimitive {
-                    cell_dyn: RaceDetectionPrimitive::clone_boxed(
-                        cell_dyn.deref(),
-                    ),
+                    cell_dyn: cell_dyn.clone_boxed_rd(),
                 }
             }
             Self::Component(component_ledger) => {

--- a/interp/src/flatten/structures/environment/mod.rs
+++ b/interp/src/flatten/structures/environment/mod.rs
@@ -5,7 +5,7 @@ mod program_counter;
 mod traverser;
 mod wave;
 
-pub use env::{Environment, PortMap, Simulator};
+pub use env::{BaseSimulator, Environment, PortMap, Simulator};
 pub use traverser::{Path, PathError, PathResolution};
 
 pub(crate) use env::CellLedger;

--- a/interp/src/flatten/structures/environment/program_counter.rs
+++ b/interp/src/flatten/structures/environment/program_counter.rs
@@ -375,7 +375,7 @@ impl WithEntry {
 
 /// The program counter for the whole program execution. Wraps over a vector of
 /// the active leaf statements for each component instance.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub(crate) struct ProgramCounter {
     vec: Vec<ControlTuple>,
     par_map: HashMap<ControlPoint, ChildCount>,

--- a/interp/src/flatten/structures/indexed_map.rs
+++ b/interp/src/flatten/structures/indexed_map.rs
@@ -143,6 +143,20 @@ where
         Self::new()
     }
 }
+
+impl<T, K> Clone for IndexedMap<K, T>
+where
+    K: IndexRef,
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data.clone(),
+            phantom: PhantomData,
+        }
+    }
+}
+
 #[allow(dead_code)]
 pub struct IndexedMapRangeIterator<'range, 'data, K, D>
 where

--- a/interp/src/flatten/structures/indexed_map.rs
+++ b/interp/src/flatten/structures/indexed_map.rs
@@ -4,7 +4,7 @@ use std::{
     ops::{self, Index},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IndexedMap<K, D>
 where
     K: IndexRef,
@@ -141,19 +141,6 @@ where
 {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl<T, K> Clone for IndexedMap<K, T>
-where
-    K: IndexRef,
-    T: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            data: self.data.clone(),
-            phantom: PhantomData,
-        }
     }
 }
 

--- a/interp/src/flatten/structures/thread.rs
+++ b/interp/src/flatten/structures/thread.rs
@@ -9,7 +9,7 @@ use super::{
 pub struct ThreadIdx(NonZeroU32);
 impl_index_nonzero!(ThreadIdx);
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ThreadInfo {
     parent: Option<ThreadIdx>,
     clock_id: ClockIdx,
@@ -25,7 +25,7 @@ impl ThreadInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ThreadMap {
     map: IndexedMap<ThreadIdx, ThreadInfo>,
 }


### PR DESCRIPTION
Creates a new `BaseSimulator` object that can be used independently of `Simulator`. Also, things are cloneable now. The rationale is we can now write a model checker using cider by cloning cider contexts at forks.