### PR TITLE
Remove `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.82.0"


### PR DESCRIPTION
Since #2364, which added `rust-toolchain.toml`, still had failing tests on main (https://github.com/calyxir/calyx/actions/runs/12151446330/job/33886064698), I don't think this is needed?