### PR TITLE
Add alternative fud2 installation instructions

### DIFF
--- a/docs/running-calyx/fud2/index.md
+++ b/docs/running-calyx/fud2/index.md
@@ -14,6 +14,8 @@ Until then, fud remains your first choice for all your build-related needs.
 fud2 is a Rust tool, so you can build it along with everything else in this monorepo with `cargo build`.
 You might then want to do something like ``ln -s `pwd`/target/debug/fud2 ~/.local/bin`` for easy access to the `fud2` binary.
 
+If you already have Calyx installed you can `cargo install --path fud2` from this repository's root to automatically add the binary to your path.
+
 fud2 depends on [Ninja][].
 Install it using your OS package manager or by downloading a binary.
 

--- a/docs/running-calyx/fud2/index.md
+++ b/docs/running-calyx/fud2/index.md
@@ -11,10 +11,12 @@ Until then, fud remains your first choice for all your build-related needs.
 
 ## Set Up
 
-fud2 is a Rust tool, so you can build it along with everything else in this monorepo with `cargo build`.
+If you would like to use `fud2` as is, and already have Calyx installed, you can `cargo install --path fud2` from this repository's root to automatically add the binary to your path.
+
+If you would like to work on development of `fud2` and/or keep up with the latest changes when you `git pull`, you can build it along with everything else in this monorepo with `cargo build`.
 You might then want to do something like ``ln -s `pwd`/target/debug/fud2 ~/.local/bin`` for easy access to the `fud2` binary.
 
-If you already have Calyx installed you can `cargo install --path fud2` from this repository's root to automatically add the binary to your path.
+
 
 fud2 depends on [Ninja][].
 Install it using your OS package manager or by downloading a binary.

--- a/docs/running-calyx/fud2/index.md
+++ b/docs/running-calyx/fud2/index.md
@@ -16,8 +16,6 @@ If you would like to use `fud2` as is, and already have Calyx installed, you can
 If you would like to work on development of `fud2` and/or keep up with the latest changes when you `git pull`, you can build it along with everything else in this monorepo with `cargo build`.
 You might then want to do something like ``ln -s `pwd`/target/debug/fud2 ~/.local/bin`` for easy access to the `fud2` binary.
 
-
-
 fud2 depends on [Ninja][].
 Install it using your OS package manager or by downloading a binary.
 

--- a/docs/running-calyx/fud2/index.md
+++ b/docs/running-calyx/fud2/index.md
@@ -13,7 +13,7 @@ Until then, fud remains your first choice for all your build-related needs.
 
 If you would like to use `fud2` as is, and already have Calyx installed, you can `cargo install --path fud2` from this repository's root to automatically add the binary to your path.
 
-If you would like to work on development of `fud2` and/or keep up with the latest changes when you `git pull`, you can build it along with everything else in this monorepo with `cargo build`.
+Alternatively, if you would like to work on development of `fud2` and/or keep up with the latest changes when you `git pull`, you can build it along with everything else in this monorepo with `cargo build`.
 You might then want to do something like ``ln -s `pwd`/target/debug/fud2 ~/.local/bin`` for easy access to the `fud2` binary.
 
 fud2 depends on [Ninja][].


### PR DESCRIPTION
The existing instructions did not work to add `fud2` to my path (locally on macOS). FWICT `cargo install --path fud2` did. Maybe we also want to get rid of the previous instructions? Not sure if they are still valid.
