### PR TITLE
[Cider] Improve data race errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,7 +622,7 @@ dependencies = [
  "itertools 0.11.0",
  "num-bigint",
  "num-traits",
- "owo-colors",
+ "owo-colors 4.1.0",
  "pest",
  "pest_consume",
  "pest_derive",
@@ -647,7 +647,7 @@ dependencies = [
  "baa",
  "cider",
  "dap",
- "owo-colors",
+ "owo-colors 3.5.0",
  "serde",
  "serde_json",
  "slog",
@@ -755,7 +755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1178,7 +1178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1778,8 +1778,14 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2299,6 +2305,16 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "owo-colors"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
+dependencies = [
+ "supports-color 2.1.0",
+ "supports-color 3.0.2",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2834,7 +2850,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3199,6 +3215,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
 name = "sv-parser"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,7 +3400,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3969,7 +4004,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/cider/Cargo.toml
+++ b/cider/Cargo.toml
@@ -32,7 +32,7 @@ baa.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 
-owo-colors = "^3.5"
+owo-colors = { version = "4.1", features = ["supports-colors"] }
 rustyline = "=15.0.0"
 fraction = { version = "0.15.3", features = ["with-serde-support"] }
 num-bigint = "0.4.6"

--- a/cider/idx/src/sparse_map.rs
+++ b/cider/idx/src/sparse_map.rs
@@ -151,6 +151,10 @@ where
     pub fn get(&self, key: K) -> Option<&D> {
         self.data.get(&key)
     }
+
+    pub fn get_mut(&mut self, key: K) -> Option<&mut D> {
+        self.data.get_mut(&key)
+    }
 }
 
 impl<K, D> Default for SecondarySparseMap<K, D>

--- a/cider/src/configuration.rs
+++ b/cider/src/configuration.rs
@@ -1,5 +1,7 @@
 use bon::Builder;
 
+use crate::flatten::text_utils;
+
 // this can be a copy type because it's just a bunch of bools
 #[derive(Debug, Default, Clone, Copy, Builder)]
 /// Configuration struct which controls runtime behavior
@@ -35,6 +37,10 @@ impl RuntimeConfig {
             quiet: self.quiet,
             debug_logging: self.debug_logging,
         }
+    }
+
+    pub fn set_force_color(self, force_color: bool) {
+        text_utils::force_color(force_color);
     }
 }
 

--- a/cider/src/debugger/debugger_core.rs
+++ b/cider/src/debugger/debugger_core.rs
@@ -20,6 +20,7 @@ use crate::{
             context::Context,
             environment::{Path as ParsePath, PathError, Simulator},
         },
+        text_utils::{print_debugger_welcome, Color},
     },
     serialization::PrintCode,
 };
@@ -27,7 +28,6 @@ use crate::{
 use std::{collections::HashSet, path::PathBuf, rc::Rc};
 
 use itertools::Itertools;
-use owo_colors::OwoColorize;
 use std::path::Path as FilePath;
 
 /// Constant amount of space used for debugger messages
@@ -246,7 +246,7 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
                         print_tuple.print_code(),
                         *print_tuple.print_mode(),
                     ) {
-                        println!("{}", e.red().bold());
+                        println!("{}", e.stylize_error());
                     };
                 }
             }
@@ -261,8 +261,7 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
                     self.program_context
                         .as_ref()
                         .lookup_name(group)
-                        .bright_purple()
-                        .underline()
+                        .stylize_breakpoint()
                 );
             }
             self.interpreter.converge()?;
@@ -292,14 +291,7 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
         let mut input_stream =
             input_stream.map(Ok).unwrap_or_else(Input::new)?;
 
-        println!(
-            "==== {}: The {}alyx {}nterpreter and {}bugge{} ====",
-            "Cider".bold(),
-            "C".underline(),
-            "I".underline(),
-            "De".underline(),
-            "r".underline()
-        );
+        print_debugger_welcome();
 
         let mut err_count = 0_u8;
 
@@ -314,13 +306,13 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
                     CiderError::InvalidCommand(_)
                     | CiderError::UnknownCommand(_)
                     | CiderError::ParseError(_) => {
-                        println!("Error: {}", e.red().bold());
+                        println!("Error: {}", e.stylize_error());
                         err_count += 1;
                         if err_count == 3 {
                             println!(
                                 "Type {} for a list of commands or {} for usage examples.",
-                                "help".yellow().bold().underline(),
-                                "explain".yellow().bold().underline()
+                                "help".stylize_command(),
+                                "explain".stylize_command()
                             );
                             err_count = 0;
                         }
@@ -344,7 +336,7 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
                     for target in print_lists {
                         if let Err(e) = self.do_print(&target, code, print_mode)
                         {
-                            println!("{}", e.red().bold());
+                            println!("{}", e.stylize_error());
                         };
                     }
                 }
@@ -477,7 +469,7 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
                     CiderError::InvalidCommand(_)
                     | CiderError::UnknownCommand(_)
                     | CiderError::ParseError(_) => {
-                        println!("Error: {}", e.red().bold());
+                        println!("Error: {}", e.stylize_error());
                         continue;
                     }
                     _ => return Err(e),
@@ -493,7 +485,7 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
                     for target in print_lists {
                         if let Err(e) = self.do_print(&target, code, print_mode)
                         {
-                            println!("{}", e.red().bold());
+                            println!("{}", e.stylize_error());
                         };
                     }
                 }
@@ -542,14 +534,14 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
                 }
                 Err(e) => {
                     error_occurred = true;
-                    println!("{}", e.red().bold());
+                    println!("{}", e.stylize_error());
                     continue;
                 }
             }
         }
 
         if error_occurred {
-            println!("{}", "No watchpoints have been added.".red());
+            println!("{}", "No watchpoints have been added.".stylize_error());
             return;
         }
 
@@ -557,7 +549,7 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
             match group.lookup_group(self.program_context.as_ref()) {
                 Ok(v) => v,
                 Err(e) => {
-                    println!("Error: {}", e.red());
+                    println!("Error: {}", e.stylize_error());
                     return;
                 }
             };
@@ -576,7 +568,7 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
         let target = match target.lookup_group(self.program_context.as_ref()) {
             Ok(v) => v,
             Err(e) => {
-                println!("Error: {}", e.red());
+                println!("Error: {}", e.stylize_error());
                 return Ok(());
             }
         };
@@ -602,7 +594,7 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
 
             if self.interpreter.is_group_running(target) {
                 println!("Warning: the group {} is already running. This breakpoint will not trigger until the next time the group runs.",
-                        self.program_context.as_ref().lookup_name(target).yellow().italic())
+                        self.program_context.as_ref().lookup_name(target).stylize_warning())
             }
 
             self.debugging_context.add_breakpoint(target);
@@ -651,7 +643,7 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
                         println!("{}", state);
                         return Ok(());
                     } else {
-                        println!("{}","Target cell has no internal state, printing port information instead".red());
+                        println!("{}","Target cell has no internal state, printing port information instead".stylize_warning());
                     }
                 }
 

--- a/cider/src/debugger/debugging_context/context.rs
+++ b/cider/src/debugger/debugging_context/context.rs
@@ -13,7 +13,6 @@ use crate::{
 use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use cider_idx::maps::IndexedMap;
 use itertools::Itertools;
-use owo_colors::OwoColorize;
 use smallvec::{smallvec, SmallVec};
 use std::fmt::Display;
 
@@ -28,8 +27,12 @@ enum PointStatus {
 impl Display for PointStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PointStatus::Enabled => write!(f, "{}", "enabled".green()),
-            PointStatus::Disabled => write!(f, "{}", "disabled".red()),
+            PointStatus::Enabled => {
+                write!(f, "{}", "enabled".stylize_breakpoint_enabled())
+            }
+            PointStatus::Disabled => {
+                write!(f, "{}", "disabled".stylize_breakpoint_disabled())
+            }
         }
     }
 }
@@ -504,9 +507,10 @@ impl DebuggingContext {
             }
         } else if matches!(target, BreakpointID::Name(_)) {
             let name = target.as_name().unwrap();
+            let name = format!("{:?}", name);
             println!(
-                "Error: There is no breakpoint named '{:?}'",
-                name.red().bold().strikethrough()
+                "Error: There is no breakpoint named '{}'",
+                name.stylize_debugger_missing()
             )
         } else {
             let num = target.as_number().unwrap();
@@ -596,7 +600,7 @@ impl DebuggingContext {
                 } else {
                     println!(
                         "Error: There is no watchpoint numbered {}",
-                        num.red().bold().strikethrough()
+                        num.stylize_debugger_missing()
                     )
                 }
             }
@@ -707,7 +711,7 @@ impl DebuggingContext {
             if indicies.get_before().is_some() {
                 println!(
                     "{outer_spacing}Before {}:",
-                    group_name.magenta().bold()
+                    group_name.stylize_breakpoint()
                 );
             }
             for watchpoint_idx in indicies
@@ -727,7 +731,7 @@ impl DebuggingContext {
             if indicies.get_after().is_some() {
                 println!(
                     "{outer_spacing}After {}:",
-                    group_name.magenta().bold()
+                    group_name.stylize_breakpoint()
                 );
             }
 

--- a/cider/src/debugger/debugging_context/context.rs
+++ b/cider/src/debugger/debugging_context/context.rs
@@ -2,6 +2,7 @@ use super::super::{
     commands::{PrintTuple, WatchPosition},
     debugger_core::SPACING,
 };
+use crate::flatten::text_utils::Color;
 use crate::{
     debugger::commands::{BreakpointID, BreakpointIdx, WatchID, WatchpointIdx},
     flatten::{
@@ -511,7 +512,7 @@ impl DebuggingContext {
             let num = target.as_number().unwrap();
             println!(
                 "Error: There is no breakpoint numbered {}",
-                num.red().bold().strikethrough()
+                num.stylize_debugger_missing()
             )
         }
     }

--- a/cider/src/debugger/macros.rs
+++ b/cider/src/debugger/macros.rs
@@ -5,7 +5,10 @@ macro_rules! unwrap_error_message {
         let $name = match $name {
             Ok(v) => v,
             Err(e) => {
-                println!("Error: {}", owo_colors::OwoColorize::red(&e));
+                println!(
+                    "Error: {}",
+                    crate::flatten::text_utils::Color::stylize_error(&e)
+                );
                 continue;
             }
         };

--- a/cider/src/errors.rs
+++ b/cider/src/errors.rs
@@ -330,7 +330,7 @@ impl RuntimeError {
                     // memory
                     match error {
                         ClockError::ReadAfterWrite { write, read } => {
-                            CiderError::GenericError(format!("Concurrent read & write to the same memory {} at entry {num}\n  {}\n  {}", env.get_full_name(cell).underline(), write.format(env), read.format(env.ctx())))
+                            CiderError::GenericError(format!("Concurrent read & write to the same memory {} at entry {num}\n  {}\n  {}", env.get_full_name(cell).underline(), write.format(env), read.format(env)))
                         },
                         ClockError::WriteAfterWrite { write1, write2 } => {
                             CiderError::GenericError(format!("Concurrent writes to the same memory {} at entry {num}\n  1. {}\n  2. {}", env.get_full_name(cell).underline(), write1.format(env), write2.format(env)))
@@ -343,13 +343,13 @@ impl RuntimeError {
                     // register
                     match error {
                         ClockError::ReadAfterWrite { write, read } => {
-                            CiderError::GenericError(format!("Concurrent read & write to the same register {}\n  {}\n  {}", env.get_full_name(cell).underline(), write.format(env), read.format(env.ctx())))
+                            CiderError::GenericError(format!("Concurrent read & write to the same register {}\n  {}\n  {}", env.get_full_name(cell).underline(), write.format(env), read.format(env)))
                         },
                         ClockError::WriteAfterWrite { write1, write2 } => {
                             CiderError::GenericError(format!("Concurrent writes to the same register {}\n  1. {}\n  2. {}", env.get_full_name(cell).underline(), write1.format(env), write2.format(env)))
                         },
                         ClockError::WriteAfterRead { write } => {
-                            CiderError::GenericError(format!("Concurrent read and write to the same register {}\n  1. {}\n  read <UNAVAILABLE>", env.get_full_name(cell).underline(), write.format(env)))
+                            CiderError::GenericError(format!("Concurrent read & write to the same register {}\n  {}\n  read <UNAVAILABLE>", env.get_full_name(cell).underline(), write.format(env)))
                         },
                     }
                 }

--- a/cider/src/errors.rs
+++ b/cider/src/errors.rs
@@ -11,13 +11,13 @@ use crate::{
             clock::{ClockError, ClockErrorWithCell},
             Environment,
         },
+        text_utils::Color,
     },
     serialization::Shape,
 };
 use baa::BitVecOps;
 use calyx_utils::{Error as CalyxError, MultiError as CalyxMultiError};
 use itertools::Itertools;
-use owo_colors::OwoColorize;
 use rustyline::error::ReadlineError;
 use thiserror::Error;
 
@@ -355,9 +355,9 @@ impl RuntimeError {
             RuntimeError::UndefinedGuardError(v) => {
                 let mut message = String::from("Some guards contained undefined values after convergence:\n");
                 for (cell, assign, ports) in v {
-                    writeln!(message, "({}) in assignment {}", env.get_full_name(cell), env.ctx().printer().print_assignment(env.get_component_idx(cell).unwrap(), assign).bold()).unwrap();
+                    writeln!(message, "({}) in assignment {}", env.get_full_name(cell), env.ctx().printer().print_assignment(env.get_component_idx(cell).unwrap(), assign).stylize_assignment()).unwrap();
                     for port in ports {
-                        writeln!(message, "    {} is undefined", env.get_full_name(port).yellow()).unwrap();
+                        writeln!(message, "    {} is undefined", env.get_full_name(port).stylize_assignment()).unwrap();
                     }
                     writeln!(message).unwrap()
                 }

--- a/cider/src/errors.rs
+++ b/cider/src/errors.rs
@@ -330,26 +330,26 @@ impl RuntimeError {
                     // memory
                     match error {
                         ClockError::ReadAfterWrite { write, read } => {
-                            CiderError::GenericError(format!("Concurrent read & write to the same memory {} at entry {num}\n  {}\n  {}", env.get_full_name(cell).underline(), write.format(env.ctx()), read.format(env.ctx())))
+                            CiderError::GenericError(format!("Concurrent read & write to the same memory {} at entry {num}\n  {}\n  {}", env.get_full_name(cell).underline(), write.format(env), read.format(env.ctx())))
                         },
                         ClockError::WriteAfterWrite { write1, write2 } => {
-                            CiderError::GenericError(format!("Concurrent writes to the same memory {} at entry {num}\n  1. {}\n  2. {}", env.get_full_name(cell).underline(), write1.format(env.ctx()), write2.format(env.ctx())))
+                            CiderError::GenericError(format!("Concurrent writes to the same memory {} at entry {num}\n  1. {}\n  2. {}", env.get_full_name(cell).underline(), write1.format(env), write2.format(env)))
                         },
                         ClockError::WriteAfterRead { write } => {
-                            CiderError::GenericError(format!("Concurrent read and write to the same memory {} at entry {num}\n  1. {}\n  read <UNAVAILABLE>", env.get_full_name(cell).underline(), write.format(env.ctx())))
+                            CiderError::GenericError(format!("Concurrent read and write to the same memory {} at entry {num}\n  1. {}\n  read <UNAVAILABLE>", env.get_full_name(cell).underline(), write.format(env)))
                         },
                     }
                 } else {
                     // register
                     match error {
                         ClockError::ReadAfterWrite { write, read } => {
-                            CiderError::GenericError(format!("Concurrent read & write to the same register {}\n  {}\n  {}", env.get_full_name(cell).underline(), write.format(env.ctx()), read.format(env.ctx())))
+                            CiderError::GenericError(format!("Concurrent read & write to the same register {}\n  {}\n  {}", env.get_full_name(cell).underline(), write.format(env), read.format(env.ctx())))
                         },
                         ClockError::WriteAfterWrite { write1, write2 } => {
-                            CiderError::GenericError(format!("Concurrent writes to the same register {}\n  1. {}\n  2. {}", env.get_full_name(cell).underline(), write1.format(env.ctx()), write2.format(env.ctx())))
+                            CiderError::GenericError(format!("Concurrent writes to the same register {}\n  1. {}\n  2. {}", env.get_full_name(cell).underline(), write1.format(env), write2.format(env)))
                         },
                         ClockError::WriteAfterRead { write } => {
-                            CiderError::GenericError(format!("Concurrent read and write to the same register {}\n  1. {}\n  read <UNAVAILABLE>", env.get_full_name(cell).underline(), write.format(env.ctx())))
+                            CiderError::GenericError(format!("Concurrent read and write to the same register {}\n  1. {}\n  read <UNAVAILABLE>", env.get_full_name(cell).underline(), write.format(env)))
                         },
                     }
                 }

--- a/cider/src/flatten/flat_ir/base.rs
+++ b/cider/src/flatten/flat_ir/base.rs
@@ -403,9 +403,9 @@ pub enum AssignmentWinner {
 
 impl AssignmentWinner {
     #[must_use]
-    pub fn as_assign(&self) -> Option<&AssignmentIdx> {
-        if let Self::Assign(v, _c) = self {
-            Some(v)
+    pub fn as_assign(&self) -> Option<(AssignmentIdx, GlobalCellIdx)> {
+        if let Self::Assign(v, c) = self {
+            Some((*v, *c))
         } else {
             None
         }

--- a/cider/src/flatten/flat_ir/component.rs
+++ b/cider/src/flatten/flat_ir/component.rs
@@ -37,6 +37,9 @@ pub struct DefinitionRanges {
     /// The entire range of comb-groups defined by this component. Does not
     /// include sub-component instances.
     comb_groups: IndexRange<CombGroupIdx>,
+    /// The entire range of control nodes defined by this component. Does not
+    /// include control nodes defined in sub-components
+    control: IndexRange<ControlIdx>,
 }
 
 impl DefinitionRanges {
@@ -63,6 +66,10 @@ impl DefinitionRanges {
     pub fn comb_groups(&self) -> &IndexRange<CombGroupIdx> {
         &self.comb_groups
     }
+
+    pub fn control(&self) -> IndexRange<ControlIdx> {
+        self.control
+    }
 }
 
 impl Default for DefinitionRanges {
@@ -74,6 +81,7 @@ impl Default for DefinitionRanges {
             ref_cells: IndexRange::empty_interval(),
             groups: IndexRange::empty_interval(),
             comb_groups: IndexRange::empty_interval(),
+            control: IndexRange::empty_interval(),
         }
     }
 }
@@ -378,6 +386,14 @@ impl AuxiliaryComponentInfo {
         end: CombGroupIdx,
     ) {
         self.definitions.comb_groups = IndexRange::new(start, end)
+    }
+
+    pub fn set_control_range(&mut self, start: ControlIdx, end: ControlIdx) {
+        self.definitions.control = IndexRange::new(start, end)
+    }
+
+    pub fn contains_control(&self, target: ControlIdx) -> bool {
+        self.definitions.control.contains(target)
     }
 
     pub fn inputs(&self) -> impl Iterator<Item = LocalPortOffset> + '_ {

--- a/cider/src/flatten/flat_ir/control/translator.rs
+++ b/cider/src/flatten/flat_ir/control/translator.rs
@@ -260,11 +260,14 @@ fn translate_component(
     let ctrl_idx_end = taken_control.peek_next_idx();
 
     // unwrap all the stuff packed into the argument tuple
-    let (_, layout, mut taken_ctx, auxiliary_component_info) = argument_tuple;
+    let (_, layout, mut taken_ctx, mut auxiliary_component_info) =
+        argument_tuple;
 
     // put stuff back
     taken_ctx.primary.control = taken_control;
     *ctx = taken_ctx;
+
+    auxiliary_component_info.set_control_range(ctrl_idx_start, ctrl_idx_end);
 
     for node in IndexRange::new(ctrl_idx_start, ctrl_idx_end).iter() {
         if let Control::Invoke(i) = &mut ctx.primary.control[node].control {

--- a/cider/src/flatten/primitives/stateful/memories.rs
+++ b/cider/src/flatten/primitives/stateful/memories.rs
@@ -16,7 +16,7 @@ use crate::{
         },
         structures::{
             environment::{
-                clock::{new_clock_pair, ClockMap, ValueWithClock},
+                clock::{new_clock_pair, ClockMap, ReadSource, ValueWithClock},
                 PortMap,
             },
             thread::{ThreadIdx, ThreadMap},
@@ -1083,11 +1083,13 @@ impl RaceDetectionPrimitive for SeqMem {
                                 ),
                                 thread_clock.unwrap(),
                             ),
-                            *port_map[self.content_enable()]
-                                .winner()
-                                .unwrap()
-                                .as_assign()
-                                .unwrap(),
+                            ReadSource::Assignment(
+                                *port_map[self.content_enable()]
+                                    .winner()
+                                    .unwrap()
+                                    .as_assign()
+                                    .unwrap(),
+                            ),
                             clock_map,
                         )
                         .map_err(|e| {

--- a/cider/src/flatten/primitives/stateful/memories.rs
+++ b/cider/src/flatten/primitives/stateful/memories.rs
@@ -1075,6 +1075,12 @@ impl RaceDetectionPrimitive for SeqMem {
                     .as_bool()
                     .unwrap_or_default()
                 {
+                    let (assignment_idx, cell) = port_map
+                        [self.content_enable()]
+                    .winner()
+                    .unwrap()
+                    .as_assign()
+                    .unwrap();
                     val.clocks
                         .check_read_with_ascription(
                             (
@@ -1083,13 +1089,8 @@ impl RaceDetectionPrimitive for SeqMem {
                                 ),
                                 thread_clock.unwrap(),
                             ),
-                            ReadSource::Assignment(
-                                *port_map[self.content_enable()]
-                                    .winner()
-                                    .unwrap()
-                                    .as_assign()
-                                    .unwrap(),
-                            ),
+                            ReadSource::Assignment(assignment_idx),
+                            cell,
                             clock_map,
                         )
                         .map_err(|e| {

--- a/cider/src/flatten/structures/context.rs
+++ b/cider/src/flatten/structures/context.rs
@@ -463,6 +463,18 @@ impl Context {
         }
         unreachable!("Assignment does not belong to any component");
     }
+
+    /// Returns the assignment definition information, if it exists. This
+    /// requires the component that the assignment is defined in. If the
+    /// component is not readily available use
+    /// [Self::find_assignment_definition] instead
+    pub fn lookup_assignment_definition(
+        &self,
+        target: AssignmentIdx,
+        comp: ComponentIdx,
+    ) -> Option<AssignmentDefinitionLocation> {
+        self.primary.components[comp].contains_assignment(self, target)
+    }
 }
 
 impl AsRef<Context> for &Context {

--- a/cider/src/flatten/structures/context.rs
+++ b/cider/src/flatten/structures/context.rs
@@ -395,6 +395,19 @@ impl Context {
             .unwrap()
     }
 
+    pub fn lookup_control_definition(
+        &self,
+        target: ControlIdx,
+    ) -> ComponentIdx {
+        self.secondary
+            .comp_aux_info
+            .iter()
+            .find_map(|(id, info)| info.contains_control(target).then_some(id))
+            .expect(
+                "No component defines this control node. This shouldn't happen",
+            )
+    }
+
     /// This is a wildly inefficient search, only used for debugging right now.
     /// TODO Griffin: if relevant, replace with something more efficient.
     pub(crate) fn find_parent_cell(

--- a/cider/src/flatten/structures/environment/clock.rs
+++ b/cider/src/flatten/structures/environment/clock.rs
@@ -10,14 +10,14 @@ use crate::flatten::{
     flat_ir::base::GlobalCellIdx, structures::thread::ThreadIdx,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct ClockIdx(NonZeroU32);
-impl_index_nonzero!(ClockIdx);
-
 use baa::BitVecValue;
 use cider_idx::{impl_index_nonzero, maps::IndexedMap};
 use itertools::Itertools;
 use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ClockIdx(NonZeroU32);
+impl_index_nonzero!(ClockIdx);
 
 pub type ThreadClockPair = (ThreadIdx, ClockIdx);
 

--- a/cider/src/flatten/structures/environment/clock.rs
+++ b/cider/src/flatten/structures/environment/clock.rs
@@ -186,7 +186,7 @@ impl ReadInfoWithThread {
                     self.read_info.cell,
                 );
                 format!(
-                    "RHS from assignment {} in {}",
+                    "RHS in assignment {} in {}",
                     ctx.printer()
                         .print_assignment(comp, assignment_idx)
                         .stylize_assignment(),

--- a/cider/src/flatten/structures/environment/env.rs
+++ b/cider/src/flatten/structures/environment/env.rs
@@ -2342,13 +2342,13 @@ impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
                         let child_clock_idx =
                             self.env.thread_map.unwrap_clock_id(child_thread);
 
-                        let child_clock = std::mem::take(
-                            &mut self.env.clocks[child_clock_idx],
-                        );
+                        let (parent_clock, child_clock) = self
+                            .env
+                            .clocks
+                            .split_mut_indices(parent_clock, child_clock_idx)
+                            .unwrap();
 
-                        self.env.clocks[parent_clock].sync(&child_clock);
-
-                        self.env.clocks[child_clock_idx] = child_clock;
+                        parent_clock.sync(child_clock);
                     }
 
                     *node_thread = Some(parent);

--- a/cider/src/flatten/structures/environment/env.rs
+++ b/cider/src/flatten/structures/environment/env.rs
@@ -2045,13 +2045,14 @@ impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
                                     // transitive reads, we will check them at
                                     // the cycle boundary and attribute the read
                                     // to the continuous thread
+                                    let (assign_idx, cell) =
+                                        val.winner().as_assign().unwrap();
                                     self.check_read(
                                         ThreadMap::continuous_thread(),
                                         port,
                                         &mut clock_map,
-                                        ReadSource::Assignment(
-                                            *val.winner().as_assign().unwrap(),
-                                        ),
+                                        ReadSource::Assignment(assign_idx),
+                                        cell,
                                     )
                                     .map_err(|e| {
                                         e.prettify_message(&self.env)

--- a/cider/src/flatten/structures/environment/program_counter.rs
+++ b/cider/src/flatten/structures/environment/program_counter.rs
@@ -399,7 +399,7 @@ impl SearchPath {
             .iter()
             .fold_while(ControlIdx::new(0), |current_root, (_, comp_info)| {
                 if let Some(index) = comp_info.control() {
-                    if index >= current_root && index < target {
+                    if index >= current_root && index <= target {
                         FoldWhile::Continue(index)
                     } else {
                         FoldWhile::Done(current_root)

--- a/cider/src/flatten/structures/printer.rs
+++ b/cider/src/flatten/structures/printer.rs
@@ -175,10 +175,9 @@ impl<'a> Printer<'a> {
             Control::Empty(_) => String::new(),
             Control::Enable(e) => text_utils::indent(
                 format!(
-                    "{};     ({:?})",
+                    "{};",
                     self.ctx.secondary[self.ctx.primary[e.group()].name()]
                         .clone(),
-                    control
                 ),
                 indent,
             ),

--- a/cider/src/flatten/structures/printer.rs
+++ b/cider/src/flatten/structures/printer.rs
@@ -184,10 +184,7 @@ impl<'a> Printer<'a> {
 
             // TODO Griffin: refactor into shared function rather than copy-paste?
             Control::Seq(s) => {
-                let mut seq = text_utils::indent(
-                    format!("seq {{  ({:?})\n", control),
-                    indent,
-                );
+                let mut seq = text_utils::indent("seq {\n", indent);
                 for stmt in s.stms() {
                     let child = self.format_control(parent, *stmt, indent + 1);
                     seq += &child;

--- a/cider/src/flatten/text_utils.rs
+++ b/cider/src/flatten/text_utils.rs
@@ -33,59 +33,75 @@ pub fn indent<S: AsRef<str>>(target: S, indent_count: usize) -> String {
 pub const ASSIGN_STYLE: Style = Style::new().yellow();
 
 pub trait Color: OwoColorize + Display {
-    fn stylize_assignment<'a>(
-        &'a self,
-    ) -> owo_colors::SupportsColorsDisplay<
-        '_,
-        Self,
-        owo_colors::Styled<&Self>,
-        impl Fn(&'a Self) -> owo_colors::Styled<&Self>,
-    > {
+    fn stylize_assignment(&self) -> impl Display {
         self.if_supports_color(Stdout, |text| text.style(ASSIGN_STYLE))
     }
 
-    fn stylize_usage_example<'a>(
-        &'a self,
-    ) -> owo_colors::SupportsColorsDisplay<
-        '_,
-        Self,
-        owo_colors::Styled<&Self>,
-        impl Fn(&'a Self) -> owo_colors::Styled<&Self>,
-    > {
+    fn stylize_usage_example(&self) -> impl Display {
         // this cannot be a const due to reasons
         let style = Style::new().blue().italic();
         self.if_supports_color(Stdout, move |text| text.style(style))
     }
 
-    fn stylize_name<'a>(
-        &'a self,
-    ) -> owo_colors::SupportsColorsDisplay<
-        '_,
-        Self,
-        owo_colors::styles::UnderlineDisplay<'_, Self>,
-        impl Fn(&'a Self) -> owo_colors::styles::UnderlineDisplay<'_, Self>,
-    > {
+    fn stylize_name(&self) -> impl Display {
         self.if_supports_color(Stdout, move |text| text.underline())
     }
 
-    fn stylize_error<'a>(
-        &'a self,
-    ) -> owo_colors::SupportsColorsDisplay<
-        '_,
-        Self,
-        owo_colors::FgColorDisplay<'_, owo_colors::colors::Red, Self>,
-        impl Fn(
-            &'a Self,
-        )
-            -> owo_colors::FgColorDisplay<'_, owo_colors::colors::Red, Self>,
-    > {
-        self.if_supports_color(Stdout, |text| text.red())
+    fn stylize_error(&self) -> impl Display {
+        let style = Style::new().red().bold();
+        self.if_supports_color(Stdout, move |text| text.style(style))
     }
 
-    fn stylize_debugger_missing(&self) -> Box<dyn Display + '_> {
+    fn stylize_debugger_missing(&self) -> impl Display {
         let style = Style::new().red().bold().strikethrough();
+        Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
+    }
+
+    fn stylize_print_code(&self) -> impl Display {
+        let style = Style::new().cyan().underline();
+        Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
+    }
+
+    fn stylize_warning(&self) -> impl Display {
+        let style = Style::new().yellow().italic();
+        Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
+    }
+
+    fn stylize_command(&self) -> impl Display {
+        let style = Style::new().yellow().bold().underline();
+        Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
+    }
+
+    fn stylize_breakpoint(&self) -> impl Display {
+        let style = Style::new().yellow().underline();
+        Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
+    }
+
+    fn stylize_command_description(&self) -> impl Display {
+        let style = Style::new().yellow();
+        Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
+    }
+
+    fn stylize_breakpoint_enabled(&self) -> impl Display {
+        let style = Style::new().green();
+        Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
+    }
+
+    fn stylize_breakpoint_disabled(&self) -> impl Display {
+        let style = Style::new().red();
         Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
     }
 }
 
 impl<T: OwoColorize + Display> Color for T {}
+
+pub fn print_debugger_welcome() {
+    println!(
+        "==== {}: The {}alyx {}nterpreter and {}bugge{} ====",
+        "Cider".bold(),
+        "C".underline(),
+        "I".underline(),
+        "De".underline(),
+        "r".underline()
+    );
+}

--- a/cider/src/flatten/text_utils.rs
+++ b/cider/src/flatten/text_utils.rs
@@ -1,4 +1,6 @@
-use std::fmt::Write;
+use std::fmt::{Display, Write};
+
+use owo_colors::{OwoColorize, Stream::Stdout, Style};
 
 pub const INDENTATION: &str = "    ";
 
@@ -27,3 +29,63 @@ pub fn indent<S: AsRef<str>>(target: S, indent_count: usize) -> String {
 
     out
 }
+
+pub const ASSIGN_STYLE: Style = Style::new().yellow();
+
+pub trait Color: OwoColorize + Display {
+    fn stylize_assignment<'a>(
+        &'a self,
+    ) -> owo_colors::SupportsColorsDisplay<
+        '_,
+        Self,
+        owo_colors::Styled<&Self>,
+        impl Fn(&'a Self) -> owo_colors::Styled<&Self>,
+    > {
+        self.if_supports_color(Stdout, |text| text.style(ASSIGN_STYLE))
+    }
+
+    fn stylize_usage_example<'a>(
+        &'a self,
+    ) -> owo_colors::SupportsColorsDisplay<
+        '_,
+        Self,
+        owo_colors::Styled<&Self>,
+        impl Fn(&'a Self) -> owo_colors::Styled<&Self>,
+    > {
+        // this cannot be a const due to reasons
+        let style = Style::new().blue().italic();
+        self.if_supports_color(Stdout, move |text| text.style(style))
+    }
+
+    fn stylize_name<'a>(
+        &'a self,
+    ) -> owo_colors::SupportsColorsDisplay<
+        '_,
+        Self,
+        owo_colors::styles::UnderlineDisplay<'_, Self>,
+        impl Fn(&'a Self) -> owo_colors::styles::UnderlineDisplay<'_, Self>,
+    > {
+        self.if_supports_color(Stdout, move |text| text.underline())
+    }
+
+    fn stylize_error<'a>(
+        &'a self,
+    ) -> owo_colors::SupportsColorsDisplay<
+        '_,
+        Self,
+        owo_colors::FgColorDisplay<'_, owo_colors::colors::Red, Self>,
+        impl Fn(
+            &'a Self,
+        )
+            -> owo_colors::FgColorDisplay<'_, owo_colors::colors::Red, Self>,
+    > {
+        self.if_supports_color(Stdout, |text| text.red())
+    }
+
+    fn stylize_debugger_missing(&self) -> Box<dyn Display + '_> {
+        let style = Style::new().red().bold().strikethrough();
+        Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
+    }
+}
+
+impl<T: OwoColorize + Display> Color for T {}

--- a/cider/src/flatten/text_utils.rs
+++ b/cider/src/flatten/text_utils.rs
@@ -105,3 +105,13 @@ pub fn print_debugger_welcome() {
         "r".underline()
     );
 }
+
+pub(crate) fn force_color(force_color: bool) {
+    if force_color {
+        owo_colors::set_override(true);
+    }
+    // Allow inference of color if not forced rather than forcing no colors
+    else {
+        owo_colors::unset_override();
+    }
+}

--- a/cider/src/main.rs
+++ b/cider/src/main.rs
@@ -80,6 +80,10 @@ pub struct Opts {
     #[argh(switch, long = "check-data-race")]
     check_data_race: bool,
 
+    /// force color output
+    #[argh(switch, long = "force-color")]
+    force_color: bool,
+
     #[argh(subcommand)]
     mode: Option<Command>,
 }
@@ -118,6 +122,8 @@ fn main() -> CiderResult<()> {
         .error_on_overflow(opts.error_on_overflow)
         .undef_guard_check(opts.undef_guard_check)
         .build();
+
+    runtime_config.set_force_color(opts.force_color);
 
     let command = opts.mode.unwrap_or(Command::Interpret(CommandInterpret {}));
     let i_ctx = cider::flatten::setup_simulation(

--- a/cider/src/serialization/formatting.rs
+++ b/cider/src/serialization/formatting.rs
@@ -3,7 +3,9 @@ use itertools::Itertools;
 use serde::Serialize;
 use std::fmt::{Debug, Display};
 
-use crate::flatten::flat_ir::cell_prototype::MemoryDimensions;
+use crate::flatten::{
+    flat_ir::cell_prototype::MemoryDimensions, text_utils::Color,
+};
 use baa::{BitVecOps, BitVecValue, WidthInt};
 
 /// An enum wrapping over a tuple representing the shape of a multi-dimensional
@@ -192,14 +194,13 @@ impl Display for PrintCode {
             f,
             "{}",
             match self {
-                PrintCode::Binary =>
-                    owo_colors::OwoColorize::cyan(&"\\b").to_string(),
-                PrintCode::Unsigned =>
-                    owo_colors::OwoColorize::blue(&"\\u").to_string(),
-                PrintCode::Signed =>
-                    owo_colors::OwoColorize::yellow(&"\\s").to_string(),
-                PrintCode::UFixed(n) => format!("\\u.{}", n),
-                PrintCode::SFixed(n) => format!("\\s.{}", n),
+                PrintCode::Binary => "\\b".stylize_print_code().to_string(),
+                PrintCode::Unsigned => "\\u".stylize_print_code().to_string(),
+                PrintCode::Signed => "\\s".stylize_print_code().to_string(),
+                PrintCode::UFixed(n) =>
+                    format!("\\u.{}", n).stylize_print_code().to_string(),
+                PrintCode::SFixed(n) =>
+                    format!("\\s.{}", n).stylize_print_code().to_string(),
             }
         )
     }

--- a/cider/tests/data-race/conflict.expect
+++ b/cider/tests/data-race/conflict.expect
@@ -1,4 +1,6 @@
 ---CODE---
 1
 ---STDERR---
-Error: Concurrent read & write to the same register [4mmain.count[0m
+Error: Concurrent read and write to the same register main.count
+  write in thread ThreadIdx(4) from assignment count.write_en = 1'd1; in group main::incr_count
+  read in thread ThreadIdx(3) from RHS in assignment useless_wire.in = my_wire.out; in group main::do_mul

--- a/cider/tests/data-race/continuous-race.expect
+++ b/cider/tests/data-race/continuous-race.expect
@@ -1,4 +1,6 @@
 ---CODE---
 1
 ---STDERR---
-Error: Concurrent read & write to the same register [4mmain.val[0m
+Error: Concurrent read & write to the same register main.val
+  write in thread ThreadIdx(2) from assignment val.write_en = 1'd1; in continuous logic in main
+  read in thread ThreadIdx(1) from RHS in assignment mem.write_data = val.out; in group main::store

--- a/cider/tests/data-race/guard-conflict.expect
+++ b/cider/tests/data-race/guard-conflict.expect
@@ -1,4 +1,6 @@
 ---CODE---
 1
 ---STDERR---
-Error: Concurrent read & write to the same register [4mmain.cond_reg[0m
+Error: Concurrent read and write to the same register main.cond_reg
+  write in thread ThreadIdx(5) from assignment cond_reg.write_en = 1'd1; in group main::write_cond
+  read in thread ThreadIdx(3) from guard of assignment b.in = !cond_reg.out ? sub.out; in group main::composite

--- a/cider/tests/data-race/par-conflict-cmem.expect
+++ b/cider/tests/data-race/par-conflict-cmem.expect
@@ -1,4 +1,6 @@
 ---CODE---
 1
 ---STDERR---
-Error: Concurrent read & write to the same memory [4mmain.cond_mem[0m in slot 0
+Error: Concurrent read and write to the same memory main.cond_mem at entry 0
+  write in thread ThreadIdx(5) from assignment cond_mem.write_en = 1'd1; in group main::write_cond
+  read in thread ThreadIdx(3) from RHS in assignment cond_reg.in = cond_mem.read_data; in group main::read_cond

--- a/cider/tests/data-race/par-conflict.expect
+++ b/cider/tests/data-race/par-conflict.expect
@@ -1,4 +1,12 @@
 ---CODE---
 1
 ---STDERR---
-Error: Concurrent read & write to the same register [4mmain.cond_reg[0m
+Error: Concurrent read & write to the same register main.cond_reg
+  write in thread ThreadIdx(5) from assignment cond_reg.write_en = 1'd1; in group main::write_cond
+  read in thread ThreadIdx(3) from conditional evaluation in main: 
+     if cond_reg.out {
+        incr_a;
+    } else {
+        decr_b;
+    }
+

--- a/cider/tests/data-race/strange_mult.expect
+++ b/cider/tests/data-race/strange_mult.expect
@@ -1,4 +1,6 @@
 ---CODE---
 1
 ---STDERR---
-Error: Concurrent read & write to the same register [4mmain.first_reg[0m
+Error: Concurrent read and write to the same register main.first_reg
+  write in thread ThreadIdx(1) from assignment first_reg.write_en = 1'd1; in group main::init
+  read in thread ThreadIdx(2) from RHS in assignment mult.left = first_reg.out; in continuous logic in main

--- a/cider/tests/data-race/write-write.expect
+++ b/cider/tests/data-race/write-write.expect
@@ -1,0 +1,6 @@
+---CODE---
+1
+---STDERR---
+Error: Concurrent writes to the same register main.r1
+  write in thread ThreadIdx(4) from assignment r1.write_en = 1'd1; in group main::write_r1_5
+  write in thread ThreadIdx(3) from assignment r1.write_en = 1'd1; in group main::write_r1_10

--- a/cider/tests/data-race/write-write.futil
+++ b/cider/tests/data-race/write-write.futil
@@ -1,0 +1,47 @@
+import "primitives/core.futil";
+
+component main() -> () {
+    cells {
+        r1 = std_reg(32);
+        delay_r = std_reg(1);
+        const = std_const(32, 1);
+        wire = std_wire(1);
+    }
+
+    wires {
+        group write_r1_5 {
+            r1.in = 32'd5;
+            r1.write_en = 1'd1;
+            write_r1_5[done] = r1.done;
+        }
+
+         group write_r1_10 {
+            r1.in = 32'd10;
+            r1.write_en = 1'd1;
+            write_r1_10[done] = r1.done;
+        }
+
+        group delay {
+            delay_r.in = 1'd0;
+            delay_r.write_en = 1'd1;
+            delay[done] = delay_r.done;
+        }
+
+        comb group true {
+            wire.in = 1'd1;
+        }
+
+    }
+
+    control {
+        par {
+            if wire.out with true {
+                seq {
+                    delay;
+                    write_r1_10;
+                }
+            }
+            write_r1_5;
+        }
+    }
+}

--- a/cider/tests/data-race/write-write.futil
+++ b/cider/tests/data-race/write-write.futil
@@ -5,7 +5,7 @@ component main() -> () {
         r1 = std_reg(32);
         delay_r = std_reg(1);
         const = std_const(32, 1);
-        wire = std_wire(1);
+        cond_wire = std_wire(1);
     }
 
     wires {
@@ -28,14 +28,14 @@ component main() -> () {
         }
 
         comb group true {
-            wire.in = 1'd1;
+            cond_wire.in = 1'd1;
         }
 
     }
 
     control {
         par {
-            if wire.out with true {
+            if cond_wire.out with true {
                 seq {
                     delay;
                     write_r1_10;


### PR DESCRIPTION
A glob of stuff that improves data race errors by printing out the reads and writes which caused them. There's also some futzing around color printing and a new flag that forces it to be enabled, since now running through `fud2` won't have colors by default