### PR TITLE
[Cider] Barebones integration of the `SourceInfoTable` 

### DIFF
--- a/calyx-frontend/src/source_info.rs
+++ b/calyx-frontend/src/source_info.rs
@@ -116,6 +116,8 @@ impl SourceInfoTable {
         &self.position_map[&pos]
     }
 
+    /// Looks up the source location of the position with the given id. If no
+    /// such position exists, returns `None`
     pub fn get_position(&self, pos: PositionId) -> Option<&SourceLocation> {
         self.position_map.get(&pos)
     }

--- a/calyx-frontend/src/source_info.rs
+++ b/calyx-frontend/src/source_info.rs
@@ -116,6 +116,10 @@ impl SourceInfoTable {
         &self.position_map[&pos]
     }
 
+    pub fn get_position(&self, pos: PositionId) -> Option<&SourceLocation> {
+        self.position_map.get(&pos)
+    }
+
     /// Iterate over the stored file map, returning a tuple of references to the
     /// file id and the path
     pub fn iter_file_map(&self) -> impl Iterator<Item = (&FileId, &PathBuf)> {

--- a/cider/src/debugger/debugger_core.rs
+++ b/cider/src/debugger/debugger_core.rs
@@ -412,7 +412,40 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
                     .print_watchpoints(self.interpreter.env()),
 
                 Command::PrintPC(print_mode) => match print_mode {
-                    PrintCommand::Normal | PrintCommand::PrintCalyx => {
+                    PrintCommand::Normal => {
+                        if let Some(source_info) = &self
+                            .program_context
+                            .as_ref()
+                            .secondary
+                            .source_info_table
+                        {
+                            let mut printed_position = false;
+                            for position in
+                                self.interpreter.env().iter_positions()
+                            {
+                                if let Some(location) =
+                                    source_info.get_position(position)
+                                {
+                                    println!(
+                                        "{}:{}",
+                                        source_info
+                                            .lookup_file_path(location.file)
+                                            .display(),
+                                        location.line
+                                    );
+                                    printed_position = true;
+                                }
+                            }
+
+                            if !printed_position {
+                                println!("Source info unavailable, falling back to Calyx");
+                                self.interpreter.print_pc();
+                            }
+                        } else {
+                            self.interpreter.print_pc();
+                        }
+                    }
+                    PrintCommand::PrintCalyx => {
                         self.interpreter.print_pc();
                     }
                     PrintCommand::PrintNodes => {

--- a/cider/src/flatten/flat_ir/component.rs
+++ b/cider/src/flatten/flat_ir/component.rs
@@ -218,26 +218,26 @@ impl ComponentCore {
         } else if let Some(root) = self.control {
             let mut search_stack = vec![root];
             while let Some(node) = search_stack.pop() {
-                match &ctx.primary[node] {
-                    ControlNode::Empty(_) => {}
-                    ControlNode::Enable(e) => {
+                match &ctx.primary[node].control {
+                    Control::Empty(_) => {}
+                    Control::Enable(e) => {
                         if ctx.primary[e.group()].assignments.contains(assign) {
                             return Some(AssignmentDefinitionLocation::Group(
                                 e.group(),
                             ));
                         }
                     }
-                    ControlNode::Seq(s) => {
+                    Control::Seq(s) => {
                         for stmt in s.stms() {
                             search_stack.push(*stmt);
                         }
                     }
-                    ControlNode::Par(p) => {
+                    Control::Par(p) => {
                         for stmt in p.stms() {
                             search_stack.push(*stmt);
                         }
                     }
-                    ControlNode::If(i) => {
+                    Control::If(i) => {
                         if let Some(comb) = i.cond_group() {
                             if ctx.primary[comb].assignments.contains(assign) {
                                 return Some(
@@ -251,7 +251,7 @@ impl ComponentCore {
                         search_stack.push(i.tbranch());
                         search_stack.push(i.fbranch());
                     }
-                    ControlNode::While(wh) => {
+                    Control::While(wh) => {
                         if let Some(comb) = wh.cond_group() {
                             if ctx.primary[comb].assignments.contains(assign) {
                                 return Some(
@@ -263,10 +263,10 @@ impl ComponentCore {
                         }
                         search_stack.push(wh.body());
                     }
-                    ControlNode::Repeat(r) => {
+                    Control::Repeat(r) => {
                         search_stack.push(r.body);
                     }
-                    ControlNode::Invoke(i) => {
+                    Control::Invoke(i) => {
                         if let Some(comb) = i.comb_group {
                             if ctx.primary[comb].assignments.contains(assign) {
                                 return Some(

--- a/cider/src/flatten/flat_ir/control/structures.rs
+++ b/cider/src/flatten/flat_ir/control/structures.rs
@@ -1,3 +1,4 @@
+use calyx_frontend::source_info::PositionId;
 use cider_idx::{impl_index, iter::IndexRange, maps::IndexedMap};
 use smallvec::SmallVec;
 
@@ -278,7 +279,7 @@ impl Repeat {
 
 /// An enum representing the different types of control nodes. Analogue of [calyx_ir::Control]
 #[derive(Debug)]
-pub enum ControlNode {
+pub enum Control {
     /// An empty control node
     Empty(Empty),
     /// A group enable node
@@ -297,20 +298,44 @@ pub enum ControlNode {
     Invoke(Invoke),
 }
 
-impl ControlNode {
+impl Control {
     /// Returns true if the control node is a leaf node (i.e. invoke, enable, or
     /// empty)
     pub fn is_leaf(&self) -> bool {
         match self {
-            ControlNode::While(_)
-            | ControlNode::Repeat(_)
-            | ControlNode::Seq(_)
-            | ControlNode::Par(_)
-            | ControlNode::If(_) => false,
-            ControlNode::Enable(_)
-            | ControlNode::Invoke(_)
-            | ControlNode::Empty(_) => true,
+            Control::While(_)
+            | Control::Repeat(_)
+            | Control::Seq(_)
+            | Control::Par(_)
+            | Control::If(_) => false,
+            Control::Enable(_) | Control::Invoke(_) | Control::Empty(_) => true,
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct ControlNode {
+    pub control: Control,
+    pub pos: Option<Box<[PositionId]>>,
+}
+
+impl AsRef<Control> for ControlNode {
+    fn as_ref(&self) -> &Control {
+        &self.control
+    }
+}
+
+impl ControlNode {
+    pub fn positions(&self) -> impl Iterator<Item = PositionId> + '_ {
+        self.pos.iter().flatten().copied()
+    }
+}
+
+impl std::ops::Deref for ControlNode {
+    type Target = Control;
+
+    fn deref(&self) -> &Self::Target {
+        &self.control
     }
 }
 

--- a/cider/src/flatten/flat_ir/control/translator.rs
+++ b/cider/src/flatten/flat_ir/control/translator.rs
@@ -43,7 +43,7 @@ pub struct GroupMapper {
 }
 
 pub fn translate(orig_ctx: &cir::Context) -> Context {
-    let mut ctx = Context::new();
+    let mut ctx = Context::new(orig_ctx.source_info_table.clone());
 
     let mut component_id_map = ComponentMapper::new();
 

--- a/cider/src/flatten/structures/context.rs
+++ b/cider/src/flatten/structures/context.rs
@@ -1,5 +1,6 @@
 use std::ops::Index;
 
+use calyx_frontend::source_info::SourceInfoTable;
 use calyx_ir::Direction;
 use cider_idx::{
     iter::IndexRange,
@@ -129,6 +130,8 @@ pub struct SecondaryContext {
     pub ref_cell_defs: IndexedMap<RefCellDefinitionIdx, RefCellInfo>,
     /// auxiliary information for components
     pub comp_aux_info: SecondaryMap<ComponentIdx, AuxiliaryComponentInfo>,
+    /// Source Info Table
+    pub source_info_table: Option<SourceInfoTable>,
 }
 
 impl Index<Identifier> for SecondaryContext {
@@ -180,6 +183,18 @@ impl Index<ComponentIdx> for SecondaryContext {
 }
 
 impl SecondaryContext {
+    pub fn new(source_info_table: Option<SourceInfoTable>) -> Self {
+        Self {
+            string_table: IdMap::new(),
+            local_port_defs: Default::default(),
+            ref_port_defs: Default::default(),
+            local_cell_defs: Default::default(),
+            ref_cell_defs: Default::default(),
+            comp_aux_info: Default::default(),
+            source_info_table,
+        }
+    }
+
     /// Insert a new local port definition into the context and return its index
     pub fn push_local_port(
         &mut self,
@@ -228,19 +243,6 @@ impl SecondaryContext {
     }
 }
 
-impl Default for SecondaryContext {
-    fn default() -> Self {
-        Self {
-            string_table: IdMap::new(),
-            local_port_defs: Default::default(),
-            ref_port_defs: Default::default(),
-            local_cell_defs: Default::default(),
-            ref_cell_defs: Default::default(),
-            comp_aux_info: Default::default(),
-        }
-    }
-}
-
 /// The full immutable program context for the interpreter.
 #[derive(Debug)]
 pub struct Context {
@@ -258,7 +260,7 @@ impl Default for Context {
     fn default() -> Self {
         Self {
             primary: Default::default(),
-            secondary: Default::default(),
+            secondary: SecondaryContext::new(None),
             entry_point: ComponentIdx::new(0),
         }
     }
@@ -278,8 +280,13 @@ impl From<(InterpretationContext, SecondaryContext)> for Context {
 
 impl Context {
     /// Create a new empty context
-    pub fn new() -> Self {
-        Default::default()
+    pub fn new(source_info_table: Option<SourceInfoTable>) -> Self {
+        Self {
+            primary: Default::default(),
+            secondary: SecondaryContext::new(source_info_table),
+
+            entry_point: ComponentIdx::new(0),
+        }
     }
 
     /// Resolve the string associated with the given identifier

--- a/cider/src/flatten/structures/environment/env.rs
+++ b/cider/src/flatten/structures/environment/env.rs
@@ -756,9 +756,10 @@ impl<C: AsRef<Context> + Clone> Environment<C> {
         &self,
     ) -> impl Iterator<Item = GroupIdx> + '_ {
         self.pc.iter().filter_map(|(_, point)| {
-            let node = &self.ctx.as_ref().primary[point.control_node_idx];
+            let node =
+                &self.ctx.as_ref().primary[point.control_node_idx].control;
             match node {
-                ControlNode::Enable(x) => {
+                Control::Enable(x) => {
                     let comp_go = self.get_comp_go(point.comp).unwrap();
                     if self.ports[comp_go].as_bool().unwrap_or_default() {
                         Some(x.group())
@@ -879,9 +880,10 @@ impl<C: AsRef<Context> + Clone> Environment<C> {
 
     pub fn print_pc(&self) {
         let current_nodes = self.pc.iter().filter(|(_thread, point)| {
-            let node = &self.ctx.as_ref().primary[point.control_node_idx];
+            let node =
+                &self.ctx.as_ref().primary[point.control_node_idx].control;
             match node {
-                ControlNode::Enable(_) | ControlNode::Invoke(_) => {
+                Control::Enable(_) | Control::Invoke(_) => {
                     let comp_go = self.unwrap_comp_go(point.comp);
                     self.ports[comp_go].as_bool().unwrap_or_default()
                 }
@@ -893,9 +895,9 @@ impl<C: AsRef<Context> + Clone> Environment<C> {
         let ctx = &self.ctx.as_ref();
 
         for (_thread, point) in current_nodes {
-            let node = &ctx.primary[point.control_node_idx];
+            let node = &ctx.primary[point.control_node_idx].control;
             match node {
-                ControlNode::Enable(x) => {
+                Control::Enable(x) => {
                     let go = &self.cells[point.comp].unwrap_comp().index_bases
                         + self.ctx().primary[x.group()].go;
                     println!(
@@ -909,7 +911,7 @@ impl<C: AsRef<Context> + Clone> Environment<C> {
                         }
                     );
                 }
-                ControlNode::Invoke(x) => {
+                Control::Invoke(x) => {
                     let invoked_name = match x.cell {
                         CellRef::Local(l) => self.get_full_name(
                             &self.cells[point.comp].unwrap_comp().index_bases
@@ -1718,8 +1720,8 @@ impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
         control_points
             .iter()
             .filter_map(|(thread, node)| {
-                match &self.ctx().primary[node.control_node_idx] {
-                    ControlNode::Enable(e) => {
+                match &self.ctx().primary[node.control_node_idx].control {
+                    Control::Enable(e) => {
                         let group = &self.ctx().primary[e.group()];
 
                         Some(ScheduledAssignments::new_control(
@@ -1733,7 +1735,7 @@ impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
                         ))
                     }
 
-                    ControlNode::Invoke(i) => {
+                    Control::Invoke(i) => {
                         Some(ScheduledAssignments::new_control(
                             node.comp,
                             i.assignments,
@@ -1742,13 +1744,13 @@ impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
                         ))
                     }
 
-                    ControlNode::Empty(_) => None,
+                    Control::Empty(_) => None,
                     // non-leaf nodes
-                    ControlNode::If(_)
-                    | ControlNode::While(_)
-                    | ControlNode::Repeat(_)
-                    | ControlNode::Seq(_)
-                    | ControlNode::Par(_) => None,
+                    Control::If(_)
+                    | Control::While(_)
+                    | Control::Repeat(_)
+                    | Control::Seq(_)
+                    | Control::Par(_) => None,
                 }
             })
             .chain(self.env.pc.continuous_assigns().iter().map(|x| {
@@ -1924,9 +1926,9 @@ impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
                     PortValue::new_implicit(BitVecValue::new_false());
             }
 
-            match &ctx_ref.primary[node.control_node_idx] {
+            match &ctx_ref.primary[node.control_node_idx].control {
                 // actual nodes
-                ControlNode::Enable(enable) => {
+                Control::Enable(enable) => {
                     let go_local = ctx_ref.primary[enable.group()].go;
                     let index_bases = &self.env.cells[node.comp]
                         .as_comp()
@@ -1938,7 +1940,7 @@ impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
                     self.env.ports[go_idx] =
                         PortValue::new_implicit(BitVecValue::new_true());
                 }
-                ControlNode::Invoke(invoke) => {
+                Control::Invoke(invoke) => {
                     if invoke.comb_group.is_some()
                         && !with_map.contains_key(node)
                     {
@@ -1965,7 +1967,7 @@ impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
                     self.initialize_ref_cells(node.comp, invoke);
                 }
                 // with nodes
-                ControlNode::If(i) => {
+                Control::If(i) => {
                     if i.cond_group().is_some() && !with_map.contains_key(node)
                     {
                         with_map.insert(
@@ -1974,7 +1976,7 @@ impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
                         );
                     }
                 }
-                ControlNode::While(w) => {
+                Control::While(w) => {
                     if w.cond_group().is_some() && !with_map.contains_key(node)
                     {
                         with_map.insert(
@@ -1984,10 +1986,10 @@ impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
                     }
                 }
                 // --
-                ControlNode::Empty(_)
-                | ControlNode::Seq(_)
-                | ControlNode::Par(_)
-                | ControlNode::Repeat(_) => {}
+                Control::Empty(_)
+                | Control::Seq(_)
+                | Control::Par(_)
+                | Control::Repeat(_) => {}
             }
         }
 
@@ -2144,9 +2146,9 @@ impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
         }
 
         // just considering a single node case for the moment
-        let retain_bool = match &ctx.primary[node.control_node_idx] {
-            ControlNode::Seq(seq) => self.handle_seq(seq, node),
-            ControlNode::Par(par) => self.handle_par(
+        let retain_bool = match &ctx.primary[node.control_node_idx].control {
+            Control::Seq(seq) => self.handle_seq(seq, node),
+            Control::Par(par) => self.handle_par(
                 par_map,
                 node,
                 thread,
@@ -2154,21 +2156,17 @@ impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
                 par,
                 new_nodes,
             ),
-            ControlNode::If(i) => self.handle_if(with_map, node, thread, i)?,
-            ControlNode::While(w) => {
+            Control::If(i) => self.handle_if(with_map, node, thread, i)?,
+            Control::While(w) => {
                 self.handle_while(w, with_map, node, thread)?
             }
-            ControlNode::Repeat(rep) => {
-                self.handle_repeat(repeat_map, node, rep)
-            }
+            Control::Repeat(rep) => self.handle_repeat(repeat_map, node, rep),
 
             // ===== leaf nodes =====
-            ControlNode::Empty(_) => {
-                node.mutate_into_next(self.env.ctx.as_ref())
-            }
+            Control::Empty(_) => node.mutate_into_next(self.env.ctx.as_ref()),
 
-            ControlNode::Enable(e) => self.handle_enable(e, node),
-            ControlNode::Invoke(i) => self.handle_invoke(i, node, with_map)?,
+            Control::Enable(e) => self.handle_enable(e, node),
+            Control::Invoke(i) => self.handle_invoke(i, node, with_map)?,
         };
 
         if retain_bool && node.should_reprocess(ctx) {
@@ -2177,7 +2175,7 @@ impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
 
         if !retain_bool && ControlPoint::get_next(node, self.env.ctx.as_ref()).is_none() &&
          // either we are not a par node, or we are the last par node
-         (!matches!(&self.env.ctx.as_ref().primary[node.control_node_idx], ControlNode::Par(_)) || !par_map.contains_key(node))
+         (!matches!(&self.env.ctx.as_ref().primary[node.control_node_idx].control, Control::Par(_)) || !par_map.contains_key(node))
         {
             if self.conf.check_data_race {
                 assert!(

--- a/cider/src/flatten/structures/printer.rs
+++ b/cider/src/flatten/structures/printer.rs
@@ -171,9 +171,9 @@ impl<'a> Printer<'a> {
         control: ControlIdx,
         indent: usize,
     ) -> String {
-        match &self.ctx.primary[control] {
-            ControlNode::Empty(_) => String::new(),
-            ControlNode::Enable(e) => text_utils::indent(
+        match &self.ctx.primary[control].control {
+            Control::Empty(_) => String::new(),
+            Control::Enable(e) => text_utils::indent(
                 format!(
                     "{};     ({:?})",
                     self.ctx.secondary[self.ctx.primary[e.group()].name()]
@@ -184,7 +184,7 @@ impl<'a> Printer<'a> {
             ),
 
             // TODO Griffin: refactor into shared function rather than copy-paste?
-            ControlNode::Seq(s) => {
+            Control::Seq(s) => {
                 let mut seq = text_utils::indent(
                     format!("seq {{  ({:?})\n", control),
                     indent,
@@ -197,7 +197,7 @@ impl<'a> Printer<'a> {
                 seq += &text_utils::indent("}", indent);
                 seq
             }
-            ControlNode::Par(p) => {
+            Control::Par(p) => {
                 let mut par = text_utils::indent("par {\n", indent);
                 for stmt in p.stms() {
                     let child = self.format_control(parent, *stmt, indent + 1);
@@ -207,7 +207,7 @@ impl<'a> Printer<'a> {
                 par += &text_utils::indent("}", indent);
                 par
             }
-            ControlNode::If(i) => {
+            Control::If(i) => {
                 let cond = self.lookup_id_from_port(parent, i.cond_port());
                 let mut out = text_utils::indent(
                     format!("if {} ", cond.format_name(self.string_table())),
@@ -237,7 +237,7 @@ impl<'a> Printer<'a> {
 
                 out
             }
-            ControlNode::While(w) => {
+            Control::While(w) => {
                 let cond = self.lookup_id_from_port(parent, w.cond_port());
                 let mut out = text_utils::indent(
                     format!("while {} ", cond.format_name(self.string_table())),
@@ -257,7 +257,7 @@ impl<'a> Printer<'a> {
 
                 out
             }
-            ControlNode::Invoke(i) => {
+            Control::Invoke(i) => {
                 let invoked_name =
                     &self.ctx.secondary[self.lookup_cell_id(parent, i.cell)];
 
@@ -285,7 +285,7 @@ impl<'a> Printer<'a> {
 
                 text_utils::indent(out, indent)
             }
-            ControlNode::Repeat(_) => {
+            Control::Repeat(_) => {
                 todo!()
             }
         }


### PR DESCRIPTION
A quick and dirty integration of the newer sourceinfo into Cider such that requesting the program counter will display the source filename & line when available, similar to how it used to work with the embedded metadata lines.