### PR TITLE
Rust edition update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ readme = "README.md"
 description = "Compiler Infrastructure for Hardware Accelerator Generation"
 categories = ["compilers"]
 homepage = "https://calyxir.org"
-edition = "2021"
+edition = "2024"
 version = "0.7.1"
-rust-version = "1.80"
+rust-version = "1.85"
 
 [workspace.dependencies]
 # Internal crates

--- a/benches/component-sharing.rs
+++ b/benches/component-sharing.rs
@@ -3,7 +3,7 @@ use calyx_ir as ir;
 use calyx_opt::passes;
 use calyx_opt::traversal::Visitor;
 use criterion::{
-    criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion,
+    BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main,
 };
 use std::path::Path;
 

--- a/calyx-lsp/src/completion.rs
+++ b/calyx-lsp/src/completion.rs
@@ -1,13 +1,13 @@
 use std::path::PathBuf;
 
-use itertools::{multizip, Itertools};
+use itertools::{Itertools, multizip};
 use tower_lsp::lsp_types as lspt;
 
 use crate::{
+    Config,
     convert::Point,
     document::{Context, Document},
     query_result::QueryResult,
-    Config,
 };
 
 #[derive(Clone, Debug)]

--- a/calyx-lsp/src/convert.rs
+++ b/calyx-lsp/src/convert.rs
@@ -88,7 +88,7 @@ impl Range {
     }
 }
 
-impl<'a> From<ts::Node<'a>> for Range {
+impl From<ts::Node<'_>> for Range {
     fn from(value: ts::Node) -> Self {
         Range {
             start: value.start_position().into(),
@@ -131,7 +131,7 @@ impl Contains<&Point> for Range {
     }
 }
 
-impl<'a> Contains<&Point> for Vec<ts::Node<'a>> {
+impl Contains<&Point> for Vec<ts::Node<'_>> {
     fn contains(&self, other: &Point) -> bool {
         self.iter().any(|n| Range::from(*n).contains(other))
     }

--- a/calyx-lsp/src/document.rs
+++ b/calyx-lsp/src/document.rs
@@ -143,7 +143,7 @@ impl Document {
         &'a self,
         node: ts::Node<'node>,
         pattern: &str,
-    ) -> HashMap<String, Vec<ts::Node>> {
+    ) -> HashMap<String, Vec<ts::Node<'a>>> {
         // create the struct that manages query state
         let mut cursor = ts::QueryCursor::new();
         // create the query from the passed in pattern

--- a/calyx-lsp/src/document.rs
+++ b/calyx-lsp/src/document.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use itertools::{multizip, Itertools};
+use itertools::{Itertools, multizip};
 use regex::Regex;
 use resolve_path::PathResolveExt;
 use tower_lsp::lsp_types as lspt;
@@ -12,7 +12,7 @@ use tree_sitter as ts;
 use crate::convert::{Contains, Point, Range};
 use crate::log;
 use crate::ts_utils::ParentUntil;
-use crate::{tree_sitter_calyx, Config};
+use crate::{Config, tree_sitter_calyx};
 
 pub struct Document {
     pub url: lspt::Url,

--- a/calyx-lsp/src/goto_definition.rs
+++ b/calyx-lsp/src/goto_definition.rs
@@ -4,10 +4,10 @@ use tower_lsp::lsp_types as lspt;
 use tree_sitter as ts;
 
 use crate::{
+    Config,
     convert::Range,
     document::{Document, Things},
     query_result::QueryResult,
-    Config,
 };
 
 #[derive(Clone, Debug)]

--- a/calyx-lsp/src/main.rs
+++ b/calyx-lsp/src/main.rs
@@ -19,15 +19,15 @@ use goto_definition::DefinitionProvider;
 use query_result::QueryResult;
 use serde::Deserialize;
 use tower_lsp::lsp_types::{self as lspt, Url};
-use tower_lsp::{jsonrpc, Client, LanguageServer, LspService, Server};
+use tower_lsp::{Client, LanguageServer, LspService, Server, jsonrpc};
 use tree_sitter as ts;
 
 use crate::completion::CompletionProvider;
 use crate::log::Debug;
 
-extern "C" {
+unsafe extern "C" {
     /// Bind the tree-sitter parser to something that we can use in Rust
-    fn tree_sitter_calyx() -> ts::Language;
+    unsafe fn tree_sitter_calyx() -> ts::Language;
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/calyx-lsp/src/query_result.rs
+++ b/calyx-lsp/src/query_result.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::{document::Document, Config};
+use crate::{Config, document::Document};
 
 /// Describes the result of document queries that potentially need to access other
 /// documents. For example, to jump to definitions of imported primitives, we need

--- a/calyx/backend/src/firrtl.rs
+++ b/calyx/backend/src/firrtl.rs
@@ -3,7 +3,7 @@
 //! Transforms an [`ir::Context`](crate::ir::Context) into a formatted string that represents a
 //! valid FIRRTL program.
 
-use crate::{traits::Backend, VerilogBackend};
+use crate::{VerilogBackend, traits::Backend};
 use calyx_ir::{self as ir, Binding, RRC};
 use calyx_utils::{CalyxResult, Id, OutputFile};
 use ir::Port;
@@ -305,7 +305,9 @@ fn get_port_string(port: &calyx_ir::Port, is_dst: bool) -> String {
             }
         }
         _ => {
-            unreachable!("Groups should not be parents as this backend takes place after compiler passes.")
+            unreachable!(
+                "Groups should not be parents as this backend takes place after compiler passes."
+            )
         }
     }
 }

--- a/calyx/backend/src/mlir.rs
+++ b/calyx/backend/src/mlir.rs
@@ -160,18 +160,12 @@ impl MlirBackend {
                     .map(|(k, v)| (k.as_ref(), *v))
                     .collect();
                 match name.as_ref() {
-                    "undef" => {
-                        write!(f, "calyx.undefined @{cell_name}")?
-                    }
-                    "std_reg" => {
-                        write!(f, "calyx.register @{cell_name}")?
-                    }
+                    "undef" => write!(f, "calyx.undefined @{cell_name}")?,
+                    "std_reg" => write!(f, "calyx.register @{cell_name}")?,
                     "comb_mem_d1" => write!(
                         f,
                         "calyx.memory @{cell_name} <[{}] x {}> [{}]",
-                        bind["SIZE"],
-                        bind["WIDTH"],
-                        bind["IDX_SIZE"]
+                        bind["SIZE"], bind["WIDTH"], bind["IDX_SIZE"]
                     )?,
                     "comb_mem_d2" => write!(
                         f,
@@ -276,7 +270,10 @@ impl MlirBackend {
         } else if matches!(&*assign.guard, ir::Guard::True) {
             /* Print nothing */
         } else {
-            panic!("Failed to compile guard: {}.\nFirst run the `lower-guards` pass. If you did, report this as an issue.", ir::Printer::guard_str(&assign.guard));
+            panic!(
+                "Failed to compile guard: {}.\nFirst run the `lower-guards` pass. If you did, report this as an issue.",
+                ir::Printer::guard_str(&assign.guard)
+            );
         }
         write!(f, "{}", Self::get_port_access(&assign.src.borrow()),)?;
         write!(f, " : i{}", assign.src.borrow().width)

--- a/calyx/backend/src/resources.rs
+++ b/calyx/backend/src/resources.rs
@@ -161,8 +161,11 @@ fn estimated_size(count_map: HashMap<(ir::Id, ir::Binding, bool), u32>) {
                 );
                 eprintln!(
                     "{} {} primitive(s) with {} slot(s) of memory, each {} bit(s) wide.",
-                    count, externalize_name(name, is_external),
-                    params[1].1, params[0].1);
+                    count,
+                    externalize_name(name, is_external),
+                    params[1].1,
+                    params[0].1
+                );
             }
             "comb_mem_d2" => {
                 add_size(
@@ -173,8 +176,11 @@ fn estimated_size(count_map: HashMap<(ir::Id, ir::Binding, bool), u32>) {
                 );
                 eprintln!(
                     "{} {} primitive(s) with {} slot(s) of memory, each {} bit(s) wide.",
-                    count, externalize_name(name, is_external),
-                    (params[1].1 * params[2].1), params[0].1);
+                    count,
+                    externalize_name(name, is_external),
+                    (params[1].1 * params[2].1),
+                    params[0].1
+                );
             }
             "comb_mem_d3" => {
                 add_size(
@@ -185,8 +191,11 @@ fn estimated_size(count_map: HashMap<(ir::Id, ir::Binding, bool), u32>) {
                 );
                 eprintln!(
                     "{} {} primitive(s) with {} slot(s) of memory, each {} bit(s) wide.",
-                    count, externalize_name(name, is_external),
-                    (params[1].1 * params[2].1 * params[3].1), params[0].1);
+                    count,
+                    externalize_name(name, is_external),
+                    (params[1].1 * params[2].1 * params[3].1),
+                    params[0].1
+                );
             }
             "comb_mem_d4" => {
                 add_size(
@@ -197,8 +206,11 @@ fn estimated_size(count_map: HashMap<(ir::Id, ir::Binding, bool), u32>) {
                 );
                 eprintln!(
                     "{} {} primitive(s) with {} slot(s) of memory, each {} bit(s) wide.",
-                    count, externalize_name(name, is_external),
-                    (params[1].1 * params[2].1 * params[3].1 * params[4].1), params[0].1);
+                    count,
+                    externalize_name(name, is_external),
+                    (params[1].1 * params[2].1 * params[3].1 * params[4].1),
+                    params[0].1
+                );
             }
             "seq_mem_d1" => {
                 add_size(
@@ -209,8 +221,11 @@ fn estimated_size(count_map: HashMap<(ir::Id, ir::Binding, bool), u32>) {
                 );
                 eprintln!(
                     "{} {} primitive(s) with {} slot(s) of memory, each {} bit(s) wide.",
-                    count, externalize_name(name, is_external),
-                    params[1].1, params[0].1);
+                    count,
+                    externalize_name(name, is_external),
+                    params[1].1,
+                    params[0].1
+                );
             }
             "seq_mem_d2" => {
                 add_size(
@@ -221,8 +236,11 @@ fn estimated_size(count_map: HashMap<(ir::Id, ir::Binding, bool), u32>) {
                 );
                 eprintln!(
                     "{} {} primitive(s) with {} slot(s) of memory, each {} bit(s) wide.",
-                    count, externalize_name(name, is_external),
-                    (params[1].1 * params[2].1), params[0].1);
+                    count,
+                    externalize_name(name, is_external),
+                    (params[1].1 * params[2].1),
+                    params[0].1
+                );
             }
             "seq_mem_d3" => {
                 add_size(
@@ -233,8 +251,11 @@ fn estimated_size(count_map: HashMap<(ir::Id, ir::Binding, bool), u32>) {
                 );
                 eprintln!(
                     "{} {} primitive(s) with {} slot(s) of memory, each {} bit(s) wide.",
-                    count, externalize_name(name, is_external),
-                    (params[1].1 * params[2].1 * params[3].1), params[0].1);
+                    count,
+                    externalize_name(name, is_external),
+                    (params[1].1 * params[2].1 * params[3].1),
+                    params[0].1
+                );
             }
             "seq_mem_d4" => {
                 add_size(
@@ -245,8 +266,11 @@ fn estimated_size(count_map: HashMap<(ir::Id, ir::Binding, bool), u32>) {
                 );
                 eprintln!(
                     "{} {} primitive(s) with {} slot(s) of memory, each {} bit(s) wide.",
-                    count, externalize_name(name, is_external),
-                    (params[1].1 * params[2].1 * params[3].1 * params[4].1), params[0].1);
+                    count,
+                    externalize_name(name, is_external),
+                    (params[1].1 * params[2].1 * params[3].1 * params[4].1),
+                    params[0].1
+                );
             }
             _ => (),
         }

--- a/calyx/backend/src/verilog.rs
+++ b/calyx/backend/src/verilog.rs
@@ -982,7 +982,7 @@ impl std::fmt::Display for VerilogGuardRef {
 /// Similarly, a little wrapper for PortRefs that makes it easy to format them as Verilog variables.
 struct VerilogPortRef<'a>(&'a RRC<ir::Port>);
 
-impl<'a> std::fmt::Display for VerilogPortRef<'a> {
+impl std::fmt::Display for VerilogPortRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let port = self.0.borrow();
         match &port.parent {

--- a/calyx/backend/src/xilinx/toplevel.rs
+++ b/calyx/backend/src/xilinx/toplevel.rs
@@ -1,6 +1,6 @@
 use super::{
-    axi, control_axi::ControlInterface, fsm, memory_axi::bram,
-    memory_axi::MemoryInterface, utils,
+    axi, control_axi::ControlInterface, fsm, memory_axi::MemoryInterface,
+    memory_axi::bram, utils,
 };
 use crate::traits::Backend;
 use calyx_ir as ir;
@@ -41,8 +41,10 @@ impl Backend for XilinxInterfaceBackend {
         let memories = ir::utils::external_and_ref_memories_names(toplevel);
         if memories.is_empty() {
             return Err(Error::misc(
-                    "Program has no memories marked with attribute @external.".to_owned() +
-                    " Please make sure that at least one memory is marked as @external."));
+                "Program has no memories marked with attribute @external."
+                    .to_owned()
+                    + " Please make sure that at least one memory is marked as @external.",
+            ));
         }
 
         let mem_info = toplevel.get_mem_info();
@@ -100,7 +102,10 @@ fn external_1d_memories_cells(comp: &ir::Component) -> Vec<ir::RRC<ir::Cell>> {
     let memories = ir::utils::external_and_ref_memories_cells(comp);
     for memory in memories.iter() {
         if !memory.borrow().is_primitive(Some("comb_mem_d1")) {
-            panic!("cell `{}' marked with `@external' or `ref` but is not a comb_mem_d1. The AXI generator currently only supports `comb_mem_d1'", memory.borrow().name())
+            panic!(
+                "cell `{}' marked with `@external' or `ref` but is not a comb_mem_d1. The AXI generator currently only supports `comb_mem_d1'",
+                memory.borrow().name()
+            )
         }
     }
     memories

--- a/calyx/frontend/src/ast.rs
+++ b/calyx/frontend/src/ast.rs
@@ -1,6 +1,6 @@
 //! Abstract Syntax Tree for Calyx
 use super::parser;
-use crate::{source_info::SourceInfoTable, Attributes, PortDef, Primitive};
+use crate::{Attributes, PortDef, Primitive, source_info::SourceInfoTable};
 use atty::Stream;
 use calyx_utils::{CalyxResult, Error, GPosIdx, Id, PosString};
 use std::{num::NonZeroU64, path::PathBuf};

--- a/calyx/frontend/src/attribute.rs
+++ b/calyx/frontend/src/attribute.rs
@@ -237,7 +237,10 @@ impl FromStr for SetAttribute {
         } else {
             // Reject attributes that all caps since those are reserved for internal attributes
             if s.to_uppercase() == s {
-                return Err(Error::misc(format!("Invalid attribute: {}. All caps attributes are reserved for internal use.", s)));
+                return Err(Error::misc(format!(
+                    "Invalid attribute: {}. All caps attributes are reserved for internal use.",
+                    s
+                )));
             }
             Ok(SetAttribute::Unknown(s.into()))
         }
@@ -277,16 +280,23 @@ impl FromStr for Attribute {
             Ok(Attribute::Num(n))
         } else {
             if DEPRECATED_ATTRIBUTES.contains(&s) {
-                log::warn!("The attribute @{s} is deprecated and will be ignored by the compiler.");
+                log::warn!(
+                    "The attribute @{s} is deprecated and will be ignored by the compiler."
+                );
             }
 
             if let Ok(SetAttribute::Set(_)) = SetAttribute::from_str(s) {
-                log::warn!("Set attribute {s} incorrectly written as a standard attribute, i.e. '@{s}(..)' or '\"{s}\" = ..'. This will be ignored by the compiler. Instead write '@{s}{{..}}' or '\"{s}\" = {{..}}'.");
+                log::warn!(
+                    "Set attribute {s} incorrectly written as a standard attribute, i.e. '@{s}(..)' or '\"{s}\" = ..'. This will be ignored by the compiler. Instead write '@{s}{{..}}' or '\"{s}\" = {{..}}'."
+                );
             }
 
             // Reject attributes that all caps since those are reserved for internal attributes
             if s.to_uppercase() == s {
-                return Err(Error::misc(format!("Invalid attribute: {}. All caps attributes are reserved for internal use.", s)));
+                return Err(Error::misc(format!(
+                    "Invalid attribute: {}. All caps attributes are reserved for internal use.",
+                    s
+                )));
             }
             Ok(Attribute::Unknown(s.into()))
         }

--- a/calyx/frontend/src/attributes.rs
+++ b/calyx/frontend/src/attributes.rs
@@ -1,5 +1,5 @@
 use super::Attribute;
-use crate::{attribute::SetAttribute, InlineAttributes};
+use crate::{InlineAttributes, attribute::SetAttribute};
 use calyx_utils::{CalyxResult, GPosIdx, WithPos};
 use itertools::Itertools;
 use linked_hash_map::LinkedHashMap;

--- a/calyx/frontend/src/common.rs
+++ b/calyx/frontend/src/common.rs
@@ -45,10 +45,10 @@ impl Primitive {
     ) -> CalyxResult<(SmallVec<[(Id, u64); 5]>, Vec<PortDef<u64>>)> {
         if self.params.len() != parameters.len() {
             let msg = format!(
-               "primitive `{}` requires {} parameters but instantiation provides {} parameters",
-               self.name.clone(),
-               self.params.len(),
-               parameters.len(),
+                "primitive `{}` requires {} parameters but instantiation provides {} parameters",
+                self.name.clone(),
+                self.params.len(),
+                parameters.len(),
             );
             return Err(Error::malformed_structure(msg));
         }

--- a/calyx/frontend/src/lib.rs
+++ b/calyx/frontend/src/lib.rs
@@ -18,8 +18,8 @@ use attribute::InlineAttributes;
 
 pub use ast::NamespaceDef;
 pub use attribute::{
-    Attribute, BoolAttr, InternalAttr, NumAttr, SetAttr, SetAttribute,
-    DEPRECATED_ATTRIBUTES,
+    Attribute, BoolAttr, DEPRECATED_ATTRIBUTES, InternalAttr, NumAttr, SetAttr,
+    SetAttribute,
 };
 pub use attributes::{Attributes, GetAttributes};
 pub use common::{Direction, PortDef, Primitive, Width};

--- a/calyx/frontend/src/lib_sig.rs
+++ b/calyx/frontend/src/lib_sig.rs
@@ -49,12 +49,8 @@ impl PrimitiveInfo {
     /// Mark this primitive as a source primitive
     pub fn set_source(&mut self) {
         match self {
-            PrimitiveInfo::Extern {
-                ref mut is_source, ..
-            } => *is_source = true,
-            PrimitiveInfo::Inline {
-                ref mut is_source, ..
-            } => *is_source = true,
+            PrimitiveInfo::Extern { is_source, .. } => *is_source = true,
+            PrimitiveInfo::Inline { is_source, .. } => *is_source = true,
         }
     }
 }

--- a/calyx/frontend/src/parser.rs
+++ b/calyx/frontend/src/parser.rs
@@ -1,23 +1,23 @@
 #![allow(clippy::upper_case_acronyms)]
 
 //! Parser for Calyx programs.
+use super::Attributes;
 use super::ast::{
     self, BitNum, Control, GuardComp as GC, GuardExpr, NumType, StaticGuardExpr,
 };
-use super::Attributes;
 use crate::{
+    Attribute, Direction, PortDef, Primitive, Width,
     attribute::SetAttribute,
     attributes::ParseAttributeWrapper,
     source_info::{
         FileId as MetadataFileId, LineNum, PositionId, SourceInfoResult,
         SourceInfoTable,
     },
-    Attribute, Direction, PortDef, Primitive, Width,
 };
-use calyx_utils::{self, float, CalyxResult, Id, PosString};
+use calyx_utils::{self, CalyxResult, Id, PosString, float};
 use calyx_utils::{FileIdx, GPosIdx, GlobalPositionTable};
 use pest::pratt_parser::{Assoc, Op, PrattParser};
-use pest_consume::{match_nodes, Error, Parser};
+use pest_consume::{Error, Parser, match_nodes};
 use std::io::Read;
 use std::path::Path;
 use std::str::FromStr;

--- a/calyx/frontend/src/source_info.rs
+++ b/calyx/frontend/src/source_info.rs
@@ -260,14 +260,14 @@ impl SourceInfoTable {
 
         // write file table
         writeln!(f, "FILES")?;
-        for (file, path) in self.file_map.iter().sorted_by_key(|(&k, _)| k) {
+        for (file, path) in self.file_map.iter().sorted_by_key(|(k, _)| **k) {
             writeln!(f, "{file}: {}", path.display())?;
         }
 
         // write the position table
         writeln!(f, "POSITIONS")?;
         for (position, SourceLocation { line, file }) in
-            self.position_map.iter().sorted_by_key(|(&k, _)| k)
+            self.position_map.iter().sorted_by_key(|(k, _)| **k)
         {
             writeln!(f, "{position}: {file} {line}")?;
         }

--- a/calyx/frontend/src/workspace.rs
+++ b/calyx/frontend/src/workspace.rs
@@ -2,7 +2,7 @@ use super::{
     ast::{ComponentDef, NamespaceDef},
     parser,
 };
-use crate::{source_info::SourceInfoTable, LibrarySignatures};
+use crate::{LibrarySignatures, source_info::SourceInfoTable};
 use calyx_utils::{CalyxResult, Error, WithPos};
 use std::{
     collections::HashSet,

--- a/calyx/ir/src/common.rs
+++ b/calyx/ir/src/common.rs
@@ -32,7 +32,10 @@ impl<T: GetName> WRC<T> {
     pub fn upgrade(&self) -> RRC<T> {
         let Some(r) = self.internal.upgrade() else {
             #[cfg(debug_assertions)]
-            unreachable!("weak reference points to a dropped value. Original object's name: `{}'", self.debug_name);
+            unreachable!(
+                "weak reference points to a dropped value. Original object's name: `{}'",
+                self.debug_name
+            );
             #[cfg(not(debug_assertions))]
             unreachable!("weak reference points to a dropped value.");
         };

--- a/calyx/ir/src/component.rs
+++ b/calyx/ir/src/component.rs
@@ -1,10 +1,10 @@
 use super::{
     Assignment, Attribute, Attributes, BoolAttr, Builder, Cell, CellType,
-    CombGroup, Control, Direction, GetName, Group, Id, NumAttr, PortDef,
-    StaticGroup, RRC,
+    CombGroup, Control, Direction, GetName, Group, Id, NumAttr, PortDef, RRC,
+    StaticGroup,
 };
-use crate::guard::StaticTiming;
 use crate::Nothing;
+use crate::guard::StaticTiming;
 use calyx_utils::NameGenerator;
 use itertools::Itertools;
 use linked_hash_map::LinkedHashMap;

--- a/calyx/ir/src/component.rs
+++ b/calyx/ir/src/component.rs
@@ -420,7 +420,7 @@ impl<T: GetName> IdList<T> {
 
     /// Removes all elements from the collection and returns an iterator over
     /// the owned elements.
-    pub fn drain(&mut self) -> impl Iterator<Item = RRC<T>> {
+    pub fn drain(&mut self) -> impl Iterator<Item = RRC<T>> + use<T> {
         let drain = std::mem::take(&mut self.0);
 
         drain.into_iter().map(|(_, cell)| cell)

--- a/calyx/ir/src/context.rs
+++ b/calyx/ir/src/context.rs
@@ -2,7 +2,7 @@
 //! need to transform, lower, an emit a program.
 //! Passes usually have transform/analyze the components in the IR.
 use super::{Component, Id};
-use calyx_frontend::{source_info::SourceInfoTable, LibrarySignatures};
+use calyx_frontend::{LibrarySignatures, source_info::SourceInfoTable};
 
 /// Configuration information for the backends.
 #[derive(Default)]

--- a/calyx/ir/src/from_ast.rs
+++ b/calyx/ir/src/from_ast.rs
@@ -1,11 +1,11 @@
 use super::{
     Assignment, Attributes, BackendConf, Builder, Cell, CellType, Component,
     Context, Control, Direction, GetAttributes, Guard, Id, Invoke,
-    LibrarySignatures, Port, PortDef, StaticControl, StaticInvoke,
-    RESERVED_NAMES, RRC,
+    LibrarySignatures, Port, PortDef, RESERVED_NAMES, RRC, StaticControl,
+    StaticInvoke,
 };
 use crate::{Nothing, PortComp, StaticTiming};
-use calyx_frontend::{ast, BoolAttr, NumAttr, Workspace};
+use calyx_frontend::{BoolAttr, NumAttr, Workspace, ast};
 use calyx_utils::{CalyxResult, Error, GPosIdx, WithPos};
 use itertools::Itertools;
 
@@ -733,7 +733,7 @@ fn build_static_par(
     {
         Some(s) => s.get_latency(),
         None => {
-            return Err(Error::malformed_control("empty par block".to_string()))
+            return Err(Error::malformed_control("empty par block".to_string()));
         }
     };
     assert_latencies_eq(latency, inferred_latency);
@@ -913,7 +913,7 @@ fn build_static_control(
         } => {
             return build_static_seq(
                 stmts, attributes, latency, builder, sig_ctx,
-            )
+            );
         }
         ast::Control::StaticPar {
             stmts,
@@ -922,7 +922,7 @@ fn build_static_control(
         } => {
             return build_static_par(
                 stmts, attributes, latency, builder, sig_ctx,
-            )
+            );
         }
         ast::Control::StaticIf {
             port,
@@ -933,7 +933,7 @@ fn build_static_control(
         } => {
             return build_static_if(
                 port, *tbranch, *fbranch, attributes, latency, builder, sig_ctx,
-            )
+            );
         }
         ast::Control::StaticRepeat {
             attributes,
@@ -946,7 +946,7 @@ fn build_static_control(
                 builder,
                 attributes,
                 sig_ctx,
-            )
+            );
         }
         ast::Control::Par { .. }
         | ast::Control::If { .. }

--- a/calyx/ir/src/from_ast.rs
+++ b/calyx/ir/src/from_ast.rs
@@ -733,7 +733,9 @@ fn build_static_par(
     {
         Some(s) => s.get_latency(),
         None => {
-            return Err(Error::malformed_control("empty par block".to_string()));
+            return Err(Error::malformed_control(
+                "empty par block".to_string(),
+            ));
         }
     };
     assert_latencies_eq(latency, inferred_latency);

--- a/calyx/ir/src/lib.rs
+++ b/calyx/ir/src/lib.rs
@@ -24,7 +24,7 @@ pub mod rewriter;
 // Re-export types at the module level.
 pub use builder::Builder;
 pub use calyx_utils::{GetName, Id};
-pub use common::{rrc, RRC, WRC};
+pub use common::{RRC, WRC, rrc};
 pub use component::{Component, IdList};
 pub use context::{BackendConf, Context};
 pub use control::{
@@ -44,9 +44,9 @@ pub use structure::{
 
 // Re-export types from the frontend.
 pub use calyx_frontend::{
-    Attribute, Attributes, BoolAttr, Direction, GetAttributes, InternalAttr,
-    LibrarySignatures, NumAttr, PortDef, Primitive, PrimitiveInfo, Width,
-    DEPRECATED_ATTRIBUTES,
+    Attribute, Attributes, BoolAttr, DEPRECATED_ATTRIBUTES, Direction,
+    GetAttributes, InternalAttr, LibrarySignatures, NumAttr, PortDef,
+    Primitive, PrimitiveInfo, Width,
 };
 
 /// Module to transform AST programs into IR.

--- a/calyx/ir/src/printer.rs
+++ b/calyx/ir/src/printer.rs
@@ -2,7 +2,7 @@
 //! The printing operation clones inner nodes and doesn't perform any mutation
 //! to the Component.
 use crate::{self as ir, RRC};
-use calyx_frontend::{source_info::SourceInfoTable, PrimitiveInfo};
+use calyx_frontend::{PrimitiveInfo, source_info::SourceInfoTable};
 use calyx_utils::float;
 use itertools::Itertools;
 use std::io;

--- a/calyx/ir/src/serializers.rs
+++ b/calyx/ir/src/serializers.rs
@@ -4,8 +4,8 @@ use crate::{Cell, Context, Control, IdList, PortParent, RRC};
 use calyx_utils::GetName;
 #[cfg(feature = "serialize")]
 use serde::{
-    ser::{SerializeSeq, SerializeStruct},
     Serialize, Serializer,
+    ser::{SerializeSeq, SerializeStruct},
 };
 #[cfg(feature = "serialize")]
 use serde_with::SerializeAs;

--- a/calyx/ir/src/structure.rs
+++ b/calyx/ir/src/structure.rs
@@ -1,7 +1,7 @@
 //! Representation for structure (wires and cells) in a Calyx program.
 
-use crate::guard::StaticTiming;
 use crate::Nothing;
+use crate::guard::StaticTiming;
 
 use super::{
     Attributes, Direction, GetAttributes, Guard, Id, PortDef, RRC, WRC,
@@ -9,7 +9,7 @@ use super::{
 use calyx_frontend::{Attribute, BoolAttr};
 use calyx_utils::{CalyxResult, Error, GetName};
 use itertools::Itertools;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 use std::hash::Hash;
 use std::rc::Rc;
 

--- a/calyx/ir/src/utils.rs
+++ b/calyx/ir/src/utils.rs
@@ -117,6 +117,9 @@ fn dimension_count(mem_id: Id) -> u64 {
     } else if mem_name.contains("d4") {
         4
     } else {
-        panic!("Cell {} does not seem to be a memory primitive. Memory primitives are expected to have 1-4 dimensions inclusive.", mem_name);
+        panic!(
+            "Cell {} does not seem to be a memory primitive. Memory primitives are expected to have 1-4 dimensions inclusive.",
+            mem_name
+        );
     }
 }

--- a/calyx/opt/src/analysis/compaction_analysis.rs
+++ b/calyx/opt/src/analysis/compaction_analysis.rs
@@ -182,7 +182,12 @@ impl CompactionAnalysis {
             // Double checking that we have built the static par correctly.
             let max: Option<u64> =
                 par_control_threads.iter().map(|c| c.get_latency()).max();
-            assert!(max.unwrap() == total_time, "The schedule expects latency {}. The static par that was built has latency {}", total_time, max.unwrap());
+            assert!(
+                max.unwrap() == total_time,
+                "The schedule expects latency {}. The static par that was built has latency {}",
+                total_time,
+                max.unwrap()
+            );
 
             let mut s_par = ir::StaticControl::Par(ir::StaticPar {
                 stmts: par_control_threads,

--- a/calyx/opt/src/analysis/compute_static.rs
+++ b/calyx/opt/src/analysis/compute_static.rs
@@ -164,14 +164,18 @@ impl IntoStatic for ir::Seq {
         let mut latency = 0;
         for stmt in self.stmts.iter() {
             if !matches!(stmt, ir::Control::Static(_)) {
-                log::debug!("Cannot build `static seq`. Control statement inside `seq` is not static");
+                log::debug!(
+                    "Cannot build `static seq`. Control statement inside `seq` is not static"
+                );
                 return None;
             }
         }
 
         for stmt in self.stmts.drain(..) {
             let ir::Control::Static(sc) = stmt else {
-                unreachable!("We have already checked that all control statements are static")
+                unreachable!(
+                    "We have already checked that all control statements are static"
+                )
             };
             latency += sc.get_latency();
             static_stmts.push(sc);
@@ -191,14 +195,18 @@ impl IntoStatic for ir::Par {
         let mut latency = 0;
         for stmt in self.stmts.iter() {
             if !matches!(stmt, ir::Control::Static(_)) {
-                log::debug!("Cannot build `static seq`. Control statement inside `seq` is not static");
+                log::debug!(
+                    "Cannot build `static seq`. Control statement inside `seq` is not static"
+                );
                 return None;
             }
         }
 
         for stmt in self.stmts.drain(..) {
             let ir::Control::Static(sc) = stmt else {
-                unreachable!("We have already checked that all control statements are static")
+                unreachable!(
+                    "We have already checked that all control statements are static"
+                )
             };
             latency = std::cmp::max(latency, sc.get_latency());
             static_stmts.push(sc);

--- a/calyx/opt/src/analysis/control_order.rs
+++ b/calyx/opt/src/analysis/control_order.rs
@@ -140,7 +140,10 @@ impl<const BETTER_ERR: bool> ControlOrder<BETTER_ERR> {
                     })
                     .join("\n");
             }
-            Err(Error::misc(format!("No possible sequential ordering. Control programs exhibit data race:\n{}", msg)))
+            Err(Error::misc(format!(
+                "No possible sequential ordering. Control programs exhibit data race:\n{}",
+                msg
+            )))
         }
     }
 

--- a/calyx/opt/src/analysis/domination_analysis/dominator_map.rs
+++ b/calyx/opt/src/analysis/domination_analysis/dominator_map.rs
@@ -1,9 +1,9 @@
 use crate::analysis::{
+    ControlId, ShareSet,
     domination_analysis::{
         node_analysis::{NodeReads, NodeSearch},
         static_par_domination::StaticParDomination,
     },
-    ControlId, ShareSet,
 };
 use calyx_ir as ir;
 use ir::GenericControl;
@@ -506,8 +506,7 @@ impl DominatorMap {
                             "should not pattern match agaisnt empty in update_map()"
                         )
                     }
-                    ir::Control::Invoke(_)
-                    | ir::Control::Enable(_) => {
+                    ir::Control::Invoke(_) | ir::Control::Enable(_) => {
                         self.update_node(pred, cur_id);
                     }
                     ir::Control::Seq(ir::Seq { stmts, .. }) => {
@@ -519,12 +518,13 @@ impl DominatorMap {
                             nxt = self
                                 .exits_map
                                 .get(&id)
-                                .unwrap_or(pred
-                                    // If the exits map is empty, then it means the
-                                    // current stmt is `Repeat 0`/Empty.
-                                    // So the predecessors for the nxt stmt are the
-                                    // same as the predecessors for the current stmt
-                                ).clone();
+                                .unwrap_or(
+                                    pred, // If the exits map is empty, then it means the
+                                         // current stmt is `Repeat 0`/Empty.
+                                         // So the predecessors for the nxt stmt are the
+                                         // same as the predecessors for the current stmt
+                                )
+                                .clone();
                             p = &nxt;
                         }
                     }
@@ -534,7 +534,11 @@ impl DominatorMap {
                             self.update_map(main_c, id, pred);
                         }
                     }
-                    ir::Control::Repeat(ir::Repeat { body, num_repeats, .. }) => {
+                    ir::Control::Repeat(ir::Repeat {
+                        body,
+                        num_repeats,
+                        ..
+                    }) => {
                         if *num_repeats != 0 {
                             let body_id = get_id::<true>(body);
                             self.update_map(main_c, body_id, pred);
@@ -579,7 +583,9 @@ impl DominatorMap {
                             ControlId::get_guaranteed_attribute(c, END_ID);
                         self.update_node(&if_guard_set, end_id)
                     }
-                    ir::Control::Static(_) => panic!("when matching c in GenericControl::Dynamic(c), c shouldn't be Static Control")
+                    ir::Control::Static(_) => panic!(
+                        "when matching c in GenericControl::Dynamic(c), c shouldn't be Static Control"
+                    ),
                 };
             }
             Some(GenericControl::Static(sc)) => {
@@ -612,10 +618,12 @@ impl DominatorMap {
                     match Self::get_static_control(id, stmt) {
                         None => (),
                         Some(GenericControl::Dynamic(_)) => {
-                            unreachable!("Got a GenericControl::Dynamic when we called get_static_control")
+                            unreachable!(
+                                "Got a GenericControl::Dynamic when we called get_static_control"
+                            )
                         }
                         Some(GenericControl::Static(sc)) => {
-                            return Some(GenericControl::from(sc))
+                            return Some(GenericControl::from(sc));
                         }
                     }
                 }
@@ -626,19 +634,23 @@ impl DominatorMap {
             }) => {
                 match Self::get_static_control(id, tbranch) {
                     Some(GenericControl::Dynamic(_)) => {
-                        unreachable!("Got a GenericControl::Dynamic when we called get_static_control")
+                        unreachable!(
+                            "Got a GenericControl::Dynamic when we called get_static_control"
+                        )
                     }
                     Some(GenericControl::Static(sc)) => {
-                        return Some(GenericControl::from(sc))
+                        return Some(GenericControl::from(sc));
                     }
                     None => (),
                 }
                 match Self::get_static_control(id, fbranch) {
                     Some(GenericControl::Dynamic(_)) => {
-                        unreachable!("Got a GenericControl::Dynamic when we called get_static_control")
+                        unreachable!(
+                            "Got a GenericControl::Dynamic when we called get_static_control"
+                        )
                     }
                     Some(GenericControl::Static(sc)) => {
-                        return Some(GenericControl::from(sc))
+                        return Some(GenericControl::from(sc));
                     }
                     None => (),
                 };
@@ -666,10 +678,10 @@ impl DominatorMap {
                     match Self::get_control(id, stmt) {
                         None => (),
                         Some(GenericControl::Dynamic(c)) => {
-                            return Some(GenericControl::from(c))
+                            return Some(GenericControl::from(c));
                         }
                         Some(GenericControl::Static(sc)) => {
-                            return Some(GenericControl::from(sc))
+                            return Some(GenericControl::from(sc));
                         }
                     }
                 }
@@ -683,19 +695,19 @@ impl DominatorMap {
             }) => {
                 match Self::get_control(id, tbranch) {
                     Some(GenericControl::Dynamic(c)) => {
-                        return Some(GenericControl::from(c))
+                        return Some(GenericControl::from(c));
                     }
                     Some(GenericControl::Static(sc)) => {
-                        return Some(GenericControl::from(sc))
+                        return Some(GenericControl::from(sc));
                     }
                     None => (),
                 }
                 match Self::get_control(id, fbranch) {
                     Some(GenericControl::Dynamic(c)) => {
-                        return Some(GenericControl::from(c))
+                        return Some(GenericControl::from(c));
                     }
                     Some(GenericControl::Static(sc)) => {
-                        return Some(GenericControl::from(sc))
+                        return Some(GenericControl::from(sc));
                     }
                     None => (),
                 };

--- a/calyx/opt/src/analysis/graph.rs
+++ b/calyx/opt/src/analysis/graph.rs
@@ -243,10 +243,10 @@ impl GraphAnalysis {
 
         graph_copy.retain_nodes(|_g, n_idx| {
             let node = graph[n_idx].borrow();
-            return *num_neighbors
+            *num_neighbors
                 .get(&(node.get_parent_name(), node.name))
                 .unwrap()
-                > 0;
+                > 0
         });
 
         // retain_nodes breaks existing `NodeIndex`s, so repopulate nodes.

--- a/calyx/opt/src/analysis/graph.rs
+++ b/calyx/opt/src/analysis/graph.rs
@@ -1,9 +1,9 @@
 use calyx_ir::{self as ir, Id, PortIterator, RRC};
 use petgraph::{
+    Direction::{Incoming, Outgoing},
     algo,
     graph::{DiGraph, NodeIndex},
     visit::EdgeRef,
-    Direction::{Incoming, Outgoing},
 };
 use std::fmt::{Display, Write};
 use std::{collections::HashMap, rc::Rc};
@@ -130,7 +130,7 @@ impl GraphAnalysis {
                                 Rc::clone(&self.graph[node_idx])
                             },
                         ),
-                    ))
+                    ));
                 }
                 ir::Direction::Output => (),
             }

--- a/calyx/opt/src/analysis/live_range_analysis.rs
+++ b/calyx/opt/src/analysis/live_range_analysis.rs
@@ -102,9 +102,9 @@ impl Prop {
     /// Defines the dataflow transfer function.
     /// We use the standard definition for liveness:
     /// `(alive - kill) + gen`
-    fn transfer(&mut self, gen: Prop, kill: Prop) {
+    fn transfer(&mut self, r#gen: Prop, kill: Prop) {
         self.sub(kill);
-        self.or(gen);
+        self.or(r#gen);
     }
 
     fn insert(&mut self, (cell_type, cell_name): (ir::CellType, ir::Id)) {
@@ -113,9 +113,9 @@ impl Prop {
 
     /// Defines the data_flow transfer function. `(alive - kill) + gen`.
     /// However, this is for when gen and kill are sets, and self is a map.
-    fn transfer_set(&mut self, gen: TypeNameSet, kill: TypeNameSet) {
+    fn transfer_set(&mut self, r#gen: TypeNameSet, kill: TypeNameSet) {
         self.sub_set(kill);
-        self.or_set(gen);
+        self.or_set(r#gen);
     }
 
     // The or operation, but when the self is a map and rhs is a set of tuples.
@@ -1131,7 +1131,7 @@ impl LiveRangeAnalysis {
                     .fold(
                         (Prop::default(), Prop::default(), Prop::default()),
                         |(mut acc_alive, mut acc_gen, mut acc_kill),
-                         (alive, gen, kill)| {
+                         (alive, r#gen, kill)| {
                             (
                                 // Doing in place operations saves time
                                 {
@@ -1139,7 +1139,7 @@ impl LiveRangeAnalysis {
                                     acc_alive
                                 },
                                 {
-                                    acc_gen.or(gen);
+                                    acc_gen.or(r#gen);
                                     acc_gen
                                 },
                                 {
@@ -1327,7 +1327,7 @@ impl LiveRangeAnalysis {
                     .fold(
                         (Prop::default(), Prop::default(), Prop::default()),
                         |(mut acc_alive, mut acc_gen, mut acc_kill),
-                         (alive, gen, kill)| {
+                         (alive, r#gen, kill)| {
                             (
                                 // Doing in place operations saves time
                                 {
@@ -1335,7 +1335,7 @@ impl LiveRangeAnalysis {
                                     acc_alive
                                 },
                                 {
-                                    acc_gen.or(gen);
+                                    acc_gen.or(r#gen);
                                     acc_gen
                                 },
                                 {

--- a/calyx/opt/src/analysis/promotion_analysis.rs
+++ b/calyx/opt/src/analysis/promotion_analysis.rs
@@ -10,13 +10,19 @@ pub struct PromotionAnalysis {
 
 impl PromotionAnalysis {
     fn check_latencies_match(actual: u64, inferred: u64) {
-        assert_eq!(actual, inferred, "Inferred and Annotated Latencies do not match. Latency: {}. Inferred: {}", actual, inferred);
+        assert_eq!(
+            actual, inferred,
+            "Inferred and Annotated Latencies do not match. Latency: {}. Inferred: {}",
+            actual, inferred
+        );
     }
 
     pub fn get_inferred_latency(c: &ir::Control) -> u64 {
         let ir::Control::Static(sc) = c else {
             let Some(latency) = c.get_attribute(ir::NumAttr::Promotable) else {
-                unreachable!("Called get_latency on control that is neither static nor promotable")
+                unreachable!(
+                    "Called get_latency on control that is neither static nor promotable"
+                )
             };
             return latency;
         };

--- a/calyx/opt/src/analysis/static_fsm.rs
+++ b/calyx/opt/src/analysis/static_fsm.rs
@@ -1,6 +1,6 @@
 use crate::passes::math_utilities::get_bit_width_from;
 use calyx_ir::{self as ir};
-use calyx_ir::{build_assignments, Nothing};
+use calyx_ir::{Nothing, build_assignments};
 use calyx_ir::{guard, structure};
 use std::collections::HashMap;
 use std::rc::Rc;

--- a/calyx/opt/src/analysis/static_tree.rs
+++ b/calyx/opt/src/analysis/static_tree.rs
@@ -1,6 +1,6 @@
 use super::{FSMEncoding, StaticFSM};
 use calyx_ir::{self as ir};
-use calyx_ir::{build_assignments, Nothing};
+use calyx_ir::{Nothing, build_assignments};
 use calyx_ir::{guard, structure};
 use itertools::Itertools;
 use std::collections::{BTreeMap, HashMap};

--- a/calyx/opt/src/analysis/variable_detection.rs
+++ b/calyx/opt/src/analysis/variable_detection.rs
@@ -1,4 +1,4 @@
-use super::{read_write_set::AssignmentAnalysis, GraphAnalysis};
+use super::{GraphAnalysis, read_write_set::AssignmentAnalysis};
 use crate::analysis::ShareSet;
 use calyx_ir::{self as ir, RRC};
 
@@ -49,7 +49,10 @@ impl VariableDetection {
             .map(|src| src.borrow().is_constant(1, 1))
             .collect::<Vec<_>>();
         if activation.len() != 1 || (!activation.is_empty() && !activation[0]) {
-            log::debug!("`{}' is not variableLike: Assignment to cell's go port is not 1'd1", group.name());
+            log::debug!(
+                "`{}' is not variableLike: Assignment to cell's go port is not 1'd1",
+                group.name()
+            );
             // failed write_en check
             return None;
         }
@@ -62,7 +65,10 @@ impl VariableDetection {
             .map(|src| src.borrow().get_parent_name() == cell.name())
             .collect::<Vec<_>>();
         if activation.len() != 1 || (!activation.is_empty() && !activation[0]) {
-            log::debug!("`{}' is not variableLike: Assignment to group's done port is not cell.done", group.name());
+            log::debug!(
+                "`{}' is not variableLike: Assignment to group's done port is not cell.done",
+                group.name()
+            );
             // failed g[done] = reg.done check
             return None;
         }

--- a/calyx/opt/src/passes/add_guard.rs
+++ b/calyx/opt/src/passes/add_guard.rs
@@ -41,7 +41,10 @@ impl Visitor for AddGuard {
                         assign.guard = Box::new(new_g);
                     }
                 } else {
-                    unreachable!("Non-Enable Static Control should have been compiled away. Run {} to do this", crate::passes::StaticInliner::name());
+                    unreachable!(
+                        "Non-Enable Static Control should have been compiled away. Run {} to do this",
+                        crate::passes::StaticInliner::name()
+                    );
                 }
             }
         }

--- a/calyx/opt/src/passes/cell_share.rs
+++ b/calyx/opt/src/passes/cell_share.rs
@@ -6,10 +6,10 @@ use crate::traversal::{
     Action, ConstructVisitor, Named, ParseVal, PassOpt, VisResult, Visitor,
 };
 use calyx_ir::{self as ir};
-use calyx_ir::{rewriter, BoolAttr};
+use calyx_ir::{BoolAttr, rewriter};
 use calyx_utils::{CalyxResult, OutputFile};
 use itertools::Itertools;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
 
 // function to turn cell types to string when we are building the json for
@@ -136,26 +136,26 @@ impl Named for CellShare {
                 "print-share-freqs",
                 "print sharing frequencies",
                 ParseVal::OutStream(OutputFile::Null),
-                PassOpt::parse_outstream
+                PassOpt::parse_outstream,
             ),
             PassOpt::new(
                 "bounds",
                 "maximum amount of sharing for combinational components, registers, and other components. Negative valye means no bound",
                 ParseVal::List(vec![]),
-                PassOpt::parse_num_list
+                PassOpt::parse_num_list,
             ),
             PassOpt::new(
                 "print-par-timing",
                 "print timing information for `par` blocks",
                 ParseVal::OutStream(OutputFile::Null),
-                PassOpt::parse_outstream
+                PassOpt::parse_outstream,
             ),
             PassOpt::new(
                 "calyx-2020",
                 "share using the Calyx 2020 settings: no component sharing, only share registers/combinational components",
                 ParseVal::Bool(false),
-                PassOpt::parse_bool
-            )
+                PassOpt::parse_bool,
+            ),
         ]
     }
 }
@@ -414,11 +414,7 @@ impl Visitor for CellShare {
                     // otherwise, look at the actual self.bounds values to
                     // get the bounds
                     if self.calyx_2020 {
-                        if is_comb || is_reg {
-                            &None
-                        } else {
-                            &Some(1)
-                        }
+                        if is_comb || is_reg { &None } else { &Some(1) }
                     } else if is_comb {
                         comb_bound
                     } else if is_reg {

--- a/calyx/opt/src/passes/compile_invoke.rs
+++ b/calyx/opt/src/passes/compile_invoke.rs
@@ -24,11 +24,9 @@ fn get_go_port(cell_ref: ir::RRC<ir::Cell>) -> CalyxResult<ir::RRC<ir::Port>> {
         Ok(None) => Err(Error::malformed_control(format!(
             "Invoked component `{name}` does not define a @go signal. Cannot compile the invoke",
         ))),
-        Err(_) => {
-            Err(Error::malformed_control(format!(
-                "Invoked component `{name}` defines multiple @go signals. Cannot compile the invoke",
-            )))
-        }
+        Err(_) => Err(Error::malformed_control(format!(
+            "Invoked component `{name}` defines multiple @go signals. Cannot compile the invoke",
+        ))),
     }
 }
 
@@ -135,7 +133,6 @@ impl CompileInvoke {
     ///
     /// Since this pass eliminates all ref cells in post order, we expect that
     /// invoked component already had all of its ref cells removed.
-
     fn ref_cells_to_ports_assignments<T>(
         &mut self,
         inv_cell: RRC<ir::Cell>,
@@ -156,7 +153,10 @@ impl CompileInvoke {
             // i.e. ref_reg.in -> ref_reg_in
             // These have name of ref cell, not the cell passed in as an arugment
             let Some(comp_ports) = self.port_names.get(&inv_comp_id) else {
-                unreachable!("component `{}` invoked but not already visited by the pass", inv_comp_id)
+                unreachable!(
+                    "component `{}` invoked but not already visited by the pass",
+                    inv_comp_id
+                )
             };
 
             // tracks ports used in assigments of the invoked component
@@ -175,7 +175,8 @@ impl CompileInvoke {
             // If the `invoked_comp` passed to the function is `None`,
             // then the component being invoked is a primitive.
             } else {
-                unreachable!("Primitives should not have ref cells passed into them at invocation. However ref cells were found at the invocation of {}.",
+                unreachable!(
+                    "Primitives should not have ref cells passed into them at invocation. However ref cells were found at the invocation of {}.",
                     inv_comp_id
                 );
             }
@@ -218,10 +219,15 @@ impl CompileInvoke {
                 }
 
                 let Some(comp_port) = comp_ports.get(ref_cell_canon) else {
-                    unreachable!("port `{}` not found in the signature of {}. Known ports are: {}",
+                    unreachable!(
+                        "port `{}` not found in the signature of {}. Known ports are: {}",
                         ref_cell_canon,
                         inv_comp_id,
-                        comp_ports.keys().map(|c| c.port.as_ref()).collect_vec().join(", ")
+                        comp_ports
+                            .keys()
+                            .map(|c| c.port.as_ref())
+                            .collect_vec()
+                            .join(", ")
                     )
                 };
                 // Get the port on the new cell with the same name as ref_port

--- a/calyx/opt/src/passes/component_iniliner.rs
+++ b/calyx/opt/src/passes/component_iniliner.rs
@@ -3,7 +3,7 @@ use crate::traversal::{
     Action, ConstructVisitor, Named, Order, ParseVal, PassOpt, VisResult,
     Visitor,
 };
-use calyx_ir::{self as ir, rewriter, GetAttributes, LibrarySignatures, RRC};
+use calyx_ir::{self as ir, GetAttributes, LibrarySignatures, RRC, rewriter};
 use calyx_utils::Error;
 use ir::Nothing;
 use itertools::Itertools;
@@ -426,13 +426,13 @@ impl Visitor for ComponentInliner {
                         )
                     })
                     .join("\n");
-                return Err(
-                    Error::pass_assumption(
-                        Self::name(),
-                        format!(
-                            "Instance `{}.{instance}` invoked with multiple parameters (currently unsupported):\n{bindings_str}",
-                            comp.name,
-                        )));
+                return Err(Error::pass_assumption(
+                    Self::name(),
+                    format!(
+                        "Instance `{}.{instance}` invoked with multiple parameters (currently unsupported):\n{bindings_str}",
+                        comp.name,
+                    ),
+                ));
             }
         }
 

--- a/calyx/opt/src/passes/group_to_invoke.rs
+++ b/calyx/opt/src/passes/group_to_invoke.rs
@@ -292,10 +292,10 @@ impl GroupToInvoke {
                     return;
                 } else if !assign.guard.is_true() {
                     log::info!(
-                            "Cannot transform `{}` due to guarded write to @go port: {}",
-                            group_name,
-                            ir::Printer::assignment_to_str(assign)
-                        );
+                        "Cannot transform `{}` due to guarded write to @go port: {}",
+                        group_name,
+                        ir::Printer::assignment_to_str(assign)
+                    );
                     return;
                 } else if assign.src.borrow().is_constant(1, 1) {
                     go_wr_cnt += 1;
@@ -310,16 +310,16 @@ impl GroupToInvoke {
             if assign.src == done_port {
                 if done_wr_cnt > 0 {
                     log::info!(
-                            "Cannot transform `{}` due to multiple writes to @done port",
-                            group_name,
-                        );
+                        "Cannot transform `{}` due to multiple writes to @done port",
+                        group_name,
+                    );
                     return;
                 } else if !assign.guard.is_true() {
                     log::info!(
-                            "Cannot transform `{}` due to guarded write to @done port: {}",
-                            group_name,
-                            ir::Printer::assignment_to_str(assign)
-                        );
+                        "Cannot transform `{}` due to guarded write to @done port: {}",
+                        group_name,
+                        ir::Printer::assignment_to_str(assign)
+                    );
                     return;
                 } else if assign.dst == *group_done_port {
                     done_wr_cnt += 1;
@@ -339,7 +339,10 @@ impl GroupToInvoke {
             );
             return;
         } else if done_wr_cnt != 1 {
-            log::info!("Cannot transform `{}` because there are no writes to @done port", group_name);
+            log::info!(
+                "Cannot transform `{}` because there are no writes to @done port",
+                group_name
+            );
             return;
         }
 

--- a/calyx/opt/src/passes/group_to_seq.rs
+++ b/calyx/opt/src/passes/group_to_seq.rs
@@ -292,7 +292,11 @@ where
                         self.snd_asmts.push(asmt);
                     } else {
                         // assert that we're writing to a combinational component
-                        assert!(cell_ref.borrow().is_comb_cell(), "writes to more than 2 stateful cells: {first_cell_name}, {second_cell_name}, {}", cell_ref.borrow().name());
+                        assert!(
+                            cell_ref.borrow().is_comb_cell(),
+                            "writes to more than 2 stateful cells: {first_cell_name}, {second_cell_name}, {}",
+                            cell_ref.borrow().name()
+                        );
                         self.comb_asmts.push(asmt);
                     }
                 }

--- a/calyx/opt/src/passes/papercut.rs
+++ b/calyx/opt/src/passes/papercut.rs
@@ -190,7 +190,12 @@ impl Visitor for Papercut {
                 {
                     // If the cell is combinational and not driven by continuous assignments
                     if *is_comb && !self.cont_cells.contains(&cell.name()) {
-                        let msg = format!("Port `{}.{}` is an output port on combinational primitive `{}` and will always output 0. Add a `with` statement to the `while` statement to ensure it has a valid value during execution.", cell.name(), port.name, prim_name);
+                        let msg = format!(
+                            "Port `{}.{}` is an output port on combinational primitive `{}` and will always output 0. Add a `with` statement to the `while` statement to ensure it has a valid value during execution.",
+                            cell.name(),
+                            port.name,
+                            prim_name
+                        );
                         // Use dummy Id to get correct source location for error
                         self.diag
                             .err(Error::papercut(msg).with_pos(&s.attributes));
@@ -221,7 +226,12 @@ impl Visitor for Papercut {
                 {
                     // If the cell is combinational and not driven by continuous assignments
                     if *is_comb && !self.cont_cells.contains(&cell.name()) {
-                        let msg = format!("Port `{}.{}` is an output port on combinational primitive `{}` and will always output 0. Add a `with` statement to the `if` statement to ensure it has a valid value during execution.", cell.name(), port.name, prim_name);
+                        let msg = format!(
+                            "Port `{}.{}` is an output port on combinational primitive `{}` and will always output 0. Add a `with` statement to the `if` statement to ensure it has a valid value during execution.",
+                            cell.name(),
+                            port.name,
+                            prim_name
+                        );
                         // Use dummy Id to get correct source location for error
                         self.diag
                             .err(Error::papercut(msg).with_pos(&s.attributes));
@@ -266,14 +276,12 @@ impl Papercut {
                             .sorted()
                             .map(|port| format!("{}.{}", inst.clone(), port))
                             .join(", ");
-                        let msg =
-                            format!("Required signal not driven inside the group.\
+                        let msg = format!(
+                            "Required signal not driven inside the group.\
                                         \nWhen reading the port `{}.{}', the ports [{}] must be written to.\
                                         \nThe primitive type `{}' requires this invariant.",
-                                    inst,
-                                    read,
-                                    missing,
-                                    comp_type);
+                            inst, read, missing, comp_type
+                        );
                         self.diag.err(Error::papercut(msg).with_pos(pos));
                     }
                 }
@@ -301,14 +309,12 @@ impl Papercut {
                         .sorted()
                         .map(|port| format!("{}.{}", inst, port))
                         .join(", ");
-                    let msg =
-                        format!("Required signal not driven inside the group. \
+                    let msg = format!(
+                        "Required signal not driven inside the group. \
                                  When writing to the port `{}.{}', the ports [{}] must also be written to. \
                                  The primitive type `{}' specifies this using a @write_together spec.",
-                                inst,
-                                first,
-                                missing,
-                                comp_type);
+                        inst, first, missing, comp_type
+                    );
                     self.diag.err(Error::papercut(msg).with_pos(pos));
                 }
             }

--- a/calyx/opt/src/passes/simplify_with_control.rs
+++ b/calyx/opt/src/passes/simplify_with_control.rs
@@ -1,6 +1,6 @@
 use crate::analysis;
 use crate::traversal::{Action, Named, VisResult, Visitor};
-use calyx_ir::{self as ir, structure, GetAttributes, LibrarySignatures, RRC};
+use calyx_ir::{self as ir, GetAttributes, LibrarySignatures, RRC, structure};
 use calyx_utils::{CalyxResult, Error};
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -253,8 +253,10 @@ impl Visitor for SimplifyWithControl {
         _comps: &[ir::Component],
     ) -> VisResult {
         if comp.is_static() {
-            let msg =
-                format!("Static Component {} has combinational groups which is not supported", comp.name);
+            let msg = format!(
+                "Static Component {} has combinational groups which is not supported",
+                comp.name
+            );
             return Err(Error::pass_assumption(Self::name(), msg)
                 .with_pos(&comp.attributes));
         }

--- a/calyx/opt/src/passes/static_inliner.rs
+++ b/calyx/opt/src/passes/static_inliner.rs
@@ -2,8 +2,8 @@ use crate::analysis::GraphColoring;
 use crate::traversal::{
     Action, ConstructVisitor, Named, ParseVal, PassOpt, VisResult, Visitor,
 };
-use calyx_ir::structure;
 use calyx_ir::LibrarySignatures;
+use calyx_ir::structure;
 use calyx_ir::{self as ir, StaticTiming};
 use calyx_utils::CalyxResult;
 use ir::build_assignments;
@@ -389,7 +389,10 @@ impl StaticInliner {
                         // first recursively call each stmt in par, and turn each stmt
                         // into static group g.
                         let g = self.inline_static_control(stmt, builder);
-                        assert!(g.borrow().get_latency() == stmt_latency, "static group latency doesn't match static stmt latency");
+                        assert!(
+                            g.borrow().get_latency() == stmt_latency,
+                            "static group latency doesn't match static stmt latency"
+                        );
                         // get the assignments from g
                         let mut g_assigns: Vec<
                             ir::Assignment<ir::StaticTiming>,
@@ -590,7 +593,10 @@ impl StaticInliner {
                 let fbranch_latency = fbranch.get_latency();
                 let max_latency =
                     std::cmp::max(tbranch_latency, fbranch_latency);
-                assert_eq!(max_latency, *latency, "if group latency and max of the if branch latencies do not match");
+                assert_eq!(
+                    max_latency, *latency,
+                    "if group latency and max of the if branch latencies do not match"
+                );
 
                 // Inline assignments in tbranch and fbranch, and get resulting
                 // tgroup_assigns and fgroup_assigns
@@ -609,7 +615,11 @@ impl StaticInliner {
                         _ => {
                             let fgroup =
                                 self.inline_static_control(fbranch, builder);
-                            assert_eq!(fbranch_latency, fgroup.borrow().get_latency(), "false branch and false branch group latency do not match");
+                            assert_eq!(
+                                fbranch_latency,
+                                fgroup.borrow().get_latency(),
+                                "false branch and false branch group latency do not match"
+                            );
                             let fgroup_assigns: Vec<
                                 ir::Assignment<ir::StaticTiming>,
                             > = fgroup.borrow_mut().assignments.clone();
@@ -710,7 +720,11 @@ impl StaticInliner {
                     builder.add_static_group("static_repeat", *latency);
                 // turn body into a group body_group by recursively calling inline_static_control
                 let body_group = self.inline_static_control(body, builder);
-                assert_eq!(*latency, (num_repeats * body_group.borrow().get_latency()), "latency of static repeat is not equal to num_repeats * latency of body");
+                assert_eq!(
+                    *latency,
+                    (num_repeats * body_group.borrow().get_latency()),
+                    "latency of static repeat is not equal to num_repeats * latency of body"
+                );
                 // the assignments in the repeat group should simply trigger the
                 // body group. So the static group will literally look like:
                 // static group static_repeat <num_repeats * body_latency> {body[go] = 1'd1;}

--- a/calyx/opt/src/passes/static_promotion.rs
+++ b/calyx/opt/src/passes/static_promotion.rs
@@ -104,7 +104,7 @@ impl Named for StaticPromotion {
                 "Whether to perform compaction.  True by Default ",
                 ParseVal::Bool(true),
                 PassOpt::parse_bool,
-            )
+            ),
         ]
     }
 }

--- a/calyx/opt/src/passes/top_down_compile_control.rs
+++ b/calyx/opt/src/passes/top_down_compile_control.rs
@@ -6,7 +6,7 @@ use crate::traversal::{
 use calyx_ir::{
     self as ir, BoolAttr, Cell, GetAttributes, LibrarySignatures, Printer, RRC,
 };
-use calyx_ir::{build_assignments, guard, structure, Id};
+use calyx_ir::{Id, build_assignments, guard, structure};
 use calyx_utils::Error;
 use calyx_utils::{CalyxResult, OutputFile};
 use ir::Nothing;
@@ -56,30 +56,38 @@ fn control_exits(con: &ir::Control, exits: &mut Vec<PredEdge>) {
             exits.push((cur_state, guard!(group["done"])))
         }
         ir::Control::Seq(ir::Seq { stmts, .. }) => {
-            if let Some(stmt) = stmts.last() { control_exits(stmt, exits) }
+            if let Some(stmt) = stmts.last() {
+                control_exits(stmt, exits)
+            }
         }
         ir::Control::If(ir::If {
             tbranch, fbranch, ..
         }) => {
-            control_exits(
-                tbranch, exits,
-            );
-            control_exits(
-                fbranch, exits,
-            )
+            control_exits(tbranch, exits);
+            control_exits(fbranch, exits)
         }
         ir::Control::While(ir::While { body, port, .. }) => {
             let mut loop_exits = vec![];
             control_exits(body, &mut loop_exits);
             // Loop exits only happen when the loop guard is false
-            exits.extend(loop_exits.into_iter().map(|(s, g)| {
-                (s, g & !ir::Guard::from(port.clone()))
-            }));
-        },
-        ir::Control::Repeat(_) => unreachable!("`repeat` statements should have been compiled away. Run `{}` before this pass.", passes::CompileRepeat::name()),
-        ir::Control::Invoke(_) => unreachable!("`invoke` statements should have been compiled away. Run `{}` before this pass.", passes::CompileInvoke::name()),
+            exits.extend(
+                loop_exits
+                    .into_iter()
+                    .map(|(s, g)| (s, g & !ir::Guard::from(port.clone()))),
+            );
+        }
+        ir::Control::Repeat(_) => unreachable!(
+            "`repeat` statements should have been compiled away. Run `{}` before this pass.",
+            passes::CompileRepeat::name()
+        ),
+        ir::Control::Invoke(_) => unreachable!(
+            "`invoke` statements should have been compiled away. Run `{}` before this pass.",
+            passes::CompileInvoke::name()
+        ),
         ir::Control::Par(_) => unreachable!(),
-        ir::Control::Static(_) => unreachable!(" static control should have been compiled away. Run the static compilation passes before this pass")
+        ir::Control::Static(_) => unreachable!(
+            " static control should have been compiled away. Run the static compilation passes before this pass"
+        ),
     }
 }
 
@@ -131,7 +139,7 @@ fn compute_unique_ids(con: &mut ir::Control, cur_state: u64) -> u64 {
             let new_fsm = attributes.has(ir::BoolAttr::NewFSM);
             // if new_fsm is true, then insert attribute at the seq, and then
             // start over counting states from 0
-            let mut cur = if new_fsm{
+            let mut cur = if new_fsm {
                 attributes.insert(NODE_ID, cur_state);
                 0
             } else {
@@ -142,14 +150,13 @@ fn compute_unique_ids(con: &mut ir::Control, cur_state: u64) -> u64 {
             });
             // If new_fsm is true then we want to return cur_state + 1, since this
             // seq should really only take up 1 "state" on the "outer" fsm
-            if new_fsm{
-                cur_state + 1
-            } else {
-                cur
-            }
+            if new_fsm { cur_state + 1 } else { cur }
         }
         ir::Control::If(ir::If {
-            tbranch, fbranch, attributes, ..
+            tbranch,
+            fbranch,
+            attributes,
+            ..
         }) => {
             let new_fsm = attributes.has(ir::BoolAttr::NewFSM);
             // if new_fsm is true, then we want to add an attribute to this
@@ -166,25 +173,19 @@ fn compute_unique_ids(con: &mut ir::Control, cur_state: u64) -> u64 {
             } else {
                 cur_state
             };
-            let tru_nxt = compute_unique_ids(
-                tbranch, cur
-            );
-            let false_nxt = compute_unique_ids(
-                fbranch, tru_nxt
-            );
+            let tru_nxt = compute_unique_ids(tbranch, cur);
+            let false_nxt = compute_unique_ids(fbranch, tru_nxt);
             // If new_fsm is true then we want to return cur_state + 1, since this
             // if stmt should really only take up 1 "state" on the "outer" fsm
-            if new_fsm {
-                cur_state + 1
-            } else {
-                false_nxt
-            }
+            if new_fsm { cur_state + 1 } else { false_nxt }
         }
-        ir::Control::While(ir::While { body, attributes, .. }) => {
+        ir::Control::While(ir::While {
+            body, attributes, ..
+        }) => {
             let new_fsm = attributes.has(ir::BoolAttr::NewFSM);
             // if new_fsm is true, then we want to add an attribute to this
             // control statement
-            if new_fsm{
+            if new_fsm {
                 attributes.insert(NODE_ID, cur_state);
             }
             // If the program starts with a branch then branches can't get
@@ -199,16 +200,20 @@ fn compute_unique_ids(con: &mut ir::Control, cur_state: u64) -> u64 {
             let body_nxt = compute_unique_ids(body, cur);
             // If new_fsm is true then we want to return cur_state + 1, since this
             // while loop should really only take up 1 "state" on the "outer" fsm
-            if new_fsm{
-                cur_state + 1
-            } else {
-                body_nxt
-            }
+            if new_fsm { cur_state + 1 } else { body_nxt }
         }
         ir::Control::Empty(_) => cur_state,
-        ir::Control::Repeat(_) => unreachable!("`repeat` statements should have been compiled away. Run `{}` before this pass.", passes::CompileRepeat::name()),
-        ir::Control::Invoke(_) => unreachable!("`invoke` statements should have been compiled away. Run `{}` before this pass.", passes::CompileInvoke::name()),
-        ir::Control::Static(_) => unreachable!("static control should have been compiled away. Run the static compilation passes before this pass")
+        ir::Control::Repeat(_) => unreachable!(
+            "`repeat` statements should have been compiled away. Run `{}` before this pass.",
+            passes::CompileRepeat::name()
+        ),
+        ir::Control::Invoke(_) => unreachable!(
+            "`invoke` statements should have been compiled away. Run `{}` before this pass.",
+            passes::CompileInvoke::name()
+        ),
+        ir::Control::Static(_) => unreachable!(
+            "static control should have been compiled away. Run the static compilation passes before this pass"
+        ),
     }
 }
 
@@ -346,7 +351,8 @@ impl Schedule<'_, '_> {
 
         debug_assert!(
             petgraph::algo::connected_components(&graph) == 1,
-            "State transition graph has unreachable states (graph has more than one connected component).");
+            "State transition graph has unreachable states (graph has more than one connected component)."
+        );
     }
 
     /// Return the max state in the transition graph
@@ -715,71 +721,86 @@ impl Schedule<'_, '_> {
         has_fast_guarantee: bool,
     ) -> CalyxResult<Vec<PredEdge>> {
         match con {
-        // See explanation of FSM states generated in [ir::TopDownCompileControl].
-        ir::Control::Enable(ir::Enable { group, attributes }) => {
-            let cur_state = attributes.get(NODE_ID).unwrap_or_else(|| panic!("Group `{}` does not have node_id information", group.borrow().name()));
-            // If there is exactly one previous transition state with a `true`
-            // guard, then merge this state into previous state.
-            // This happens when the first control statement is an enable not
-            // inside a branch.
-            let (cur_state, prev_states) = if preds.len() == 1 && preds[0].1.is_true() {
-                (preds[0].0, vec![])
-            } else {
-                (cur_state, preds)
-            };
+            // See explanation of FSM states generated in [ir::TopDownCompileControl].
+            ir::Control::Enable(ir::Enable { group, attributes }) => {
+                let cur_state = attributes.get(NODE_ID).unwrap_or_else(|| {
+                    panic!(
+                        "Group `{}` does not have node_id information",
+                        group.borrow().name()
+                    )
+                });
+                // If there is exactly one previous transition state with a `true`
+                // guard, then merge this state into previous state.
+                // This happens when the first control statement is an enable not
+                // inside a branch.
+                let (cur_state, prev_states) =
+                    if preds.len() == 1 && preds[0].1.is_true() {
+                        (preds[0].0, vec![])
+                    } else {
+                        (cur_state, preds)
+                    };
 
-            // Add group to mapping for emitting group JSON info
-            self.groups_to_states.insert(FSMStateInfo { id: cur_state, group: group.borrow().name() });
+                // Add group to mapping for emitting group JSON info
+                self.groups_to_states.insert(FSMStateInfo {
+                    id: cur_state,
+                    group: group.borrow().name(),
+                });
 
-            let not_done = !guard!(group["done"]);
-            let signal_on = self.builder.add_constant(1, 1);
+                let not_done = !guard!(group["done"]);
+                let signal_on = self.builder.add_constant(1, 1);
 
-            // Activate this group in the current state
-            let en_go = build_assignments!(self.builder;
-                group["go"] = not_done ? signal_on["out"];
-            );
-            self
-                .enables
-                .entry(cur_state)
-                .or_default()
-                .extend(en_go);
+                // Activate this group in the current state
+                let en_go = build_assignments!(self.builder;
+                    group["go"] = not_done ? signal_on["out"];
+                );
+                self.enables.entry(cur_state).or_default().extend(en_go);
 
-            // Activate group in the cycle when previous state signals done.
-            // NOTE: We explicilty do not add `not_done` to the guard.
-            // See explanation in [ir::TopDownCompileControl] to understand
-            // why.
-            if early_transitions || has_fast_guarantee {
-                for (st, g) in &prev_states {
-                    let early_go = build_assignments!(self.builder;
-                        group["go"] = g ? signal_on["out"];
-                    );
-                    self.enables.entry(*st).or_default().extend(early_go);
+                // Activate group in the cycle when previous state signals done.
+                // NOTE: We explicilty do not add `not_done` to the guard.
+                // See explanation in [ir::TopDownCompileControl] to understand
+                // why.
+                if early_transitions || has_fast_guarantee {
+                    for (st, g) in &prev_states {
+                        let early_go = build_assignments!(self.builder;
+                            group["go"] = g ? signal_on["out"];
+                        );
+                        self.enables.entry(*st).or_default().extend(early_go);
+                    }
                 }
+
+                let transitions = prev_states
+                    .into_iter()
+                    .map(|(st, guard)| (st, cur_state, guard));
+                self.transitions.extend(transitions);
+
+                let done_cond = guard!(group["done"]);
+                Ok(vec![(cur_state, done_cond)])
             }
-
-            let transitions = prev_states
-                .into_iter()
-                .map(|(st, guard)| (st, cur_state, guard));
-            self.transitions.extend(transitions);
-
-            let done_cond = guard!(group["done"]);
-            Ok(vec![(cur_state, done_cond)])
+            ir::Control::Seq(seq) => {
+                self.calc_seq_recur(seq, preds, early_transitions)
+            }
+            ir::Control::If(if_stmt) => {
+                self.calc_if_recur(if_stmt, preds, early_transitions)
+            }
+            ir::Control::While(while_stmt) => {
+                self.calc_while_recur(while_stmt, preds, early_transitions)
+            }
+            ir::Control::Par(_) => unreachable!(),
+            ir::Control::Repeat(_) => unreachable!(
+                "`repeat` statements should have been compiled away. Run `{}` before this pass.",
+                passes::CompileRepeat::name()
+            ),
+            ir::Control::Invoke(_) => unreachable!(
+                "`invoke` statements should have been compiled away. Run `{}` before this pass.",
+                passes::CompileInvoke::name()
+            ),
+            ir::Control::Empty(_) => unreachable!(
+                "`calculate_states_recur` should not see an `empty` control."
+            ),
+            ir::Control::Static(_) => unreachable!(
+                "static control should have been compiled away. Run the static compilation passes before this pass"
+            ),
         }
-        ir::Control::Seq(seq) => {
-            self.calc_seq_recur(seq, preds, early_transitions)
-        }
-        ir::Control::If(if_stmt) => {
-            self.calc_if_recur(if_stmt, preds, early_transitions)
-        }
-        ir::Control::While(while_stmt) => {
-            self.calc_while_recur(while_stmt, preds, early_transitions)
-        }
-        ir::Control::Par(_) => unreachable!(),
-        ir::Control::Repeat(_) => unreachable!("`repeat` statements should have been compiled away. Run `{}` before this pass.", passes::CompileRepeat::name()),
-        ir::Control::Invoke(_) => unreachable!("`invoke` statements should have been compiled away. Run `{}` before this pass.", passes::CompileInvoke::name()),
-        ir::Control::Empty(_) => unreachable!("`calculate_states_recur` should not see an `empty` control."),
-        ir::Control::Static(_) => unreachable!("static control should have been compiled away. Run the static compilation passes before this pass")
-    }
     }
 
     /// Builds a finite state machine for `seq` represented by a [Schedule].
@@ -820,7 +841,11 @@ impl Schedule<'_, '_> {
         early_transitions: bool,
     ) -> CalyxResult<Vec<PredEdge>> {
         if if_stmt.cond.is_some() {
-            return Err(Error::malformed_structure(format!("{}: Found group `{}` in with position of if. This should have compiled away.", TopDownCompileControl::name(), if_stmt.cond.as_ref().unwrap().borrow().name())));
+            return Err(Error::malformed_structure(format!(
+                "{}: Found group `{}` in with position of if. This should have compiled away.",
+                TopDownCompileControl::name(),
+                if_stmt.cond.as_ref().unwrap().borrow().name()
+            )));
         }
         let port_guard: ir::Guard<Nothing> = Rc::clone(&if_stmt.port).into();
         // Previous states transitioning into true branch need the conditional
@@ -873,7 +898,11 @@ impl Schedule<'_, '_> {
         early_transitions: bool,
     ) -> CalyxResult<Vec<PredEdge>> {
         if while_stmt.cond.is_some() {
-            return Err(Error::malformed_structure(format!("{}: Found group `{}` in with position of if. This should have compiled away.", TopDownCompileControl::name(), while_stmt.cond.as_ref().unwrap().borrow().name())));
+            return Err(Error::malformed_structure(format!(
+                "{}: Found group `{}` in with position of if. This should have compiled away.",
+                TopDownCompileControl::name(),
+                while_stmt.cond.as_ref().unwrap().borrow().name()
+            )));
         }
 
         let port_guard: ir::Guard<Nothing> = Rc::clone(&while_stmt.port).into();

--- a/calyx/opt/src/passes/top_down_compile_control.rs
+++ b/calyx/opt/src/passes/top_down_compile_control.rs
@@ -335,7 +335,7 @@ impl<'b, 'a> From<&'b mut ir::Builder<'a>> for Schedule<'b, 'a> {
     }
 }
 
-impl<'b, 'a> Schedule<'b, 'a> {
+impl Schedule<'_, '_> {
     /// Validate that all states are reachable in the transition graph.
     fn validate(&self) {
         let graph = DiGraph::<(), u32>::from_edges(

--- a/calyx/opt/src/passes/well_formed.rs
+++ b/calyx/opt/src/passes/well_formed.rs
@@ -21,7 +21,7 @@ fn port_is_static_prim(port: &ir::Port) -> bool {
     let parent_cell = match &port.parent {
         ir::PortParent::Cell(cell_wref) => cell_wref.upgrade(),
         ir::PortParent::Group(_) | ir::PortParent::StaticGroup(_) => {
-            return false
+            return false;
         }
     };
     // if celltype is this component/constant, then obviously not static
@@ -296,11 +296,9 @@ fn check_fast_seq_invariant(seq: &Seq) -> CalyxResult<()> {
         .is_static();
     for stmt in seq.stmts.iter().skip(1) {
         if stmt.is_static() == last_is_static {
-            return Err(
-                Error::malformed_control(
-                    "`seq` marked `@fast` does not contain alternating static-dynamic control children (see #1828)"
-                )
-            );
+            return Err(Error::malformed_control(
+                "`seq` marked `@fast` does not contain alternating static-dynamic control children (see #1828)",
+            ));
         }
         last_is_static = stmt.is_static();
     }

--- a/calyx/opt/src/passes/wire_inliner.rs
+++ b/calyx/opt/src/passes/wire_inliner.rs
@@ -1,6 +1,6 @@
 use crate::traversal::{Action, Named, VisResult, Visitor};
 use calyx_ir as ir;
-use ir::{build_assignments, guard, structure, LibrarySignatures};
+use ir::{LibrarySignatures, build_assignments, guard, structure};
 use ir::{Nothing, RRC};
 use itertools::Itertools;
 use std::{collections::HashMap, rc::Rc};

--- a/calyx/opt/src/passes_experimental/discover_external.rs
+++ b/calyx/opt/src/passes_experimental/discover_external.rs
@@ -54,7 +54,10 @@ impl ConstructVisitor for DiscoverExternal {
             if spl == Some("default") {
                 let Some(val) = splits.next().and_then(|v| v.parse().ok())
                 else {
-                    log::warn!("Failed to parse default value. Please specify using -x {}:default=<n>", n);
+                    log::warn!(
+                        "Failed to parse default value. Please specify using -x {}:default=<n>",
+                        n
+                    );
                     continue;
                 };
                 log::info!("Setting default value to {}", val);
@@ -64,7 +67,10 @@ impl ConstructVisitor for DiscoverExternal {
             // Search for "strip-suffix=<str>" option
             else if spl == Some("strip-suffix") {
                 let Some(suff) = splits.next() else {
-                    log::warn!("Failed to parse suffix. Please specify using -x {}:strip-suffix=<str>", n);
+                    log::warn!(
+                        "Failed to parse suffix. Please specify using -x {}:strip-suffix=<str>",
+                        n
+                    );
                     continue;
                 };
                 log::info!("Setting suffix to {}", suff);

--- a/calyx/opt/src/passes_experimental/hole_inliner.rs
+++ b/calyx/opt/src/passes_experimental/hole_inliner.rs
@@ -1,6 +1,6 @@
 use crate::traversal::{Action, Named, VisResult, Visitor};
 use crate::{analysis::GraphAnalysis, passes::TopDownCompileControl};
-use calyx_ir::{self as ir, structure, LibrarySignatures, RRC};
+use calyx_ir::{self as ir, LibrarySignatures, RRC, structure};
 use calyx_utils::Error;
 use ir::Nothing;
 use std::{collections::HashMap, rc::Rc};
@@ -105,11 +105,13 @@ impl Visitor for HoleInliner {
         let top_level = match &*comp.control.borrow() {
             ir::Control::Empty(_) => return Ok(Action::Stop),
             ir::Control::Enable(en) => Rc::clone(&en.group),
-            _ => return Err(Error::malformed_control(format!(
+            _ => {
+                return Err(Error::malformed_control(format!(
                     "{}: Control shoudl be a single enable. Try running `{}` before inlining.",
                     Self::name(),
-                    TopDownCompileControl::name()))
-            )
+                    TopDownCompileControl::name()
+                )));
+            }
         };
 
         let this_comp = Rc::clone(&comp.signature);

--- a/calyx/opt/src/passes_experimental/hole_inliner.rs
+++ b/calyx/opt/src/passes_experimental/hole_inliner.rs
@@ -55,11 +55,7 @@ fn fixed_point(graph: &GraphAnalysis, map: &mut Store) {
 
     // helper to check if a guard has holes
     let has_holes = |guard: &ir::Guard<Nothing>| {
-        guard
-            .all_ports()
-            .iter()
-            .map(|p| p.borrow().is_hole())
-            .any(|e| e)
+        guard.all_ports().iter().any(|p| p.borrow().is_hole())
     };
 
     // initialize the worklist to have guards that have no holes

--- a/calyx/opt/src/passes_experimental/metadata_table_gen.rs
+++ b/calyx/opt/src/passes_experimental/metadata_table_gen.rs
@@ -103,6 +103,9 @@ mod tests {
         );
         data.add_entry(Id::from("main"), Id::from("group_2"), (23, 28), path);
         let test_string = data.to_string();
-        assert_eq!(test_string, "main.group_1: /temp/path/for/testing.futil 12-16\nmain.group_2: /temp/path/for/testing.futil 23-28\n")
+        assert_eq!(
+            test_string,
+            "main.group_1: /temp/path/for/testing.futil 12-16\nmain.group_2: /temp/path/for/testing.futil 23-28\n"
+        )
     }
 }

--- a/calyx/opt/src/passes_experimental/register_unsharing.rs
+++ b/calyx/opt/src/passes_experimental/register_unsharing.rs
@@ -4,7 +4,7 @@ use crate::analysis::reaching_defns::{
     GroupOrInvoke, ReachingDefinitionAnalysis,
 };
 use crate::traversal::{Action, Named, VisResult, Visitor};
-use calyx_ir::{self as ir, rewriter, Builder, LibrarySignatures};
+use calyx_ir::{self as ir, Builder, LibrarySignatures, rewriter};
 use std::collections::HashMap;
 
 /// Unsharing registers reduces the amount of multiplexers used in the final design, trading them

--- a/calyx/opt/src/passes_experimental/sync/compile_sync.rs
+++ b/calyx/opt/src/passes_experimental/sync/compile_sync.rs
@@ -28,7 +28,6 @@ use std::rc::Rc;
 ///       wait_*;
 ///       wait_restore_*;
 ///     }
-
 pub struct CompileSync {
     barriers: BarrierMap,
 }

--- a/calyx/opt/src/traversal/construct.rs
+++ b/calyx/opt/src/traversal/construct.rs
@@ -44,11 +44,7 @@ impl ParseVal {
 
     pub fn pos_num(&self) -> Option<u64> {
         let n = self.num();
-        if n < 0 {
-            None
-        } else {
-            Some(n as u64)
-        }
+        if n < 0 { None } else { Some(n as u64) }
     }
 
     pub fn num_list(&self) -> Vec<i64> {

--- a/calyx/utils/src/float.rs
+++ b/calyx/utils/src/float.rs
@@ -28,8 +28,8 @@ pub fn parse(rep: u64, width: u64, fl: String) -> CalyxResult<u64> {
         }
         r => {
             return Err(Error::misc(format!(
-            "Unsupported floating point width: {r}. Supported values: 32, 64"
-        )))
+                "Unsupported floating point width: {r}. Supported values: 32, 64"
+            )));
         }
     };
 

--- a/calyx/utils/src/math.rs
+++ b/calyx/utils/src/math.rs
@@ -1,11 +1,7 @@
 use std::cmp;
 
 fn bits_helper(n: u64, i: u64) -> u64 {
-    if n == 0 {
-        i
-    } else {
-        bits_helper(n / 2, i + 1)
-    }
+    if n == 0 { i } else { bits_helper(n / 2, i + 1) }
 }
 
 /// Number of bits needed to represent a number.

--- a/calyx/utils/src/weight_graph.rs
+++ b/calyx/utils/src/weight_graph.rs
@@ -102,7 +102,8 @@ where
     pub fn add_node(&mut self, node: T) {
         debug_assert!(
             !self.index_map.contains_key(&node),
-            "Attempted to add pre-existing node to WeightGraph. Client code should ensure that this never happens.");
+            "Attempted to add pre-existing node to WeightGraph. Client code should ensure that this never happens."
+        );
         let idx = self.graph.add_node(());
         self.index_map.insert(node, idx);
     }

--- a/cider/Cargo.toml
+++ b/cider/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cider"
 version = "0.1.1"
 authors = ["The Calyx authors"]
-edition = "2021"
+edition.workspace = true
 rust-version.workspace = true
 
 [[bin]]

--- a/cider/dap/Cargo.toml
+++ b/cider/dap/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cider-dap"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cider/dap/src/main.rs
+++ b/cider/dap/src/main.rs
@@ -12,10 +12,10 @@ use error::MyAdapterError;
 use dap::prelude::*;
 use error::AdapterResult;
 use responses::VariablesResponse;
-use slog::{info, Drain};
+use slog::{Drain, info};
 //use std::default;
 use std::fs::OpenOptions;
-use std::io::{stdin, stdout, BufReader, BufWriter, Read, Write};
+use std::io::{BufReader, BufWriter, Read, Write, stdin, stdout};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 

--- a/cider/idx/src/index_trait.rs
+++ b/cider/idx/src/index_trait.rs
@@ -1,4 +1,4 @@
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -321,7 +321,10 @@ where
                 last.set_end(I::new(last.end.index() + 1));
                 return;
             } else {
-                assert!(last.end < value, "Inserted value must not be less than end of the prior range");
+                assert!(
+                    last.end < value,
+                    "Inserted value must not be less than end of the prior range"
+                );
             }
         }
         self.0

--- a/cider/src/debugger/commands/command_parser.rs
+++ b/cider/src/debugger/commands/command_parser.rs
@@ -1,11 +1,11 @@
 use super::{
+    PrintCommand,
     core::{
         Command, ParsedBreakPointID, ParsedGroupName, PrintMode, WatchPosition,
     },
-    PrintCommand,
 };
 use baa::WidthInt;
-use pest_consume::{match_nodes, Error, Parser};
+use pest_consume::{Error, Parser, match_nodes};
 
 type ParseResult<T> = std::result::Result<T, Error<Rule>>;
 type Node<'i> = pest_consume::Node<'i, Rule, ()>;

--- a/cider/src/debugger/commands/path_parser.rs
+++ b/cider/src/debugger/commands/path_parser.rs
@@ -1,6 +1,6 @@
-use super::{core::ParseNodes, ParsePath};
+use super::{ParsePath, core::ParseNodes};
 
-use pest_consume::{match_nodes, Error, Parser};
+use pest_consume::{Error, Parser, match_nodes};
 
 type ParseResult<T> = std::result::Result<T, Error<Rule>>;
 type Node<'i> = pest_consume::Node<'i, Rule, ()>;

--- a/cider/src/debugger/commands/path_parser.rs
+++ b/cider/src/debugger/commands/path_parser.rs
@@ -10,7 +10,6 @@ const _GRAMMAR: &str = include_str!("path_parser.pest");
 
 #[derive(Parser)]
 #[grammar = "debugger/commands/path_parser.pest"]
-
 pub struct PathParser;
 
 #[pest_consume::parser]

--- a/cider/src/debugger/debugger_core.rs
+++ b/cider/src/debugger/debugger_core.rs
@@ -20,7 +20,7 @@ use crate::{
             context::Context,
             environment::{Path as ParsePath, PathError, Simulator},
         },
-        text_utils::{print_debugger_welcome, Color},
+        text_utils::{Color, print_debugger_welcome},
     },
     serialization::PrintCode,
 };
@@ -430,7 +430,9 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
                             }
 
                             if !printed_position {
-                                println!("Source info unavailable, falling back to Calyx");
+                                println!(
+                                    "Source info unavailable, falling back to Calyx"
+                                );
                                 self.interpreter.print_pc();
                             }
                         } else {
@@ -459,7 +461,9 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
             }
         }
 
-        println!("Main component has finished executing. Debugger is now in inspection mode.");
+        println!(
+            "Main component has finished executing. Debugger is now in inspection mode."
+        );
 
         loop {
             let comm = input_stream.next_command();
@@ -593,8 +597,13 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
             unwrap_error_message!(target);
 
             if self.interpreter.is_group_running(target) {
-                println!("Warning: the group {} is already running. This breakpoint will not trigger until the next time the group runs.",
-                        self.program_context.as_ref().lookup_name(target).stylize_warning())
+                println!(
+                    "Warning: the group {} is already running. This breakpoint will not trigger until the next time the group runs.",
+                    self.program_context
+                        .as_ref()
+                        .lookup_name(target)
+                        .stylize_warning()
+                )
             }
 
             self.debugging_context.add_breakpoint(target);

--- a/cider/src/debugger/debugging_context/context.rs
+++ b/cider/src/debugger/debugging_context/context.rs
@@ -13,7 +13,7 @@ use crate::{
 use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use cider_idx::maps::IndexedMap;
 use itertools::Itertools;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 use std::fmt::Display;
 
 #[derive(Debug, Clone)]

--- a/cider/src/debugger/io_utils.rs
+++ b/cider/src/debugger/io_utils.rs
@@ -1,5 +1,5 @@
-use super::commands::parse_command;
 use super::commands::Command;
+use super::commands::parse_command;
 use crate::errors::{BoxedCiderError, CiderResult};
 use rustyline::{DefaultEditor, Editor};
 

--- a/cider/src/debugger/source/metadata_parser.rs
+++ b/cider/src/debugger/source/metadata_parser.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use pest_consume::{match_nodes, Error, Parser};
+use pest_consume::{Error, Parser, match_nodes};
 
 use crate::errors::CiderResult;
 

--- a/cider/src/debugger/source/new_parser.rs
+++ b/cider/src/debugger/source/new_parser.rs
@@ -1,6 +1,6 @@
 use super::structures::{GroupContents, NewSourceMap};
 use crate::errors::CiderResult;
-use pest_consume::{match_nodes, Error, Parser};
+use pest_consume::{Error, Parser, match_nodes};
 use std::collections::HashMap;
 type ParseResult<T> = std::result::Result<T, Error<Rule>>;
 type Node<'i> = pest_consume::Node<'i, Rule, ()>;

--- a/cider/src/flatten/flat_ir/base.rs
+++ b/cider/src/flatten/flat_ir/base.rs
@@ -9,7 +9,7 @@ use crate::{
     serialization::PrintCode,
 };
 use baa::{BitVecOps, BitVecValue};
-use cider_idx::{impl_index, impl_index_nonzero, iter::IndexRange, IndexRef};
+use cider_idx::{IndexRef, impl_index, impl_index_nonzero, iter::IndexRange};
 use std::collections::HashSet;
 
 // making these all u32 for now, can give the macro an optional type as the

--- a/cider/src/flatten/flat_ir/control/translator.rs
+++ b/cider/src/flatten/flat_ir/control/translator.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use ahash::{HashMap, HashMapExt};
-use calyx_frontend::{source_info::PositionId, SetAttr};
+use calyx_frontend::{SetAttr, source_info::PositionId};
 use calyx_ir::GetAttributes;
 use calyx_ir::{self as cir, NumAttr, RRC};
 use cider_idx::iter::IndexRange;
@@ -17,7 +17,7 @@ use crate::{
                 AuxiliaryComponentInfo, CombComponentCore, ComponentCore,
                 PrimaryComponentInfo,
             },
-            flatten_trait::{flatten_tree, FlattenTree, SingleHandle},
+            flatten_trait::{FlattenTree, SingleHandle, flatten_tree},
             prelude::{
                 Assignment, AssignmentIdx, CellRef, CombGroup, CombGroupIdx,
                 ComponentIdx, GroupIdx, GuardIdx, PortRef,
@@ -527,7 +527,9 @@ fn compute_local_layout(
             };
             aux.skip_offsets(skips);
         } else {
-            unreachable!("Component cell isn't a component?. This shouldn't be possible please report this.")
+            unreachable!(
+                "Component cell isn't a component?. This shouldn't be possible please report this."
+            )
         }
     }
 
@@ -700,8 +702,8 @@ impl FlattenTree for cir::Control {
 
                 let ref_cells = inv.ref_cells.iter().map(|(ref_cell_id, realizing_cell)| {
                         let invoked_comp = invoked_comp.as_component().expect("cannot invoke a non-component with ref cells");
-                        let target = &ctx.secondary[*invoked_comp].ref_cell_offset_map.iter().find(|(_idx, &def_idx)| {
-                            let def = &ctx.secondary[def_idx];
+                        let target = &ctx.secondary[*invoked_comp].ref_cell_offset_map.iter().find(|(_idx, def_idx)| {
+                            let def = &ctx.secondary[**def_idx];
                             def.name == resolve_id(ref_cell_id)
                         }).map(|(t, _)| t).expect("Unable to find the given ref cell in the invoked component");
                         (*target, layout.cell_map[&realizing_cell.as_raw()])
@@ -726,7 +728,10 @@ impl FlattenTree for cir::Control {
                     .borrow()
                     .find_all_with_attr(NumAttr::Go)
                     .collect_vec();
-                assert!(go.len() == 1, "cannot handle multiple go ports yet or the invoked cell has none");
+                assert!(
+                    go.len() == 1,
+                    "cannot handle multiple go ports yet or the invoked cell has none"
+                );
                 let comp_go = layout.port_map[&go[0].as_raw()];
                 let done = inv
                     .comp

--- a/cider/src/flatten/flat_ir/flatten_trait.rs
+++ b/cider/src/flatten/flat_ir/flatten_trait.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use cider_idx::{maps::IndexedMap, IndexRef};
+use cider_idx::{IndexRef, maps::IndexedMap};
 
 /// A handle bundling a queue of nodes to be processed and a vector of nodes that
 /// have already been processed. The vec itself is not owned by the handle.

--- a/cider/src/flatten/flat_ir/identifier.rs
+++ b/cider/src/flatten/flat_ir/identifier.rs
@@ -1,5 +1,5 @@
 use ahash::{HashMap, HashMapExt};
-use cider_idx::{impl_index, IndexRef};
+use cider_idx::{IndexRef, impl_index};
 use std::hash::Hash;
 
 /// An index type corresponding to a string.

--- a/cider/src/flatten/primitives/builder.rs
+++ b/cider/src/flatten/primitives/builder.rs
@@ -1,8 +1,8 @@
 use ahash::HashSet;
 
 use super::{
-    combinational::*, prim_trait::RaceDetectionPrimitive, stateful::*,
-    Primitive,
+    Primitive, combinational::*, prim_trait::RaceDetectionPrimitive,
+    stateful::*,
 };
 use crate::{
     flatten::{
@@ -16,7 +16,7 @@ use crate::{
         },
         structures::{
             context::Context,
-            environment::{clock::ClockMap, CellLedger},
+            environment::{CellLedger, clock::ClockMap},
         },
     },
     serialization::DataDump,

--- a/cider/src/flatten/primitives/combinational.rs
+++ b/cider/src/flatten/primitives/combinational.rs
@@ -1,14 +1,14 @@
 use crate::flatten::{
     flat_ir::prelude::{AssignedValue, GlobalPortIdx, PortValue},
     primitives::{
-        all_defined, comb_primitive, declare_ports, ports,
-        prim_trait::UpdateStatus, utils::floored_division, Primitive,
+        Primitive, all_defined, comb_primitive, declare_ports, ports,
+        prim_trait::UpdateStatus, utils::floored_division,
     },
     structures::environment::PortMap,
 };
 
 use baa::{BitVecOps, BitVecValue};
-use cider_idx::{iter::SplitIndexRange, IndexRef};
+use cider_idx::{IndexRef, iter::SplitIndexRange};
 
 use super::prim_trait::UpdateResult;
 

--- a/cider/src/flatten/primitives/prim_trait.rs
+++ b/cider/src/flatten/primitives/prim_trait.rs
@@ -3,7 +3,7 @@ use crate::{
     flatten::{
         flat_ir::base::GlobalPortIdx,
         structures::{
-            environment::{clock::ClockMap, PortMap},
+            environment::{PortMap, clock::ClockMap},
             thread::ThreadMap,
         },
     },

--- a/cider/src/flatten/primitives/stateful/math.rs
+++ b/cider/src/flatten/primitives/stateful/math.rs
@@ -5,7 +5,7 @@ use crate::{
         primitives::{
             declare_ports, ports,
             prim_trait::*,
-            utils::{floored_division, int_sqrt, ShiftBuffer},
+            utils::{ShiftBuffer, floored_division, int_sqrt},
         },
         structures::environment::PortMap,
     },

--- a/cider/src/flatten/primitives/stateful/memories.rs
+++ b/cider/src/flatten/primitives/stateful/memories.rs
@@ -1,4 +1,4 @@
-use cider_idx::{iter::SplitIndexRange, maps::IndexedMap, IndexRef};
+use cider_idx::{IndexRef, iter::SplitIndexRange, maps::IndexedMap};
 use itertools::Itertools;
 
 use crate::{
@@ -9,15 +9,15 @@ use crate::{
             prelude::{AssignedValue, GlobalPortIdx, PortValue},
         },
         primitives::{
-            declare_ports, declare_ports_no_signature, make_getters, ports,
+            Primitive, declare_ports, declare_ports_no_signature, make_getters,
+            ports,
             prim_trait::{RaceDetectionPrimitive, UpdateResult, UpdateStatus},
             utils::infer_thread_id,
-            Primitive,
         },
         structures::{
             environment::{
-                clock::{new_clock_pair, ClockMap, ReadSource, ValueWithClock},
                 PortMap,
+                clock::{ClockMap, ReadSource, ValueWithClock, new_clock_pair},
             },
             thread::{ThreadIdx, ThreadMap},
         },
@@ -499,10 +499,11 @@ impl CombMem {
             .collect_vec();
 
         assert_eq!(internal_state.len(), size.size());
-        assert!(data
-            .chunks_exact(byte_count as usize)
-            .remainder()
-            .is_empty());
+        assert!(
+            data.chunks_exact(byte_count as usize)
+                .remainder()
+                .is_empty()
+        );
 
         Self {
             base_port,
@@ -829,10 +830,11 @@ impl SeqMem {
             .collect_vec();
 
         assert_eq!(internal_state.len(), size.size());
-        assert!(data
-            .chunks_exact(byte_count as usize)
-            .remainder()
-            .is_empty());
+        assert!(
+            data.chunks_exact(byte_count as usize)
+                .remainder()
+                .is_empty()
+        );
 
         Self {
             base_port,

--- a/cider/src/flatten/structures/context.rs
+++ b/cider/src/flatten/structures/context.rs
@@ -3,9 +3,9 @@ use std::ops::Index;
 use calyx_frontend::source_info::SourceInfoTable;
 use calyx_ir::Direction;
 use cider_idx::{
+    IndexRef,
     iter::IndexRange,
     maps::{IndexedMap, SecondaryMap, SecondarySparseMap},
-    IndexRef,
 };
 
 use crate::flatten::flat_ir::{

--- a/cider/src/flatten/structures/environment/clock.rs
+++ b/cider/src/flatten/structures/environment/clock.rs
@@ -374,7 +374,7 @@ impl ClockMap {
         &'a self,
         read_clock: ClockIdx,
         threads: I,
-    ) -> impl Iterator<Item = ReadInfoWithThread> + '_
+    ) -> impl Iterator<Item = ReadInfoWithThread> + 'a
     where
         I: IntoIterator<Item = ThreadIdx> + 'a,
     {
@@ -605,14 +605,10 @@ where
     pub fn get_strictly_greater<'a>(
         &'a self,
         other: &'a Self,
-    ) -> impl Iterator<Item = &I> + '_ {
+    ) -> impl Iterator<Item = &'a I> + 'a {
         other.map.iter().filter_map(|(key, other_count)| {
             if let Some(count) = self.get(key) {
-                if other_count > count {
-                    Some(key)
-                } else {
-                    None
-                }
+                if other_count > count { Some(key) } else { None }
             } else {
                 Some(key)
             }

--- a/cider/src/flatten/structures/environment/clock.rs
+++ b/cider/src/flatten/structures/environment/clock.rs
@@ -1,5 +1,5 @@
 use std::{
-    cmp::{max, Ordering},
+    cmp::{Ordering, max},
     collections::HashMap,
     hash::Hash,
     num::NonZeroU32,
@@ -879,17 +879,23 @@ pub struct ReadError;
 
 #[derive(Debug, Clone, Error)]
 pub enum ClockError {
-    #[error("Concurrent read & write to the same register/memory. This text should never be seen")]
+    #[error(
+        "Concurrent read & write to the same register/memory. This text should never be seen"
+    )]
     ReadAfterWrite {
         write: WriteInfo,
         read: ReadInfoWithThread,
     },
-    #[error("Concurrent writes to the same register/memory. This text should never be seen")]
+    #[error(
+        "Concurrent writes to the same register/memory. This text should never be seen"
+    )]
     WriteAfterWrite {
         write1: WriteInfo,
         write2: WriteInfo,
     },
-    #[error("Concurrent writes to the same register/memory. This text should never be seen")]
+    #[error(
+        "Concurrent writes to the same register/memory. This text should never be seen"
+    )]
     WriteAfterRead {
         write: WriteInfo,
         reads: Box<[ReadInfoWithThread]>,

--- a/cider/src/flatten/structures/environment/program_counter.rs
+++ b/cider/src/flatten/structures/environment/program_counter.rs
@@ -1,7 +1,7 @@
 use std::{collections::hash_map::Entry, num::NonZeroU32};
 
 use ahash::{HashMap, HashMapExt};
-use cider_idx::{impl_index_nonzero, iter::IndexRange, IndexRef};
+use cider_idx::{IndexRef, impl_index_nonzero, iter::IndexRange};
 use smallvec::SmallVec;
 
 use super::super::context::Context;
@@ -260,7 +260,9 @@ impl SearchPath {
                     Control::Invoke(_)
                     | Control::Empty(_)
                     | Control::Enable(_) => {
-                        unreachable!("SearchPath is malformed. This is an error and should be reported")
+                        unreachable!(
+                            "SearchPath is malformed. This is an error and should be reported"
+                        )
                     }
                 }
             }

--- a/cider/src/flatten/structures/environment/traverser.rs
+++ b/cider/src/flatten/structures/environment/traverser.rs
@@ -8,7 +8,7 @@ use crate::flatten::{
     },
     structures::context::Context,
 };
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 use thiserror::Error;
 
 use super::Environment;
@@ -261,7 +261,9 @@ impl Traverser {
                                     });
                                 }
                             }
-                            unreachable!("port exists on cell but not in signature. Internal structure is in an inconsistent state. This is an error please report it");
+                            unreachable!(
+                                "port exists on cell but not in signature. Internal structure is in an inconsistent state. This is an error please report it"
+                            );
                         } else if env.ctx().lookup_name(name) == target.as_ref()
                         {
                             return Ok(Path::AbstractPort {

--- a/cider/src/flatten/structures/printer.rs
+++ b/cider/src/flatten/structures/printer.rs
@@ -148,20 +148,53 @@ impl<'a> Printer<'a> {
         let parent = self.ctx.find_parent_cell(comp, target);
 
         match (port, parent) {
-            (PortDefinitionRef::Local(l), ParentIdx::Component(c)) => CanonicalIdentifier::interface_port( self.ctx.secondary[c].name, self.ctx.secondary[l].name),
+            (PortDefinitionRef::Local(l), ParentIdx::Component(c)) => {
+                CanonicalIdentifier::interface_port(
+                    self.ctx.secondary[c].name,
+                    self.ctx.secondary[l].name,
+                )
+            }
             (PortDefinitionRef::Local(l), ParentIdx::Cell(c)) => {
-                if let CellPrototype::Constant { value, width, c_type }= &self.ctx.secondary[c].prototype {
+                if let CellPrototype::Constant {
+                    value,
+                    width,
+                    c_type,
+                } = &self.ctx.secondary[c].prototype
+                {
                     match c_type {
-                        ConstantType::Literal => CanonicalIdentifier::literal((*width).into(), *value),
-                        ConstantType::Primitive => CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l].name),
+                        ConstantType::Literal => CanonicalIdentifier::literal(
+                            (*width).into(),
+                            *value,
+                        ),
+                        ConstantType::Primitive => {
+                            CanonicalIdentifier::cell_port(
+                                self.ctx.secondary[c].name,
+                                self.ctx.secondary[l].name,
+                            )
+                        }
                     }
                 } else {
-                    CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l].name)
+                    CanonicalIdentifier::cell_port(
+                        self.ctx.secondary[c].name,
+                        self.ctx.secondary[l].name,
+                    )
                 }
-            },
-            (PortDefinitionRef::Local(l), ParentIdx::Group(g)) => CanonicalIdentifier::group_port( self.ctx.primary[g].name(), self.ctx.secondary[l].name),
-            (PortDefinitionRef::Ref(rp), ParentIdx::RefCell(rc)) => CanonicalIdentifier::cell_port( self.ctx.secondary[rc].name, self.ctx.secondary[rp]),
-            _ => unreachable!("Inconsistent port definition and parent. This should never happen"),
+            }
+            (PortDefinitionRef::Local(l), ParentIdx::Group(g)) => {
+                CanonicalIdentifier::group_port(
+                    self.ctx.primary[g].name(),
+                    self.ctx.secondary[l].name,
+                )
+            }
+            (PortDefinitionRef::Ref(rp), ParentIdx::RefCell(rc)) => {
+                CanonicalIdentifier::cell_port(
+                    self.ctx.secondary[rc].name,
+                    self.ctx.secondary[rp],
+                )
+            }
+            _ => unreachable!(
+                "Inconsistent port definition and parent. This should never happen"
+            ),
         }
     }
 

--- a/cider/src/serialization/data_dump.rs
+++ b/cider/src/serialization/data_dump.rs
@@ -474,10 +474,12 @@ mod tests {
                     *bytes.last_mut().unwrap() &= mask;
                 }
 
-                assert!(header_data[cursor..cursor + mem.byte_count()]
-                    .chunks_exact(bytes_per_val)
-                    .remainder()
-                    .is_empty());
+                assert!(
+                    header_data[cursor..cursor + mem.byte_count()]
+                        .chunks_exact(bytes_per_val)
+                        .remainder()
+                        .is_empty()
+                );
                 cursor += mem.byte_count();
             }
 

--- a/cider/src/tests/values.rs
+++ b/cider/src/tests/values.rs
@@ -174,27 +174,33 @@ mod signed_fixed_point_tests {
     #[test]
     fn test_mixed_bits_set() {
         assert_eq!(
-            BitVecValue::from_u64(/*value=*/ 0b10110101, /*width=*/ 8)
-                .to_signed_fixed_point(/*fractional_width=*/ 3)
-                .unwrap(),
+            BitVecValue::from_u64(
+                /*value=*/ 0b10110101, /*width=*/ 8
+            )
+            .to_signed_fixed_point(/*fractional_width=*/ 3)
+            .unwrap(),
             -Fraction::new(75u32, 8u32)
         );
     }
     #[test]
     fn test_mixed_bits_set2() {
         assert_eq!(
-            BitVecValue::from_u64(/*value=*/ 0b10100011, /*width=*/ 8)
-                .to_signed_fixed_point(/*fractional_width=*/ 4)
-                .unwrap(),
+            BitVecValue::from_u64(
+                /*value=*/ 0b10100011, /*width=*/ 8
+            )
+            .to_signed_fixed_point(/*fractional_width=*/ 4)
+            .unwrap(),
             -Fraction::new(93u32, 16u32)
         );
     }
     #[test]
     fn test_mixed_bits_set3() {
         assert_eq!(
-            BitVecValue::from_u64(/*value=*/ 0b11111101, /*width=*/ 8)
-                .to_signed_fixed_point(/*fractional_width=*/ 4)
-                .unwrap(),
+            BitVecValue::from_u64(
+                /*value=*/ 0b11111101, /*width=*/ 8
+            )
+            .to_signed_fixed_point(/*fractional_width=*/ 4)
+            .unwrap(),
             -Fraction::new(3u32, 16u32)
         );
     }

--- a/fud2/Cargo.toml
+++ b/fud2/Cargo.toml
@@ -6,7 +6,7 @@ authors.workspace = true
 license-file.workspace = true
 repository.workspace = true
 homepage.workspace = true
-rust-version = "1.76"
+rust-version.workspace = true
 
 keywords = ["build-tool"]
 readme = "README.md"

--- a/fud2/fud-core/Cargo.toml
+++ b/fud2/fud-core/Cargo.toml
@@ -3,7 +3,7 @@ name = "fud-core"
 version = "0.0.2"
 edition.workspace = true
 license-file.workspace = true
-rust-version = "1.76"
+rust-version.workspace = true
 
 keywords = ["build-tool"]
 readme = "../README.md"

--- a/fud2/fud-core/src/cli.rs
+++ b/fud2/fud-core/src/cli.rs
@@ -1,8 +1,8 @@
 pub use crate::cli_ext::{CliExt, FakeCli, FromArgFn, RedactArgFn};
 use crate::config;
-use crate::exec::{plan, Driver, Request, StateRef};
+use crate::exec::{Driver, Request, StateRef, plan};
 use crate::run::Run;
-use anyhow::{anyhow, bail, Context};
+use anyhow::{Context, anyhow, bail};
 use argh::FromArgs;
 use camino::Utf8PathBuf;
 use figment::providers::Serialized;

--- a/fud2/fud-core/src/cli_ext.rs
+++ b/fud2/fud-core/src/cli_ext.rs
@@ -121,8 +121,8 @@ impl CliExt for () {
         vec![]
     }
 
-    fn inner_redact_arg_values(
-    ) -> Vec<(&'static str, crate::cli_ext::RedactArgFn)> {
+    fn inner_redact_arg_values()
+    -> Vec<(&'static str, crate::cli_ext::RedactArgFn)> {
         vec![]
     }
 

--- a/fud2/fud-core/src/config.rs
+++ b/fud2/fud-core/src/config.rs
@@ -1,6 +1,6 @@
 use figment::{
-    providers::{Format, Serialized, Toml},
     Figment,
+    providers::{Format, Serialized, Toml},
 };
 use serde::{Deserialize, Serialize};
 use std::{env, path::Path};

--- a/fud2/fud-core/src/exec/mod.rs
+++ b/fud2/fud-core/src/exec/mod.rs
@@ -5,5 +5,5 @@ mod request;
 
 pub(super) use data::Setup;
 pub use data::{OpRef, Operation, SetupRef, State, StateRef};
-pub use driver::{Driver, DriverBuilder, Plan, IO};
+pub use driver::{Driver, DriverBuilder, IO, Plan};
 pub use request::Request;

--- a/fud2/fud-core/src/exec/plan/egg_planner.rs
+++ b/fud2/fud-core/src/exec/plan/egg_planner.rs
@@ -59,7 +59,7 @@ use super::{
 };
 use cranelift_entity::PrimaryMap;
 use egg::{
-    define_language, rewrite, Id, Pattern, PatternAst, RecExpr, Rewrite, Runner,
+    Id, Pattern, PatternAst, RecExpr, Rewrite, Runner, define_language, rewrite,
 };
 
 #[derive(Debug, Default)]

--- a/fud2/fud-core/src/exec/plan/legacy_planner.rs
+++ b/fud2/fud-core/src/exec/plan/legacy_planner.rs
@@ -2,8 +2,8 @@ use crate::exec::State;
 
 use super::{
     super::{OpRef, Operation, StateRef},
-    planner::Step,
     FindPlan,
+    planner::Step,
 };
 use cranelift_entity::{PrimaryMap, SecondaryMap};
 

--- a/fud2/fud-core/src/exec/request.rs
+++ b/fud2/fud-core/src/exec/request.rs
@@ -1,4 +1,4 @@
-use super::{plan::FindPlan, OpRef, StateRef};
+use super::{OpRef, StateRef, plan::FindPlan};
 use camino::Utf8PathBuf;
 
 /// A request to the Driver directing it what to build.

--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -694,8 +694,8 @@ fn ninja_cmd_io_error(e: std::io::Error) -> std::io::Error {
         std::io::ErrorKind::NotFound => std::io::Error::new(
             e.kind(),
             format!(
-            "Unable to run ninja \"{e}\"\nHint: Is ninja installed correctly?",
-        ),
+                "Unable to run ninja \"{e}\"\nHint: Is ninja installed correctly?",
+            ),
         ),
         _ => e,
     }

--- a/fud2/fud-core/src/script/error.rs
+++ b/fud2/fud-core/src/script/error.rs
@@ -114,7 +114,10 @@ impl Display for RhaiSystemError {
                 write!(f, "Unable to construct StateRef: `{v:?}`")
             }
             RhaiSystemErrorKind::BeganOp(old_name, new_name) => {
-                write!(f, "Unable to build two ops at once: trying to build `{new_name:?}` but already building `{old_name:?}`")
+                write!(
+                    f,
+                    "Unable to build two ops at once: trying to build `{new_name:?}` but already building `{old_name:?}`"
+                )
             }
             RhaiSystemErrorKind::NoOp => {
                 write!(
@@ -123,22 +126,37 @@ impl Display for RhaiSystemError {
                 )
             }
             RhaiSystemErrorKind::NoDep(dep) => {
-                write!(f, "Unable to find dep: `{dep:?}`. A call to `shell` with `{dep:?}` as an output must occur prior to this call.")
+                write!(
+                    f,
+                    "Unable to find dep: `{dep:?}`. A call to `shell` with `{dep:?}` as an output must occur prior to this call."
+                )
             }
             RhaiSystemErrorKind::ExpectedString(v) => {
                 write!(f, "Expected string, got: `{v:?}`.")
             }
             RhaiSystemErrorKind::DupTarget(target) => {
-                write!(f, "Duplicate target: `{target:?}`. Consider removing a shell command generating `{target:?}`.")
+                write!(
+                    f,
+                    "Duplicate target: `{target:?}`. Consider removing a shell command generating `{target:?}`."
+                )
             }
             RhaiSystemErrorKind::ExpectedShell => {
-                write!(f, "Expected `shell`, got `shell_deps`. Ops may contain only one of `shell` or `shell_deps` calls, not calls to both")
+                write!(
+                    f,
+                    "Expected `shell`, got `shell_deps`. Ops may contain only one of `shell` or `shell_deps` calls, not calls to both"
+                )
             }
             RhaiSystemErrorKind::ExpectedShellDeps => {
-                write!(f, "Expected `shell_deps`, got `shell`. Ops may contain only one of `shell` or `shell_deps` calls, not calls to both")
+                write!(
+                    f,
+                    "Expected `shell_deps`, got `shell`. Ops may contain only one of `shell` or `shell_deps` calls, not calls to both"
+                )
             }
             RhaiSystemErrorKind::EmptyOp => {
-                write!(f, "Error: Op must contain at least one call to `shell` or `shell_deps`.")
+                write!(
+                    f,
+                    "Error: Op must contain at least one call to `shell` or `shell_deps`."
+                )
             }
         }
     }

--- a/fud2/fud-core/src/script/plugin.rs
+++ b/fud2/fud-core/src/script/plugin.rs
@@ -1,8 +1,8 @@
 use rhai::{Dynamic, ImmutableString, ParseError, Position};
 
 use crate::{
-    exec::{SetupRef, StateRef},
     DriverBuilder,
+    exec::{SetupRef, StateRef},
 };
 use std::{
     cell::{RefCell, RefMut},
@@ -13,7 +13,7 @@ use std::{
 
 use super::{
     error::RhaiSystemError,
-    exec_scripts::{to_rhai_err, to_str_slice, RhaiResult, RhaiSetupCtx},
+    exec_scripts::{RhaiResult, RhaiSetupCtx, to_rhai_err, to_str_slice},
     report::RhaiReport,
     resolver::Resolver,
 };
@@ -479,7 +479,7 @@ impl ScriptRunner {
                         "{} in {}",
                         e,
                         f.to_str().unwrap()
-                    ))
+                    ));
                 }
                 Ok(ast) => ast,
             };

--- a/fud2/fud-core/tests/tests.rs
+++ b/fud2/fud-core/tests/tests.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeSet;
 
 use fud_core::{
-    exec::plan::{EnumeratePlanner, FindPlan},
     DriverBuilder,
+    exec::plan::{EnumeratePlanner, FindPlan},
 };
 use rand::SeedableRng as _;
 

--- a/fud2/src/cli_pyenv.rs
+++ b/fud2/src/cli_pyenv.rs
@@ -101,7 +101,9 @@ impl PyenvCommand {
         let pyenv = data_dir.join("venv");
 
         if !pyenv.exists() {
-            anyhow::bail!("You need to run `fud2 env init` before you can activate the venv")
+            anyhow::bail!(
+                "You need to run `fud2 env init` before you can activate the venv"
+            )
         }
 
         println!("{}", pyenv.join("bin").join("activate").to_str().unwrap());

--- a/fud2/src/main.rs
+++ b/fud2/src/main.rs
@@ -1,5 +1,5 @@
+use fud_core::{DriverBuilder, cli::CliStart};
 use fud2::Fud2CliExt;
-use fud_core::{cli::CliStart, DriverBuilder};
 
 fn main() -> anyhow::Result<()> {
     let mut bld = DriverBuilder::new("fud2");

--- a/fud2/tests/tests.rs
+++ b/fud2/tests/tests.rs
@@ -1,12 +1,12 @@
 use figment::providers::Format as _;
 use fud_core::{
+    Driver, DriverBuilder,
     config::default_config,
     exec::{
+        IO, Plan, Request,
         plan::{EnumeratePlanner, FindPlan, LegacyPlanner},
-        Plan, Request, IO,
     },
     run::Run,
-    Driver, DriverBuilder,
 };
 use itertools::Itertools;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 # This file is used by github actions for the CI checks.
 
 [toolchain]
-channel = "1.82.0"
+channel = "1.85"

--- a/src/build.rs
+++ b/src/build.rs
@@ -93,7 +93,9 @@ fn create_primitives() -> Result<path::PathBuf> {
         }
         Err(e) => {
             // Move the old primitives back
-            println!("cargo:warning=Failed to write primitives directory. Restoring old directory: {e}");
+            println!(
+                "cargo:warning=Failed to write primitives directory. Restoring old directory: {e}"
+            );
             if let Some(old) = old_prims {
                 fs::rename(old, &prims)?;
             }

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -3,9 +3,9 @@ use argh::FromArgs;
 #[cfg(feature = "serialize")]
 use calyx_backend::SexpBackend;
 use calyx_backend::{
-    xilinx::{XilinxInterfaceBackend, XilinxXmlBackend},
     Backend, BackendOpt, FirrtlBackend, MlirBackend, PrimitiveUsesBackend,
     ResourcesBackend, VerilogBackend,
+    xilinx::{XilinxInterfaceBackend, XilinxXmlBackend},
 };
 use calyx_ir as ir;
 use calyx_utils::{CalyxResult, Error, OutputFile};
@@ -127,7 +127,10 @@ impl FromStr for CompileMode {
         match s {
             "file" => Ok(CompileMode::File),
             "project" => Ok(CompileMode::Project),
-            s => Err(format!("Unknown compilation mode: {}. Valid options are `file` or `project`", s))
+            s => Err(format!(
+                "Unknown compilation mode: {}. Valid options are `file` or `project`",
+                s
+            )),
         }
     }
 }

--- a/tools/calyx-pass-explorer/src/main.rs
+++ b/tools/calyx-pass-explorer/src/main.rs
@@ -34,7 +34,9 @@ fn main() -> std::io::Result<()> {
         println!(" - Focus a component");
         println!(" - Set breakpoints");
         println!();
-        println!("See more at https://github.com/calyxir/calyx/blob/calyx-pass/tools/calyx-pass/README.md");
+        println!(
+            "See more at https://github.com/calyxir/calyx/blob/calyx-pass/tools/calyx-pass/README.md"
+        );
         return Ok(());
     }
 
@@ -55,26 +57,42 @@ fn main() -> std::io::Result<()> {
 
     if !args.disable.is_empty() && args.breakpoint.is_none() {
         fail("Invalid command line flags.", || {
-            println!("Using the disable pass option (`-d`) requires a breakpoint to be set. You can set one with `-b`.");
+            println!(
+                "Using the disable pass option (`-d`) requires a breakpoint to be set. You can set one with `-b`."
+            );
         });
     }
 
-    assert!(!args.calyx_exec.is_empty(), "We just assigned it a non-empty value if it was empty (unless fud somehow set the calyx executable as empty...");
+    assert!(
+        !args.calyx_exec.is_empty(),
+        "We just assigned it a non-empty value if it was empty (unless fud somehow set the calyx executable as empty..."
+    );
 
     if util::capture_command_stdout(&args.calyx_exec, &["--version"], true)
         .is_err()
     {
-        fail("Failed to determine or repair calyx executable path automatically.", || {
+        fail(
+            "Failed to determine or repair calyx executable path automatically.",
+            || {
                 println!("{}", "Here's how to fix it:".bold());
-                println!("Option 1. Setup your fud config so that 'stages.calyx.exec' yields a valid path to the calyx executable");
-                println!("Option 2. Determine the path manually and pass it to the `-e` or `--calyx-exec` option");
-                println!("Option 3. Run this tool from the repository directory after calling `cargo build`");
-            });
+                println!(
+                    "Option 1. Setup your fud config so that 'stages.calyx.exec' yields a valid path to the calyx executable"
+                );
+                println!(
+                    "Option 2. Determine the path manually and pass it to the `-e` or `--calyx-exec` option"
+                );
+                println!(
+                    "Option 3. Run this tool from the repository directory after calling `cargo build`"
+                );
+            },
+        );
     }
 
     if args.input_file.is_none() {
         fail("Invalid command line arguments.", || {
-            println!("You must pass a single calyx program as input. However, when the version is requested through `--version`, this input file is not required and will be ignored.");
+            println!(
+                "You must pass a single calyx program as input. However, when the version is requested through `--version`, this input file is not required and will be ignored."
+            );
         });
     }
 

--- a/tools/calyx-pass-explorer/src/scrollback_buffer.rs
+++ b/tools/calyx-pass-explorer/src/scrollback_buffer.rs
@@ -138,7 +138,7 @@ impl<'a> ScrollbackBuffer<'a> {
     }
 }
 
-impl<'a> std::io::Write for ScrollbackBuffer<'a> {
+impl std::io::Write for ScrollbackBuffer<'_> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         if self.lines.is_empty() {
             self.lines.push("".into());

--- a/tools/calyx-pass-explorer/src/scrollback_buffer.rs
+++ b/tools/calyx-pass-explorer/src/scrollback_buffer.rs
@@ -1,4 +1,4 @@
-use crossterm::{cursor, style, terminal, ExecutableCommand, QueueableCommand};
+use crossterm::{ExecutableCommand, QueueableCommand, cursor, style, terminal};
 use std::cmp::min;
 
 /// Implements a scrollback buffer.

--- a/tools/calyx-pass-explorer/src/tui.rs
+++ b/tools/calyx-pass-explorer/src/tui.rs
@@ -143,21 +143,21 @@ impl<'a> PassExplorerTUI<'a> {
             "Calyx Pass Explorer".underlined()
         )?;
         writeln!(
-        self.scrollback_buffer,
-        "Usage:\n  1. Explore: {} {}, {} {}, {} {}, {} {}\n  2. Movement: {} {}, {} {}, up/down arrows, scroll",
-        ACCEPT.to_string().green(),
-        "accept".dark_green(),
-        SKIP,
-        "skip",
-        QUIT.to_string().red(),
-        "quit".dark_red(),
-        UNDO.to_string().cyan(),
-        "undo".dark_cyan(),
-        JUMP_FWD.to_string().magenta(),
-        "forward".dark_magenta(),
-        JUMP_BCK.to_string().magenta(),
-        "back".dark_magenta(),
-    )?;
+            self.scrollback_buffer,
+            "Usage:\n  1. Explore: {} {}, {} {}, {} {}, {} {}\n  2. Movement: {} {}, {} {}, up/down arrows, scroll",
+            ACCEPT.to_string().green(),
+            "accept".dark_green(),
+            SKIP,
+            "skip",
+            QUIT.to_string().red(),
+            "quit".dark_red(),
+            UNDO.to_string().cyan(),
+            "undo".dark_cyan(),
+            JUMP_FWD.to_string().magenta(),
+            "forward".dark_magenta(),
+            JUMP_BCK.to_string().magenta(),
+            "back".dark_magenta(),
+        )?;
 
         let current_pass_application =
             self.pass_explorer.current_pass_application();

--- a/tools/cider-data-converter/src/converter.rs
+++ b/tools/cider-data-converter/src/converter.rs
@@ -3,7 +3,7 @@ use cider::serialization::*;
 use itertools::Itertools;
 use num_bigint::{BigInt, BigUint, ToBigInt};
 use num_rational::BigRational;
-use num_traits::{sign::Signed, Num, ToPrimitive};
+use num_traits::{Num, ToPrimitive, sign::Signed};
 use serde_json::Number;
 use std::{collections::HashMap, iter::repeat, str::FromStr};
 
@@ -153,11 +153,7 @@ fn float_to_rational(float: f64) -> BigRational {
     let denom = BigInt::from(10).pow(string[1].len() as u32);
 
     let result = BigRational::from_integer(int) + BigRational::new(frac, denom);
-    if is_neg {
-        -result
-    } else {
-        result
-    }
+    if is_neg { -result } else { result }
 }
 
 fn unroll_float(
@@ -170,68 +166,76 @@ fn unroll_float(
             signed,
             int_width,
             frac_width,
-        } =>
-            {
-                let rational = float_to_rational(val);
+        } => {
+            let rational = float_to_rational(val);
 
-                let frac_part = rational.fract().abs();
-                let frac_log = log2_exact(&frac_part.denom().to_biguint().unwrap());
+            let frac_part = rational.fract().abs();
+            let frac_log = log2_exact(&frac_part.denom().to_biguint().unwrap());
 
-                let number = if frac_log.is_none() && round_float {
-                    let w = BigInt::from(1) << frac_width;
-                    let new = (val * w.to_f64().unwrap()).round();
-                    new.to_bigint().unwrap()
-                } else if frac_log.is_none() {
-                    panic!("Number {val} cannot be represented as a fixed-point number. If you want to approximate the number, set the `round_float` flag to true.");
-                } else {
-                    let int_part = rational.to_integer();
+            let number = if frac_log.is_none() && round_float {
+                let w = BigInt::from(1) << frac_width;
+                let new = (val * w.to_f64().unwrap()).round();
+                new.to_bigint().unwrap()
+            } else if frac_log.is_none() {
+                panic!(
+                    "Number {val} cannot be represented as a fixed-point number. If you want to approximate the number, set the `round_float` flag to true."
+                );
+            } else {
+                let int_part = rational.to_integer();
 
-                    let frac_log = frac_log.unwrap_or_else(|| panic!("unable to round the given value to a value representable with {frac_width} fractional bits"));
-                    if frac_log > frac_width {
-                        panic!("cannot represent value with {frac_width} fractional bits, requires at least {frac_log} bits");
-                    }
-
-                    let mut int_log =
-                        log2_round_down(&int_part.abs().to_biguint().unwrap());
-                    if (BigInt::from(1) << int_log) <= int_part.abs() {
-                        int_log += 1;
-                    }
-                    if signed {
-                        int_log += 1;
-                    }
-
-                    if int_log > int_width {
-                        let signed_str = if signed { "signed " } else { "" };
-
-                        panic!("cannot represent {signed_str}value of {val} with {int_width} integer bits, requires at least {int_log} bits");
-                    }
-
-                    rational.numer() << (frac_width - frac_log)
-                };
-
-                let bit_count = number.bits() + if signed { 1 } else { 0 };
-
-                if bit_count > (frac_width + int_width) as u64 {
-                    let difference = bit_count - frac_width as u64;
-                    panic!("The approximation of the number {val} cannot be represented with {frac_width} fractional bits and {int_width} integer bits. Requires at least {difference} integer bits.");
+                let frac_log = frac_log.unwrap_or_else(|| panic!("unable to round the given value to a value representable with {frac_width} fractional bits"));
+                if frac_log > frac_width {
+                    panic!(
+                        "cannot represent value with {frac_width} fractional bits, requires at least {frac_log} bits"
+                    );
                 }
 
-                sign_extend_vec(
-                    number.to_signed_bytes_le(),
-                    frac_width + int_width,
-                    signed,
-                )
-                    .into_iter()
-                    .take((frac_width + int_width).div_ceil(8) as usize)
-                    .collect::<Vec<_>>()
+                let mut int_log =
+                    log2_round_down(&int_part.abs().to_biguint().unwrap());
+                if (BigInt::from(1) << int_log) <= int_part.abs() {
+                    int_log += 1;
+                }
+                if signed {
+                    int_log += 1;
+                }
+
+                if int_log > int_width {
+                    let signed_str = if signed { "signed " } else { "" };
+
+                    panic!(
+                        "cannot represent {signed_str}value of {val} with {int_width} integer bits, requires at least {int_log} bits"
+                    );
+                }
+
+                rational.numer() << (frac_width - frac_log)
+            };
+
+            let bit_count = number.bits() + if signed { 1 } else { 0 };
+
+            if bit_count > (frac_width + int_width) as u64 {
+                let difference = bit_count - frac_width as u64;
+                panic!(
+                    "The approximation of the number {val} cannot be represented with {frac_width} fractional bits and {int_width} integer bits. Requires at least {difference} integer bits."
+                );
             }
-        cider::serialization::FormatInfo::IEEFloat { width, .. } => {
-            match width {
-                32 => Vec::from((val as f32).to_le_bytes().as_slice()),
-                64 => Vec::from(val.to_le_bytes().as_slice()),
-                _ => unreachable!("Unsupported width {width}. Only 32 and 64 bit floats are supported.")
-            }
+
+            sign_extend_vec(
+                number.to_signed_bytes_le(),
+                frac_width + int_width,
+                signed,
+            )
+            .into_iter()
+            .take((frac_width + int_width).div_ceil(8) as usize)
+            .collect::<Vec<_>>()
         }
+        cider::serialization::FormatInfo::IEEFloat { width, .. } => match width
+        {
+            32 => Vec::from((val as f32).to_le_bytes().as_slice()),
+            64 => Vec::from(val.to_le_bytes().as_slice()),
+            _ => unreachable!(
+                "Unsupported width {width}. Only 32 and 64 bit floats are supported."
+            ),
+        },
         _ => panic!("Called unroll_float on a non-fixed point type"),
     }
 }
@@ -454,8 +458,8 @@ mod tests {
         }
     }
 
-    fn format_info_generator(
-    ) -> impl Strategy<Value = crate::json_data::FormatInfo> {
+    fn format_info_generator()
+    -> impl Strategy<Value = crate::json_data::FormatInfo> {
         prop_oneof![arb_format_info_bitnum(), arb_format_info_fixed()]
     }
 

--- a/tools/cider-data-converter/src/dat_parser.rs
+++ b/tools/cider-data-converter/src/dat_parser.rs
@@ -1,12 +1,12 @@
 use nom::{
+    IResult,
     branch::alt,
     bytes::complete::{tag, take_while_m_n},
     character::complete::{anychar, line_ending, multispace0},
     combinator::{eof, map_res, opt},
     error::Error,
-    multi::{many1, many_till},
+    multi::{many_till, many1},
     sequence::{preceded, tuple},
-    IResult,
 };
 
 fn is_hex_digit(c: char) -> bool {

--- a/tools/cider-data-converter/src/json_data.rs
+++ b/tools/cider-data-converter/src/json_data.rs
@@ -436,9 +436,10 @@ impl DataVec {
 
                 // Check that sizes are the same across each dimension
                 assert!(v1.iter().all(|v2| { v2.len() == v1_0_size }));
-                assert!(v1
-                    .iter()
-                    .all(|v2| v2.iter().all(|v3| v3.len() == v1_0_0_size)));
+                assert!(
+                    v1.iter()
+                        .all(|v2| v2.iter().all(|v3| v3.len() == v1_0_0_size))
+                );
                 v1.len() * v1_0_size * v1_0_0_size
             }
             DataVec::Id4(v1) => {
@@ -447,12 +448,16 @@ impl DataVec {
                 let v1_0_0_0_size = v1[0][0][0].len();
                 // Check that sizes are the same across each dimension
                 assert!(v1.iter().all(|v2| { v2.len() == v1_0_size }));
-                assert!(v1
-                    .iter()
-                    .all(|v2| { v2.iter().all(|v3| v3.len() == v1_0_0_size) }));
-                assert!(v1.iter().all(|v2| v2
-                    .iter()
-                    .all(|v3| v3.iter().all(|v4| v4.len() == v1_0_0_0_size))));
+                assert!(
+                    v1.iter().all(|v2| {
+                        v2.iter().all(|v3| v3.len() == v1_0_0_size)
+                    })
+                );
+                assert!(
+                    v1.iter().all(|v2| v2.iter().all(|v3| v3
+                        .iter()
+                        .all(|v4| v4.len() == v1_0_0_0_size)))
+                );
 
                 v1.len() * v1_0_size * v1_0_0_size * v1_0_0_0_size
             }
@@ -470,9 +475,10 @@ impl DataVec {
 
                 // Check that sizes are the same across each dimension
                 assert!(v1.iter().all(|v2| { v2.len() == v1_0_size }));
-                assert!(v1
-                    .iter()
-                    .all(|v2| v2.iter().all(|v3| v3.len() == v1_0_0_size)));
+                assert!(
+                    v1.iter()
+                        .all(|v2| v2.iter().all(|v3| v3.len() == v1_0_0_size))
+                );
                 v1.len() * v1_0_size * v1_0_0_size
             }
             DataVec::Fd4(v1) => {
@@ -481,12 +487,16 @@ impl DataVec {
                 let v1_0_0_0_size = v1[0][0][0].len();
                 // Check that sizes are the same across each dimension
                 assert!(v1.iter().all(|v2| { v2.len() == v1_0_size }));
-                assert!(v1
-                    .iter()
-                    .all(|v2| { v2.iter().all(|v3| v3.len() == v1_0_0_size) }));
-                assert!(v1.iter().all(|v2| v2
-                    .iter()
-                    .all(|v3| v3.iter().all(|v4| v4.len() == v1_0_0_0_size))));
+                assert!(
+                    v1.iter().all(|v2| {
+                        v2.iter().all(|v3| v3.len() == v1_0_0_size)
+                    })
+                );
+                assert!(
+                    v1.iter().all(|v2| v2.iter().all(|v3| v3
+                        .iter()
+                        .all(|v4| v4.len() == v1_0_0_0_size)))
+                );
 
                 v1.len() * v1_0_size * v1_0_0_size * v1_0_0_0_size
             }

--- a/tools/cider-data-converter/src/main.rs
+++ b/tools/cider-data-converter/src/main.rs
@@ -27,7 +27,9 @@ enum CiderDataConverterError {
     #[error("Failed to parse \"to\" argument: {0}")]
     BadToArgument(String),
 
-    #[error("Unable to guess the conversion target. Please specify the target using the \"--to\" argument")]
+    #[error(
+        "Unable to guess the conversion target. Please specify the target using the \"--to\" argument"
+    )]
     UnknownTarget,
 
     #[error(transparent)]
@@ -116,22 +118,22 @@ fn main() -> Result<(), CiderDataConverterError> {
     if opts.action.is_none()
         // input is .json
         && (opts.input_path.as_ref().is_some_and(|x| {
-            x.extension().map_or(false, |y| y == JSON_EXTENSION)
+            x.extension().is_some_and(|y| y == JSON_EXTENSION)
         })
         // output is .dump
         || opts.output_path.as_ref().is_some_and(|x| {
-            x.extension().map_or(false, |y| y == CIDER_EXTENSION)
+            x.extension().is_some_and(|y| y == CIDER_EXTENSION)
         }))
     {
         opts.action = Some(Target::DataDump);
     } else if opts.action.is_none()
         // output is .json
         && (opts.output_path.as_ref().is_some_and(|x| {
-            x.extension().map_or(false, |x| x == JSON_EXTENSION)
+            x.extension().is_some_and(|x| x == JSON_EXTENSION)
         })
         // input is .dump
         || opts.input_path.as_ref().is_some_and(|x| {
-            x.extension().map_or(false, |x| x == CIDER_EXTENSION)
+            x.extension().is_some_and(|x| x == CIDER_EXTENSION)
         })
         // input is a directory (suggesting a deserialization from dat)
         || opts.input_path.as_ref().is_some_and(|x| x.is_dir()))

--- a/tools/data-conversion/src/main.rs
+++ b/tools/data-conversion/src/main.rs
@@ -98,7 +98,7 @@ fn main() {
 
 /// Converts [filepath_get] from type [convert_from] to type
 /// [convert_to] in [filepath_send]
-
+///
 /// # Arguments
 ///
 /// * `filepath_get` - A reference to a `String` representing the path to the input file

--- a/tools/data-conversion/src/main.rs
+++ b/tools/data-conversion/src/main.rs
@@ -1,8 +1,8 @@
 //use std::env;
 use argh::FromArgs;
 use std::fmt;
-use std::fs::read_to_string;
 use std::fs::File;
+use std::fs::read_to_string;
 use std::io::stdout;
 use std::io::{self, Write};
 use std::str::FromStr;

--- a/tools/data_gen/Cargo.toml
+++ b/tools/data_gen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "data_gen"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tools/data_gen/src/main.rs
+++ b/tools/data_gen/src/main.rs
@@ -4,7 +4,7 @@ use calyx_ir as ir;
 use calyx_ir::utils::GetMemInfo;
 use calyx_utils::CalyxResult;
 use rand::Rng;
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 

--- a/tools/fileinfo_emitter/src/main.rs
+++ b/tools/fileinfo_emitter/src/main.rs
@@ -1,7 +1,7 @@
 use argh::FromArgs;
 use calyx_frontend::{
-    self as frontend, source_info::PositionId, source_info::SourceInfoTable,
-    source_info::SourceLocation, SetAttr, SetAttribute,
+    self as frontend, SetAttr, SetAttribute, source_info::PositionId,
+    source_info::SourceInfoTable, source_info::SourceLocation,
 };
 use calyx_ir::{self as ir, Id};
 use calyx_utils::{CalyxResult, OutputFile};


### PR DESCRIPTION
Bumps the rust version to 1.85 and the edition to 2024. Most of the changes related to lifetime elision and match statements. 

Unfortunately, there have also been updates to the formatter, which has resulted in a large diff. There's not much I can do about that, but I hope it doesn't end up too confusing.

`cargo fix --edition` only wanted to make one change that ultimately wasn't needed.