### PR TITLE
Remove par-to-seq from profiler passes

### DIFF
--- a/fud2/scripts/profiler.rhai
+++ b/fud2/scripts/profiler.rhai
@@ -40,7 +40,7 @@ fn calyx_to_flamegraph(e, input, output) {
     e.build_cmd(["$cells"], "component-cells", [input], []);
     e.build_cmd([instrumented_verilog], "calyx", [input], []);
     e.arg("backend", "verilog");
-    e.arg("args", " -p static-inline -p compile-static -p compile-repeat -p par-to-seq -p compile-invoke -p profiler-instrumentation -p $passes -x tdcc:dump-fsm-json=fsm.json");
+    e.arg("args", " -p static-inline -p compile-static -p compile-repeat -p compile-invoke -p profiler-instrumentation -p $passes -x tdcc:dump-fsm-json=fsm.json");
 
     let instrumented_sim = "instrumented.exe";
     // verilog --> sim; adapted from verilator::verilator_build()

--- a/fud2/tests/snapshots/tests__test@plan_profiler.snap
+++ b/fud2/tests/snapshots/tests__test@plan_profiler.snap
@@ -54,7 +54,7 @@ cycle-limit = 500000000
 build $cells: component-cells /input.ext
 build instrumented.sv: calyx /input.ext
   backend = verilog
-  args =  -p static-inline -p compile-static -p compile-repeat -p par-to-seq -p compile-invoke -p profiler-instrumentation -p $passes -x tdcc:dump-fsm-json=fsm.json
+  args =  -p static-inline -p compile-static -p compile-repeat -p compile-invoke -p profiler-instrumentation -p $passes -x tdcc:dump-fsm-json=fsm.json
 build verilator-out/Vtoplevel: verilator-compile-standalone-tb instrumented.sv | tb.sv
   out-dir = verilator-out
 build instrumented.exe: cp verilator-out/Vtoplevel


### PR DESCRIPTION
Forgot to remove `par-to-seq` from profiler passes after implementing profiling for parallel programs!!! I'll be more careful in the future.