### PR TITLE
Version 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "calyx"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "argh",
  "atty",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "calyx-backend"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "calyx-frontend",
  "calyx-ir",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "calyx-frontend"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "atty",
  "calyx-utils",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "calyx-ir"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "calyx-frontend",
  "calyx-utils",
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "calyx-lsp"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "calyx-frontend",
  "calyx-ir",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "calyx-opt"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "calyx-ir",
  "calyx-utils",
@@ -493,11 +493,11 @@ dependencies = [
 
 [[package]]
 name = "calyx-stdlib"
-version = "0.7.1"
+version = "0.8.0"
 
 [[package]]
 name = "calyx-utils"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "atty",
  "boxcar",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "calyx_writer"
-version = "0.7.1"
+version = "0.8.0"
 
 [[package]]
 name = "camino"
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "component_cells"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "argh",
  "calyx-frontend",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "data-conversion"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "argh",
 ]
@@ -4235,7 +4235,7 @@ dependencies = [
 
 [[package]]
 name = "yxi"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "argh",
  "calyx-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ description = "Compiler Infrastructure for Hardware Accelerator Generation"
 categories = ["compilers"]
 homepage = "https://calyxir.org"
 edition = "2021"
-version = "0.7.1"
+version = "0.8.0"
 rust-version = "1.80"
 
 [workspace.dependencies]
@@ -54,11 +54,11 @@ pest_derive = "2"
 pest_consume = "1"
 argh = "0.1"
 anyhow = "1"
-calyx-utils = { path = "calyx/utils", version = "0.7.1" }
-calyx-ir = { path = "calyx/ir", version = "0.7.1" }
-calyx-frontend = { path = "calyx/frontend", version = "0.7.1" }
-calyx-opt = { path = "calyx/opt", version = "0.7.1" }
-calyx-backend = { path = "calyx/backend", version = "0.7.1" }
+calyx-utils = { path = "calyx/utils", version = "0.8.0" }
+calyx-ir = { path = "calyx/ir", version = "0.8.0" }
+calyx-frontend = { path = "calyx/frontend", version = "0.8.0" }
+calyx-opt = { path = "calyx/opt", version = "0.8.0" }
+calyx-backend = { path = "calyx/backend", version = "0.8.0" }
 baa = { version = "0.16.0", features = ["bigint", "serde1", "fraction1"] }
 
 [workspace.dependencies.petgraph]
@@ -99,7 +99,7 @@ default = []
 serialize = ["calyx-ir/serialize", "serde/rc", "calyx-backend/sexp"]
 
 [build-dependencies]
-calyx-stdlib = { path = "calyx/stdlib", version = "0.7.1" }
+calyx-stdlib = { path = "calyx/stdlib", version = "0.8.0" }
 
 [dependencies]
 atty.workspace = true


### PR DESCRIPTION
Release a new version for Calyx (first one in almost 12 months!). This one is a doozy with a ton of changes like the new `static` abstractions and support for Hardfloat library.

The one thing I'd like to have before finalizing this release is a better way to install new libraries like hardfloat. I think adding a new subcommand to the `calyx` binary that pulls the version of primitives from a particular folder might be the way to go.