### PR TITLE
[Cider] Extend `step-over` for easier debugging of infinite/long groups

### DIFF
--- a/cider/src/debugger/commands/command_parser.rs
+++ b/cider/src/debugger/commands/command_parser.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use super::{
     PrintCommand,
     core::{
@@ -185,7 +187,10 @@ impl CommandParser {
 
     fn step_over(input: Node) -> ParseResult<Command> {
         Ok(match_nodes!(input.into_children();
-            [group(g)] => Command::StepOver(g)
+            [group(g)] => Command::StepOver(g, None),
+            [group(g), num(n)] => {
+               Command::StepOver(g, NonZeroU32::new(n))
+            }
         ))
     }
 

--- a/cider/src/debugger/commands/commands.pest
+++ b/cider/src/debugger/commands/commands.pest
@@ -14,7 +14,7 @@ pc_s       = { ^"s" }
 pc_ufx     = { ^"u." ~ num }
 pc_sfx     = { ^"s." ~ num }
 code_calyx = { ^"calyx" }
-code_nodes = {^"nodes"}
+code_nodes = { ^"nodes" }
 
 print_code =  {
     "\\" ~ (pc_ufx | pc_sfx | pc_s | pc_un)
@@ -40,7 +40,7 @@ watch = {
     (^"watch " | ^"w ") ~ (watch_position)? ~ group ~ (^"with")? ~ (print_state | print)
 }
 
-step_over = { ^"step-over" ~ group }
+step_over = { ^"step-over" ~ group ~ num? }
 
 step       = { (^"step" | ^"s") ~ num? }
 cont       = {

--- a/cider/src/debugger/commands/core.rs
+++ b/cider/src/debugger/commands/core.rs
@@ -4,6 +4,7 @@ use itertools::{self, Itertools};
 use std::{
     fmt::{Display, Write},
     marker::PhantomData,
+    num::NonZeroU32,
 };
 
 use crate::{
@@ -381,7 +382,7 @@ pub enum Command {
     /// Delete the given watchpoints.
     DeleteWatch(Vec<ParsedBreakPointID>),
     /// Advance the execution until the given group is no longer running.
-    StepOver(ParsedGroupName),
+    StepOver(ParsedGroupName, Option<NonZeroU32>),
     /// Create a watchpoint
     Watch(
         ParsedGroupName,
@@ -489,8 +490,10 @@ static COMMAND_INFO: LazyLock<Box<[CommandInfo]>> = LazyLock::new(|| {
                 .usage("> s").usage("> s 5").build(),
             // step-over
             CIBuilder::new().invocation("step-over")
-                .description("Advance the execution over a given group.")
-                .usage("> step-over this_group").build(),
+                .description("Advance the execution over a given group. Takes an optional number of cycles after which control should be returned even if the group is still running.")
+                .usage("> step-over this_group")
+                .usage("> step-over infinite_group 50")
+                .build(),
             // continue
             CIBuilder::new().invocation("continue")
                 .invocation("c")

--- a/cider/tests/debugger/infinite_group.expect
+++ b/cider/tests/debugger/infinite_group.expect
@@ -1,0 +1,9 @@
+
+---STDERR---
+==== [1mCider[0m: The [4mC[0malyx [4mI[0mnterpreter and [4mDe[0mbugge[4mr[0m ====
+main::write_reg1
+main::write_reg1
+main::write_reg1
+Bound reached, group is still running.
+main::write_reg1
+Exiting.

--- a/cider/tests/debugger/infinite_group.futil
+++ b/cider/tests/debugger/infinite_group.futil
@@ -1,0 +1,21 @@
+import "primitives/core.futil";
+
+
+component main() -> () {
+    cells {
+        reg1 = std_reg(32);
+        reg2 = std_reg(32);
+    }
+
+    wires {
+        group write_reg1 {
+            reg2.write_en = 1'd1;
+            reg2.in = 32'd15;
+            write_reg1[done] = reg1.done; // oops! This done signal will never go high
+        }
+    }
+
+    control {
+        write_reg1;
+    }
+}

--- a/cider/tests/debugger/infinite_group.futil.commands
+++ b/cider/tests/debugger/infinite_group.futil.commands
@@ -1,0 +1,7 @@
+pc
+s
+pc
+s 10
+pc
+step-over write_reg1 4000
+pc


### PR DESCRIPTION
Inspired by some attempts to debug an infinite loop or group running longer than expected, this PR adds an optional bound `n` to the `step-over` command. When present, the debugger will return control to the user after `n` cycles if the group is still running. If not provided, the behavior is the same as before, where it will continue to run until the group exits. In the case of non-terminating groups, this leads to an indefinite hang.