### PR TITLE
[Cider] Add test for debugger use of source info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44055e597c674aef7cb903b2b9f6e4cba1277ed0d2d61dae7cd52d7ffa81f8e2"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.11",
  "yansi",
 ]
 
@@ -277,9 +277,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitvec"
@@ -557,6 +557,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,7 +574,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -685,7 +691,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags 1.3.2",
  "textwrap",
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -730,13 +736,11 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clipboard-win"
-version = "4.5.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
 dependencies = [
  "error-code",
- "str-buf",
- "winapi",
 ]
 
 [[package]]
@@ -752,7 +756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -907,7 +911,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.8.0",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -1204,13 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "2.3.1"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
-]
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "fastrand"
@@ -1220,13 +1220,13 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fd-lock"
-version = "3.0.13"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1438,7 +1438,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -1530,6 +1530,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "httparse"
@@ -1710,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libm"
@@ -1726,7 +1735,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.8.0",
  "libc",
  "redox_syscall",
 ]
@@ -1755,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lsp-types"
@@ -1867,12 +1876,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.8.0",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -2391,7 +2401,7 @@ checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.4.2",
+ "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -2409,7 +2419,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.8.0",
  "getopts",
  "memchr",
  "unicase",
@@ -2626,7 +2636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61797318be89b1a268a018a92a7657096d83f3ecb31418b9e9c16dcbb043b702"
 dependencies = [
  "ahash 0.8.10",
- "bitflags 2.4.2",
+ "bitflags 2.8.0",
  "instant",
  "num-traits",
  "once_cell",
@@ -2659,7 +2669,7 @@ version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2686,25 +2696,24 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "10.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1cd5ae51d3f7bf65d7969d579d502168ef578f289452bd8ccc91de28fda20e"
+checksum = "2ee1e066dc922e513bda599c6ccb5f3bb2b0ea5870a579448f2622993f0a9a2f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.8.0",
  "cfg-if",
  "clipboard-win",
- "dirs-next",
  "fd-lock",
+ "home",
  "libc",
  "log",
  "memchr",
  "nix",
  "radix_trie",
- "scopeguard",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
  "utf8parse",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2996,12 +3005,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "str-buf"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
-
-[[package]]
 name = "str-concat"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3232,7 +3235,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -3644,6 +3647,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3817,7 +3826,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3835,7 +3844,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3855,17 +3873,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -3876,9 +3895,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3888,9 +3907,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3900,9 +3919,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3912,9 +3937,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3924,9 +3949,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3936,9 +3961,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3948,9 +3973,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/cider/Cargo.toml
+++ b/cider/Cargo.toml
@@ -22,7 +22,7 @@ pest_consume.workspace = true
 argh.workspace = true
 owo-colors = "^3.5"
 serde_json = "1.0"
-rustyline = "=10.0.0"
+rustyline = "=15.0.0"
 fraction = { version = "0.15.3", features = ["with-serde-support"] }
 thiserror = "1.0.26"
 slog = "2.7.0"

--- a/cider/src/debugger/io_utils.rs
+++ b/cider/src/debugger/io_utils.rs
@@ -2,27 +2,20 @@ use super::commands::parse_command;
 use super::commands::Command;
 use crate::errors::{BoxedCiderError, CiderResult};
 use rustyline::{DefaultEditor, Editor};
-use std::collections::VecDeque;
 
 const SHELL_PROMPT: &str = " > ";
 
 pub struct Input {
     buffer: DefaultEditor,
-    command_buffer: VecDeque<Command>,
 }
 
 impl Input {
     pub fn new() -> CiderResult<Self> {
         Ok(Self {
             buffer: Editor::new()?,
-            command_buffer: VecDeque::default(),
         })
     }
     pub fn next_command(&mut self) -> CiderResult<Command> {
-        if !self.command_buffer.is_empty() {
-            return Ok(self.command_buffer.pop_front().unwrap());
-        }
-
         match self.buffer.readline(SHELL_PROMPT) {
             Ok(command_str) => {
                 self.buffer.add_history_entry(command_str.clone())?;

--- a/cider/src/debugger/io_utils.rs
+++ b/cider/src/debugger/io_utils.rs
@@ -1,13 +1,13 @@
 use super::commands::parse_command;
 use super::commands::Command;
 use crate::errors::{BoxedCiderError, CiderResult};
-use rustyline::Editor;
+use rustyline::{DefaultEditor, Editor};
 use std::collections::VecDeque;
 
 const SHELL_PROMPT: &str = " > ";
 
 pub struct Input {
-    buffer: Editor<()>,
+    buffer: DefaultEditor,
     command_buffer: VecDeque<Command>,
 }
 
@@ -25,7 +25,7 @@ impl Input {
 
         match self.buffer.readline(SHELL_PROMPT) {
             Ok(command_str) => {
-                self.buffer.add_history_entry(command_str.clone());
+                self.buffer.add_history_entry(command_str.clone())?;
                 parse_command(&command_str)
             }
             Err(e) => {

--- a/cider/tests/debugger/source_info.expect
+++ b/cider/tests/debugger/source_info.expect
@@ -1,0 +1,12 @@
+
+---STDERR---
+==== [1mCider[0m: The [4mC[0malyx [4mI[0mnterpreter and [4mDe[0mbugge[4mr[0m ====
+test.futil:14
+my_super_cool_file.txt:15
+my_super_cool_file.txt:45
+test.futil:14
+test.futil:6578
+test.futil:14
+test.futil:6578
+Main component has finished executing. Debugger is now in inspection mode.
+Exiting.

--- a/cider/tests/debugger/source_info.futil
+++ b/cider/tests/debugger/source_info.futil
@@ -1,0 +1,51 @@
+import "primitives/core.futil";
+
+
+component main() -> () {
+    cells {
+        r1 = std_reg(32);
+        r2 = std_reg(32);
+        r3 = std_reg(32);
+    }
+
+    wires {
+        group write_r1 {
+            r1.in = 32'd5;
+            r1.write_en = 1'd1;
+            write_r1[done] = r1.done;
+        }
+
+        group write_r2 {
+            r2.in = 32'd10;
+            r2.write_en = 1'd1;
+            write_r2[done] = r2.done;
+        }
+
+         group write_r3 {
+            r3.in = 32'd15;
+            r3.write_en = 1'd1;
+            write_r3[done] = r3.done;
+        }
+    }
+
+    control {
+        seq {
+            @pos{0} write_r1;
+            @pos{1,3} write_r2;
+            @pos{0,2} write_r3;
+        }
+    }
+}
+
+
+sourceinfo #{
+    FILES
+        0: test.futil
+        1: my_super_cool_file.txt
+
+    POSITIONS
+        0: 0 14
+        1: 1 15
+        2: 0 6578
+        3: 1 45
+}#

--- a/cider/tests/debugger/source_info.futil.commands
+++ b/cider/tests/debugger/source_info.futil.commands
@@ -1,0 +1,9 @@
+step
+pc
+step 2
+pc
+step 2
+pc
+step
+pc
+step

--- a/cider/tests/runt.toml
+++ b/cider/tests/runt.toml
@@ -285,3 +285,11 @@ timeout = 180
 #             -s verilog.data {}.data \
 #             -s jq.expr ".main"
 # """
+
+[[tests]]
+name = "Debugger Interaction"
+paths = ["debugger/*.futil"]
+cmd = """
+cat {}.commands | fud2 --to cider-debug {} \
+         -s calyx.args="--log off"
+"""

--- a/fud2/scripts/cider.rhai
+++ b/fud2/scripts/cider.rhai
@@ -39,7 +39,7 @@ fn cider_setup(e) {
     //                                                       to avoid fud2
     //                                                       complaining about
     //                                                       there being no file
-        "$cider-exe -l $calyx-base $data $cider-flags $in debug  && echo > $out",
+        "$cider-exe -l $calyx-base $data $cider-flags $in debug && echo > $out",
     );
     e.arg("pool", "console");
 

--- a/fud2/scripts/cider.rhai
+++ b/fud2/scripts/cider.rhai
@@ -35,7 +35,11 @@ fn cider_setup(e) {
 
     e.rule(
         "run-cider-debug",
-        "$cider-exe -l $calyx-base $data $cider-flags $in debug || true",
+    //                                                       this is a dumb hack
+    //                                                       to avoid fud2
+    //                                                       complaining about
+    //                                                       there being no file
+        "$cider-exe -l $calyx-base $data $cider-flags $in debug  && echo > $out",
     );
     e.arg("pool", "console");
 

--- a/fud2/tests/snapshots/tests__test@calyx_through_cider_to_dat.snap
+++ b/fud2/tests/snapshots/tests__test@calyx_through_cider_to_dat.snap
@@ -25,7 +25,7 @@ cider-flags =
 data = --data data.dump
 sim_data = /test/data.json
 rule run-cider-debug
-  command = $cider-exe -l $calyx-base $data $cider-flags $in debug || true
+  command = $cider-exe -l $calyx-base $data $cider-flags $in debug && echo > $out
   pool = console
 rule run-cider
   command = $cider-exe -l $calyx-base $data $cider-flags $in > $out

--- a/fud2/tests/snapshots/tests__test@calyx_to_cider-debug.snap
+++ b/fud2/tests/snapshots/tests__test@calyx_to_cider-debug.snap
@@ -27,7 +27,7 @@ cider-flags =
 data = --data data.dump
 sim_data = /test/data.json
 rule run-cider-debug
-  command = $cider-exe -l $calyx-base $data $cider-flags $in debug || true
+  command = $cider-exe -l $calyx-base $data $cider-flags $in debug && echo > $out
   pool = console
 rule run-cider
   command = $cider-exe -l $calyx-base $data $cider-flags $in > $out

--- a/fud2/tests/snapshots/tests__test@plan_cider.snap
+++ b/fud2/tests/snapshots/tests__test@plan_cider.snap
@@ -25,7 +25,7 @@ cider-flags =
 data = --data data.dump
 sim_data = /test/data.json
 rule run-cider-debug
-  command = $cider-exe -l $calyx-base $data $cider-flags $in debug || true
+  command = $cider-exe -l $calyx-base $data $cider-flags $in debug && echo > $out
   pool = console
 rule run-cider
   command = $cider-exe -l $calyx-base $data $cider-flags $in > $out

--- a/fud2/tests/snapshots/tests__test@plan_debug.snap
+++ b/fud2/tests/snapshots/tests__test@plan_debug.snap
@@ -27,7 +27,7 @@ cider-flags =
 data = --data data.dump
 sim_data = /test/data.json
 rule run-cider-debug
-  command = $cider-exe -l $calyx-base $data $cider-flags $in debug || true
+  command = $cider-exe -l $calyx-base $data $cider-flags $in debug && echo > $out
   pool = console
 rule run-cider
   command = $cider-exe -l $calyx-base $data $cider-flags $in > $out


### PR DESCRIPTION
A quick PR that modifies the `fud2` execution of the debugger and some of the debugger internals to make it possible to run tests on its behavior. Using this, it adds a quick test for the display of the new source info.