### PR TITLE
Improve cmd options

### DIFF
--- a/calyx-opt/src/pass_manager.rs
+++ b/calyx-opt/src/pass_manager.rs
@@ -117,20 +117,7 @@ impl PassManager {
             ))
             .into());
         }
-        // Expand any aliases used in defining this alias.
-        let all_passes = passes
-            .into_iter()
-            .flat_map(|pass| {
-                if self.aliases.contains_key(&pass) {
-                    self.aliases[&pass].clone()
-                } else if self.passes.contains_key(&pass) {
-                    vec![pass]
-                } else {
-                    panic!("No pass or alias named: {}", pass)
-                }
-            })
-            .collect();
-        self.aliases.insert(name, all_passes);
+        self.aliases.insert(name, passes);
         Ok(())
     }
 

--- a/calyx-opt/src/pass_manager.rs
+++ b/calyx-opt/src/pass_manager.rs
@@ -288,11 +288,11 @@ impl PassManager {
                     let start = Instant::now();
                     pass(ctx)?;
                     if dump_ir {
-                        eprint!("\nAfter pass: {}\n", name);
+                        println!("After pass: {}", name);
                         ir::Printer::write_context(
                             ctx,
                             true,
-                            &mut std::io::stderr(),
+                            &mut std::io::stdout(),
                         )?;
                     }
                     let elapsed = start.elapsed();

--- a/calyx-opt/src/pass_manager.rs
+++ b/calyx-opt/src/pass_manager.rs
@@ -288,10 +288,11 @@ impl PassManager {
                     let start = Instant::now();
                     pass(ctx)?;
                     if dump_ir {
+                        eprint!("\nAfter pass: {}\n", name);
                         ir::Printer::write_context(
                             ctx,
                             true,
-                            &mut std::io::stdout(),
+                            &mut std::io::stderr(),
                         )?;
                     }
                     let elapsed = start.elapsed();

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -77,7 +77,10 @@ pub struct Opts {
     #[argh(option, short = 'b', default = "BackendOpt::default()")]
     pub backend: BackendOpt,
 
-    /// run a pass or passes during execution. Passes are separated by a semicolon i.e "a;b". Accept alias. Default is "all"
+    /// run a pass or passes during execution. You can supply multiple -p to specify the pass pipeline 
+    /// and the passes will and executed in the order it passed in. Alternatively you can provide the 
+    /// passes by a semicolon separated string. "p1;p2" is the same as "-p p1 -p p2" and will run p1 then p2.
+    /// Accept alias. Default is "all"
     #[argh(option, short = 'p')]
     pub pass: Vec<String>,
 

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -77,7 +77,7 @@ pub struct Opts {
     #[argh(option, short = 'b', default = "BackendOpt::default()")]
     pub backend: BackendOpt,
 
-    /// run this pass during execution
+    /// run a pass or passes during execution. Passes are separated by a semicolon i.e "a;b". Accept alias. Default is "all"
     #[argh(option, short = 'p')]
     pub pass: Vec<String>,
 
@@ -89,7 +89,7 @@ pub struct Opts {
     #[argh(option, short = 'x', long = "extra-opt")]
     pub extra_opts: Vec<String>,
 
-    /// establish a relative ordering of passes
+    /// establish a relative ordering of passes. "a:b" will insert pass `b` after pass `a`
     #[argh(option, short = 'i', long = "insert")]
     pub insertions: Vec<String>,
 
@@ -208,6 +208,11 @@ impl Opts {
         // in manually.
         if opts.pass.is_empty() {
             opts.pass = vec!["all".into()];
+        }
+        else {
+            opts.pass = opts.pass.iter()
+                .flat_map(|s| s.split(';').map(String::from))
+                .collect();
         }
 
         Ok(opts)

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -85,7 +85,7 @@ pub struct Opts {
     #[argh(option, short = 'd', long = "disable-pass")]
     pub disable_pass: Vec<String>,
 
-    /// extra options passed to the context
+    /// extra options passed to the context. The format is either -x pass:opt or -x pass:opt=val
     #[argh(option, short = 'x', long = "extra-opt")]
     pub extra_opts: Vec<String>,
 

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -77,9 +77,8 @@ pub struct Opts {
     #[argh(option, short = 'b', default = "BackendOpt::default()")]
     pub backend: BackendOpt,
 
-    /// run a pass or passes during execution. You can supply multiple -p to specify the pass pipeline 
-    /// and the passes will and executed in the order it passed in. Alternatively you can provide the 
-    /// passes by a semicolon separated string. "p1;p2" is the same as "-p p1 -p p2" and will run p1 then p2.
+    /// run a pass or passes during execution. You can supply multiple -p to specify the pass pipeline
+    /// and the passes will and executed in the order it passed in. i.e."-p p1 -p p2" and will run p1 then p2.
     /// Accept alias. Default is "all"
     #[argh(option, short = 'p')]
     pub pass: Vec<String>,
@@ -92,7 +91,8 @@ pub struct Opts {
     #[argh(option, short = 'x', long = "extra-opt")]
     pub extra_opts: Vec<String>,
 
-    /// establish a relative ordering of passes. "a:b" will insert pass `b` after pass `a`
+    /// establish a relative ordering of passes. "a:b" will move pass `b` after pass `a`.
+    /// Similar to the `-p` flag, you can supply multiple `-i` flags to specify multiple ordering constraints.
     #[argh(option, short = 'i', long = "insert")]
     pub insertions: Vec<String>,
 
@@ -211,11 +211,6 @@ impl Opts {
         // in manually.
         if opts.pass.is_empty() {
             opts.pass = vec!["all".into()];
-        }
-        else {
-            opts.pass = opts.pass.iter()
-                .flat_map(|s| s.split(';').map(String::from))
-                .collect();
         }
 
         Ok(opts)


### PR DESCRIPTION
There is no documentation on the `-i` switch so I have added a bit of doc about it.

The `-i` option is a bit clunky, so I have improved the pass option to allow a semi-colon-separated list to specify a pass pipeline.  

Finally, the help message listing all the passes in one go is difficult to read. So, I have added a new variable to keep track of the original pass, which can better preserve the help message provided. 
