### PR TITLE
Remove redundant output_with_attributes from python builder

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -132,18 +132,6 @@ class ComponentBuilder:
         """
         return self._port_with_attributes(name, size, False, attribute_literals)
 
-    def output_with_attributes(
-        self,
-        name: str,
-        size: int,
-        attribute_literals: List[Union[str, Tuple[str, int]]],
-    ) -> ExprBuilder:
-        """Declare an output port on the component with attributes.
-
-        Returns an expression builder for the port.
-        """
-        return self._port_with_attributes(name, size, False, attribute_literals)
-
     def attribute(self, name: str, value: int) -> None:
         """Declare an attribute on the component."""
         self.component.attributes.append(ast.CompAttribute(name, value))


### PR DESCRIPTION
Another part of #2267 that makes sense to live on it's own. Sorry for so many small PRs! But whittling things down like this is helping me better remember where everything stands