### PR TITLE
Update xilinx doc links

### DIFF
--- a/calyx-backend/src/xilinx/xml.rs
+++ b/calyx-backend/src/xilinx/xml.rs
@@ -11,7 +11,7 @@ pub struct XilinxXmlBackend;
 /// The root element of the `kernel.xml` file that describes an `.xo` package for the
 /// Xilinx toolchain, as documented [in the Vitis user guide][ug].
 ///
-/// [ug]: https://docs.xilinx.com/r/en-US/ug1393-vitis-application-acceleration/RTL-Kernel-XML-File
+/// [ug]: https://docs.amd.com/r/en-US/ug1702-vitis-accelerated-reference/RTL-Kernel-XML-File
 #[derive(Serialize)]
 #[serde(rename = "root")]
 struct Root<'a> {

--- a/docs/running-calyx/fud/axi-gen.md
+++ b/docs/running-calyx/fud/axi-gen.md
@@ -75,7 +75,7 @@ allow this.
 [pynq]: https://github.com/Xilinx/PYNQ
 [xclbin]: https://xilinx.github.io/XRT/2021.2/html/formats.html#xclbin
 [xilinx_tools]: https://github.com/calyxir/calyx/blob/master/docs/fud/xilinx.md
-[kernel_xml]: https://docs.xilinx.com/r/en-US/ug1393-vitis-application-acceleration/RTL-Kernel-XML-File
+[kernel_xml]: https://docs.amd.com/r/en-US/ug1702-vitis-accelerated-reference/RTL-Kernel-XML-File
 [external]: https://docs.calyxir.org/lang/attributes.html?highlight=external#external
 [issues]: https://github.com/calyxir/calyx/issues
 [signals]: https://developer.arm.com/documentation/ihi0022/e/AMBA-AXI3-and-AXI4-Protocol-Specification/Signal-Descriptions?lang=en
@@ -83,4 +83,4 @@ allow this.
 [access_protection]: https://developer.arm.com/documentation/ihi0022/e/AMBA-AXI3-and-AXI4-Protocol-Specification/Transaction-Attributes/Access-permissions?lang=en
 [toplevel]: https://docs.calyxir.org/lang/attributes.html?highlight=toplevel#toplevel
 [xilinx_how]: https://docs.calyxir.org/running-calyx/fud/xilinx.html?highlight=synthesis#how-it-works
-[kernel_requirements]: https://docs.xilinx.com/r/en-US/ug1393-vitis-application-acceleration/Kernel-Interface-Requirements
+[kernel_requirements]: https://docs.amd.com/r/en-US/ug1701-vitis-accelerated-embedded/RTL-Kernel-Interface-Requirements

--- a/docs/running-calyx/fud/xilinx.md
+++ b/docs/running-calyx/fud/xilinx.md
@@ -154,7 +154,7 @@ Then, look in the resulting directory, which will be named `fud-out-*` for some 
 In there, the Xilinx trace files you want are named `*.wdb` and `*.wcfg`.
 The VCD file is at `.run/*/hw_em/device0/binary_0/behav_waveform/xsim/dump.vcd` or similar.
 
-[emconfig.json]: https://docs.xilinx.com/r/en-US/ug1393-vitis-application-acceleration/emconfigutil-Utility
+[emconfig.json]: https://docs.amd.com/r/en-US/ug1702-vitis-accelerated-reference/emconfigutil-Utility
 [xrt-debug]: https://xilinx.github.io/Vitis_Accel_Examples/2021.1/html/debug_profile.html
 [vcd]: https://en.wikipedia.org/wiki/Value_change_dump
 
@@ -260,5 +260,5 @@ It sets up the necessary input files and constructs a command line that looks mu
 [ip-xact]: https://en.wikipedia.org/wiki/IP-XACT
 [duh]: https://github.com/sifive/duh
 [package_kernel]: https://github.com/Xilinx/Vitis-Tutorials/blob/2021.1/Hardware_Acceleration/Feature_Tutorials/01-rtl_kernel_workflow/reference-files/scripts/package_kernel.tcl
-[package_xo]: https://docs.xilinx.com/r/en-US/ug1393-vitis-application-acceleration/package_xo-Command
+[package_xo]: https://docs.amd.com/r/en-US/ug1702-vitis-accelerated-reference/package_xo-Command
 [pynq]: https://github.com/Xilinx/PYNQ

--- a/yxi/axi-calyx/axi-combined-calyx.futil
+++ b/yxi/axi-calyx/axi-combined-calyx.futil
@@ -34,7 +34,7 @@ component m_arread_channel(
   // 2^ARSIZE is bytes used in transfer. For memory-mapped AXI (which is what we
   // are doing I believe), should match width of data bus (to shell?, so 32 wide? This
   // is 3'b010)
-  // see https://docs.xilinx.com/r/en-US/ug1393-vitis-application-acceleration/Kernel-Interface-Requirements
+  // see https://docs.amd.com/r/en-US/ug1701-vitis-accelerated-embedded/RTL-Kernel-Interface-Requirements
   // for restrictions
   ARSIZE: 3,
   // in AXI4 this is 8 bits, 1-256 transfers in requested transaction.

--- a/yxi/xml/xml_generator.py
+++ b/yxi/xml/xml_generator.py
@@ -7,7 +7,7 @@ from math import log2
 """
 This file takes in a `.yxi` description and outputs a xml suitable for a `kernel.xml` file
 can be used to package an xclbin for the Xilinx XRT runtime.
-See https://docs.amd.com/r/en-US/ug1393-vitis-application-acceleration/RTL-Kernel-XML-File
+See https://docs.amd.com/r/en-US/ug1702-vitis-accelerated-reference/RTL-Kernel-XML-File
 for the spec this is based on.
 """
 size_key = "total_size"
@@ -26,7 +26,7 @@ def gen_xml(yxi):
             "name": yxi["toplevel"],
             "language": "ip_c",
             # TODO: Make sure this matches component.xml, Namely the `Toplevel` part.
-            #  See https://docs.amd.com/r/en-US/ug1393-vitis-application-acceleration/RTL-Kernel-XML-File
+            #  See https://docs.amd.com/r/en-US/ug1702-vitis-accelerated-reference/RTL-Kernel-XML-File
             "vlnv": "capra.cs.cornell.edu:kernel:Toplevel:1.0",
             "attributes": "",
             "preferredWorkGroupSizeMultiple": "0",


### PR DESCRIPTION
AMD decided to bork the old links to a bunch of useful docs, this updates that.

Just comment changes so going to auto merge