### PR TITLE
fixing pre commit

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/bash
 
 function check {
     prog=$1

--- a/setup_hooks.sh
+++ b/setup_hooks.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 
 for hook in .hooks/*; do
     hook_name=$(basename "$hook")


### PR DESCRIPTION
The pre-commit install is not working as expected. Start with `#!` to correctly inform the shell and run it with bash/sh. I discovered it is not working because I am using the fish shell.  