### PR TITLE
Add BRAM numbers to resource estimate executive summary

### DIFF
--- a/fud/fud/stages/vivado/extract.py
+++ b/fud/fud/stages/vivado/extract.py
@@ -80,6 +80,7 @@ def place_and_route_extract(
         if util_file.exists():
             impl_parser = rpt.RPTParser(util_file)
             slice_logic = impl_parser.get_table(re.compile(r"1\. CLB Logic"), 2)
+            bram_table = impl_parser.get_table(re.compile(r"3\. BLOCKRAM"), 2)
             dsp_table = impl_parser.get_table(re.compile(r"4\. ARITHMETIC"), 2)
 
             clb_lut = to_int(find_row(slice_logic, "Site Type", "CLB LUTs")["Used"])
@@ -96,6 +97,9 @@ def place_and_route_extract(
                         find_row(slice_logic, "Site Type", "CLB LUTs")["Used"]
                     ),
                     "dsp": to_int(find_row(dsp_table, "Site Type", "DSPs")["Used"]),
+                    "brams": to_int(
+                        find_row(bram_table, "Site Type", "Block RAM Tile")["Used"]
+                    ),
                     "registers": rtl_component_extract(synth_file, "Registers"),
                     "muxes": rtl_component_extract(synth_file, "Muxes"),
                     "clb_registers": clb_reg,


### PR DESCRIPTION
Closes #2288

I've checked that this grabs the correct values. Say our `main_utilization_placed.rpt` file had the following BRAM table

![nine](https://github.com/user-attachments/assets/9f84ee86-deb2-427e-9c27-0f35db4ed39c)
(not a real utilization file, I changed the highlighted entry from 0 to 9 to make sure I'm grabbing the correct value)

Running `fud e --from synth-files --to resource-estimate report` yields the correct BRAM count of `9`:
```
{
  "lut": 169,
  "dsp": 0,
  "brams": 9,
  "registers": 60,
  "muxes": 30,
  "clb_registers": 210,
  "carry8": 10,
  "f7_muxes": 0,
  "f8_muxes": 0,
  "f9_muxes": 0,
  "clb": 389,
  "meet_timing": 1,
  "worst_slack": 4.758,
  "period": 7.0,
  "frequency": 142.857,
  "uram": -1,
  "cell_lut1": 5,
  "cell_lut2": 110,
  "cell_lut3": 38,
  "cell_lut4": 17,
  "cell_lut5": 18,
  "cell_lut6": 49,
  "cell_fdre": 210
}
```
