### PR TITLE
Queues: add instructions for converting tests to Calyx

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,8 +20,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Rust stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-            toolchain: stable
       - name: Build calyx dev
         run: cargo build
       - name: Check calyx build

--- a/frontends/queues/README.md
+++ b/frontends/queues/README.md
@@ -3,7 +3,7 @@
 See the [docs][docs] for more details.
 
 ## Installation
-To use the queues:
+To use our queues:
 1. Install [flit][flit]
 2. Install the `queues` package:
 ```

--- a/frontends/queues/README.md
+++ b/frontends/queues/README.md
@@ -1,12 +1,35 @@
 # Queues Library
 
-See the [docs](https://docs.calyxir.org/frontends/queues.html) for more details.
+See the [docs][docs] for more details.
 
 ## Installation
-To use our queues:
-1. Install [flit](https://flit.readthedocs.io/en/latest/#install)
+To use the queues:
+1. Install [flit][flit]
 2. Install the `queues` package:
 ```
     $ cd frontends/queues/
     $ flit install --symlink
+``` 
+
+## Converting Tests to Calyx
+
+To convert any of our [randomized tests][testing-harness] to a single Calyx file and their associated data and expect files:
+
+0. Follow the [installation instructions](#installation)
+1. Choose a test by picking a `.py` file in [`tests/`][tests-dir]
+2. Convert the test to Calyx:
 ```
+python3 <queue_name>_test.py 20000 --keepgoing > <queue_name>_test.futil
+```
+3. Run the script [`gen_test_data.sh`][gen_test_data.sh] to generate data and expect files:
+```
+./gen_test_data.sh
+```
+
+The files `<queue_name>_test.py`, `<queue_name>_test.data`, and `<queue_name>_test.expect` contain the Calyx program, input data, and expected outputs for the test.
+
+[docs]: https://docs.calyxir.org/frontends/queues.html
+[flit]: https://flit.readthedocs.io/en/latest/#install
+[testing-harness]: https://docs.calyxir.org/frontends/queues.html#shared-testing-harness
+[tests-dir]: ./tests/
+[gen_test_data.sh]: ./test_data_gen/gen_test_data.sh

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.82.0"


### PR DESCRIPTION
What is says on the tin (as discussed on this [slack thread](https://cucapra.slack.com/archives/C06CV424G94/p1727223025447109))

Due to a new [release](https://releases.rs/docs/1.83.0/) for rust, CI catches a few errors (unrelated to this PR). For now, we simply pin to an older version:
- remove toolchain argument for `setup-rust-toolchain@v1` in `rust.yml`
- add `rust-toolchain.toml`