### PR TITLE
[Profiler] Fix compiler pass order for profiling

### DIFF
--- a/calyx/opt/src/default_passes.rs
+++ b/calyx/opt/src/default_passes.rs
@@ -161,12 +161,16 @@ impl PassManager {
             pm,
             "profiler",
             [
+                "validate",
                 StaticInliner,
                 CompileStatic,
                 CompileRepeat,
                 CompileInvoke,
                 ProfilerInstrumentation,
-                "all"
+                "pre-opt",
+                "compile",
+                "post-opt",
+                "lower"
             ]
         );
 

--- a/fud2/scripts/profiler.rhai
+++ b/fud2/scripts/profiler.rhai
@@ -8,8 +8,8 @@ export const flamegraph = state("flamegraph", ["svg"]);
 fn profiling_setup(e) {
     e.var_("cells", "cells.json");
 
-    // series of passes after instrumentation?
-    e.config_var_or("passes", "profiler.compilation-passes", "-p all"); // set passes="-p no-opt" to run without optimizations
+    // series of passes after validation and instrumentation
+    e.config_var_or("passes", "profiler.compilation-passes", "-p pre-opt -p compile -p post-opt -p lower"); // set passes="-p compile-sync -p simplify-with-control -p compile-invoke -p compile -p lower" to run without optimizations
 
     // eDSL python file arguments
     e.config_var_or("edsl-args", "profiler.edsl-args", "");
@@ -56,7 +56,7 @@ fn edsl_to_flamegraph(e, input, output) {
     e.build_cmd(["$cells"], "component-cells", [calyx], []);
     e.build_cmd([instrumented_verilog], "calyx", [calyx], []);
     e.arg("backend", "verilog");
-    e.arg("args", "-p static-inline -p compile-static -p compile-repeat -p compile-invoke -p profiler-instrumentation $passes");
+    e.arg("args", "-p validate -p static-inline -p compile-static -p compile-repeat -p compile-invoke -p profiler-instrumentation $passes");
 
     let instrumented_sim = "instrumented.exe";
     // verilog --> sim; adapted from verilator::verilator_build()
@@ -95,7 +95,7 @@ fn calyx_to_flamegraph(e, input, output) {
     e.build_cmd(["$cells"], "component-cells", [input], []);
     e.build_cmd([instrumented_verilog], "calyx", [input], []);
     e.arg("backend", "verilog");
-    e.arg("args", "-p static-inline -p compile-static -p compile-repeat -p compile-invoke -p profiler-instrumentation $passes");
+    e.arg("args", "-p validate -p static-inline -p compile-static -p compile-repeat -p compile-invoke -p profiler-instrumentation $passes");
 
     let instrumented_sim = "instrumented.exe";
     // verilog --> sim; adapted from verilator::verilator_build()

--- a/fud2/tests/snapshots/tests__test@plan_calyx-py-profiler.snap
+++ b/fud2/tests/snapshots/tests__test@plan_calyx-py-profiler.snap
@@ -20,7 +20,7 @@ rule calyx-cider
   command = $calyx-exe -l $calyx-lib-path $cider-calyx-passes $args $in > $out
 
 cells = cells.json
-passes = -p all
+passes = -p pre-opt -p compile -p post-opt -p lower
 edsl-args = 
 component_cells = $calyx-base/target/debug/component_cells
 rule component-cells
@@ -56,7 +56,7 @@ build $metadata-mapping-json: parse-metadata calyx.futil
 build $cells: component-cells calyx.futil
 build instrumented.sv: calyx calyx.futil
   backend = verilog
-  args = -p static-inline -p compile-static -p compile-repeat -p compile-invoke -p profiler-instrumentation $passes
+  args = -p validate -p static-inline -p compile-static -p compile-repeat -p compile-invoke -p profiler-instrumentation $passes
 build verilator-out/Vtoplevel: verilator-compile-standalone-tb instrumented.sv | tb.sv
   out-dir = verilator-out
 build instrumented.exe: cp verilator-out/Vtoplevel

--- a/fud2/tests/snapshots/tests__test@plan_profiler.snap
+++ b/fud2/tests/snapshots/tests__test@plan_profiler.snap
@@ -20,7 +20,7 @@ rule calyx-cider
   command = $calyx-exe -l $calyx-lib-path $cider-calyx-passes $args $in > $out
 
 cells = cells.json
-passes = -p all
+passes = -p pre-opt -p compile -p post-opt -p lower
 edsl-args = 
 component_cells = $calyx-base/target/debug/component_cells
 rule component-cells
@@ -54,7 +54,7 @@ cycle-limit = 500000000
 build $cells: component-cells /input.ext
 build instrumented.sv: calyx /input.ext
   backend = verilog
-  args = -p static-inline -p compile-static -p compile-repeat -p compile-invoke -p profiler-instrumentation $passes
+  args = -p validate -p static-inline -p compile-static -p compile-repeat -p compile-invoke -p profiler-instrumentation $passes
 build verilator-out/Vtoplevel: verilator-compile-standalone-tb instrumented.sv | tb.sv
   out-dir = verilator-out
 build instrumented.exe: cp verilator-out/Vtoplevel


### PR DESCRIPTION
The pass order used for profiling (both in the `-p profiler` pass and set in fud2) was buggy since validation of the original program would happen _after_ the profiler-specific compiler passes. When profiling, we compile static groups before instrumentation (because we can't directly instrument static groups), so validation fails when an (originally static) group uses a static cell, such as `pipelined_mult`.

Thanks @pedropontesgarcia for trying out the profiler and letting me know about this!