### PR TITLE
Fix failing tests on `main` due to new Rust version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ version = "0.7.1"
 dependencies = [
  "atty",
  "itertools 0.11.0",
+ "lazy_static",
  "petgraph",
  "serde",
  "serde_json",

--- a/calyx-frontend/src/parser.rs
+++ b/calyx-frontend/src/parser.rs
@@ -60,10 +60,13 @@ impl CalyxParser {
         let file = GlobalPositionTable::as_mut()
             .add_file(path.to_string_lossy().to_string(), string_content);
         let user_data = UserData { file };
-        let content = GlobalPositionTable::as_ref().get_source(file);
+        let gpos_ref = GlobalPositionTable::as_ref();
+        let content = gpos_ref.get_source(file).to_owned();
+        drop(gpos_ref);
+
         // Parse the file
         let inputs =
-            CalyxParser::parse_with_userdata(Rule::file, content, user_data)
+            CalyxParser::parse_with_userdata(Rule::file, &content, user_data)
                 .map_err(|e| e.with_path(&path.to_string_lossy()))
                 .map_err(|e| {
                     calyx_utils::Error::parse_error(e.variant.message())
@@ -96,10 +99,13 @@ impl CalyxParser {
         let file =
             GlobalPositionTable::as_mut().add_file("<stdin>".to_string(), buf);
         let user_data = UserData { file };
-        let contents = GlobalPositionTable::as_ref().get_source(file);
+        let gpos_ref = GlobalPositionTable::as_ref();
+        let content = gpos_ref.get_source(file).to_owned();
+        drop(gpos_ref);
+
         // Parse the input
         let inputs =
-            CalyxParser::parse_with_userdata(Rule::file, contents, user_data)
+            CalyxParser::parse_with_userdata(Rule::file, &content, user_data)
                 .map_err(|e| {
                 calyx_utils::Error::parse_error(e.variant.message())
                     .with_pos(&Self::error_span(&e, file))

--- a/calyx-utils/Cargo.toml
+++ b/calyx-utils/Cargo.toml
@@ -23,3 +23,4 @@ string-interner.workspace = true
 itertools.workspace = true
 petgraph.workspace = true
 symbol_table = { version = "0.3", features = ["global"] }
+lazy_static.workspace = true

--- a/calyx-utils/src/errors.rs
+++ b/calyx-utils/src/errors.rs
@@ -179,7 +179,7 @@ impl Error {
             post_msg: None,
         }
     }
-    pub fn location(&self) -> (&str, usize, usize) {
+    pub fn location(&self) -> (String, usize, usize) {
         self.pos.get_location()
     }
     pub fn message(&self) -> String {

--- a/calyx-utils/src/position.rs
+++ b/calyx-utils/src/position.rs
@@ -117,14 +117,14 @@ impl GlobalPositionTable {
     /// You may not call this function after any call to [`Self::as_ref`].
     pub fn as_mut() -> RwLockWriteGuard<'static, PositionTable> {
         GPOS_TABLE
-            .write()
+            .try_write()
             .expect("failed to get write lock for global position table")
     }
 
     /// Return an immutable reference to the global position table
     pub fn as_ref() -> RwLockReadGuard<'static, PositionTable> {
         GPOS_TABLE
-            .read()
+            .try_read()
             .expect("failed to get read lock for global position table")
     }
 }


### PR DESCRIPTION
Uses interior mutability with a `RwLock` and `lazy_static!`.