### PR TITLE
[Cider] Reimplement the display command

### DIFF
--- a/cider/idx/src/index_trait.rs
+++ b/cider/idx/src/index_trait.rs
@@ -115,6 +115,10 @@ impl<I: IndexRef + PartialOrd> SplitIndexRange<I> {
     pub fn iter_all(&self) -> OwnedIndexRangeIterator<I> {
         OwnedIndexRangeIterator::new(IndexRange::new(self.start, self.end))
     }
+
+    pub fn contains(&self, item: I) -> bool {
+        item >= self.start && item < self.end
+    }
 }
 
 impl<I> IntoIterator for IndexRange<I>

--- a/cider/src/debugger/commands/core.rs
+++ b/cider/src/debugger/commands/core.rs
@@ -501,7 +501,7 @@ static COMMAND_INFO: LazyLock<Box<[CommandInfo]>> = LazyLock::new(|| {
             // display
             CIBuilder::new().invocation("display")
                 .invocation("d")
-                .description("Display the full state of the main component").build(),
+                .description("Prints the ports for all cells that appear in the currently active groups").build(),
             // print
             CIBuilder::new().invocation("print")
                 .invocation("p")

--- a/cider/src/debugger/debugger_core.rs
+++ b/cider/src/debugger/debugger_core.rs
@@ -334,7 +334,16 @@ impl<C: AsRef<Context> + Clone> Debugger<C> {
                 Command::Continue => self.do_continue()?,
                 Command::Empty => {}
                 Command::Display => {
-                    println!("COMMAND NOT YET IMPLEMENTED");
+                    for cell in self.interpreter.iter_active_cells() {
+                        println!(
+                            "{}",
+                            self.interpreter.format_cell_ports(
+                                cell,
+                                PrintCode::Binary,
+                                None
+                            )
+                        )
+                    }
                 }
                 Command::Print(print_lists, code, print_mode) => {
                     for target in print_lists {

--- a/cider/src/flatten/flat_ir/control/translator.rs
+++ b/cider/src/flatten/flat_ir/control/translator.rs
@@ -1,6 +1,4 @@
-use std::collections::HashSet;
-
-use ahash::{HashMap, HashMapExt};
+use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use calyx_frontend::{SetAttr, source_info::PositionId};
 use calyx_ir::GetAttributes;
 use calyx_ir::{self as cir, NumAttr, RRC};
@@ -22,7 +20,10 @@ use crate::{
                 Assignment, AssignmentIdx, CellRef, CombGroup, CombGroupIdx,
                 ComponentIdx, GroupIdx, GuardIdx, PortRef,
             },
-            wires::{core::Group, guards::Guard},
+            wires::{
+                core::Group,
+                guards::{Guard, PortComp},
+            },
         },
         structures::context::{
             Context, InterpretationContext, SecondaryContext,
@@ -32,9 +33,59 @@ use crate::{
 
 use super::{structures::*, utils::CompTraversal};
 
+/// A transient version of guards that exists during translation to allow
+/// hashing, and consequently Hash-consing the flattened guards.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+enum TranslationGuard {
+    True,
+    Or(Box<TranslationGuard>, Box<TranslationGuard>),
+    And(Box<TranslationGuard>, Box<TranslationGuard>),
+    Not(Box<TranslationGuard>),
+    Comp(PortComp, PortRef, PortRef),
+    Port(PortRef),
+}
+
+impl TranslationGuard {
+    fn translate(
+        guard: &cir::Guard<cir::Nothing>,
+        mapper: &PortMapper,
+    ) -> Self {
+        // TODO griffin: make this not recursive? Probably not a huge issue
+        // right now
+        match guard {
+            calyx_ir::Guard::Or(guard, guard1) => Self::Or(
+                Box::new(Self::translate(guard, mapper)),
+                Box::new(Self::translate(guard1, mapper)),
+            ),
+            calyx_ir::Guard::And(guard, guard1) => Self::And(
+                Box::new(Self::translate(guard, mapper)),
+                Box::new(Self::translate(guard1, mapper)),
+            ),
+            calyx_ir::Guard::Not(guard) => {
+                Self::Not(Box::new(Self::translate(guard, mapper)))
+            }
+            calyx_ir::Guard::True => Self::True,
+            calyx_ir::Guard::CompOp(port_comp, ref_cell, ref_cell1) => {
+                Self::Comp(
+                    port_comp.into(),
+                    mapper[&ref_cell.as_raw()],
+                    mapper[&ref_cell1.as_raw()],
+                )
+            }
+            calyx_ir::Guard::Port(ref_cell) => {
+                Self::Port(mapper[&ref_cell.as_raw()])
+            }
+            calyx_ir::Guard::Info(_) => {
+                todo!("Guard::Info(_) is not currently supported")
+            }
+        }
+    }
+}
+
 type PortMapper = HashMap<*const cir::Port, PortRef>;
 type CellMapper = HashMap<*const cir::Cell, CellRef>;
 type ComponentMapper = HashMap<cir::Id, ComponentIdx>;
+type GuardHashConsMap = HashMap<TranslationGuard, GuardIdx>;
 
 /// An ephemeral structure used during the translation of a component.
 pub struct GroupMapper {
@@ -46,13 +97,19 @@ pub fn translate(orig_ctx: &cir::Context) -> Context {
     let mut ctx = Context::new(orig_ctx.source_info_table.clone());
 
     let mut component_id_map = ComponentMapper::new();
+    let mut hash_cons_map = GuardHashConsMap::new();
 
     // TODO (griffin)
     // the current component traversal is not well equipped for immutable
     // iteration over the components in a post-order so this is a hack instead
 
     for comp in CompTraversal::new(&orig_ctx.components).iter() {
-        translate_component(comp, &mut ctx, &mut component_id_map);
+        translate_component(
+            comp,
+            &mut ctx,
+            &mut component_id_map,
+            &mut hash_cons_map,
+        );
     }
 
     ctx.entry_point = *component_id_map
@@ -67,12 +124,14 @@ fn translate_group(
     group: &cir::Group,
     ctx: &mut Context,
     map: &PortMapper,
+    hash_cons_map: &mut GuardHashConsMap,
 ) -> Group {
     let id = ctx.secondary.string_table.insert(group.name());
     let base = ctx.primary.assignments.peek_next_idx();
 
     for assign in group.assignments.iter() {
-        let assign_new = translate_assignment(assign, &mut ctx.primary, map);
+        let assign_new =
+            translate_assignment(assign, &mut ctx.primary, map, hash_cons_map);
         ctx.primary.assignments.push(assign_new);
     }
 
@@ -92,12 +151,14 @@ fn translate_comb_group(
     comb_group: &cir::CombGroup,
     ctx: &mut Context,
     map: &PortMapper,
+    hash_cons_map: &mut GuardHashConsMap,
 ) -> CombGroup {
     let identifier = ctx.secondary.string_table.insert(comb_group.name());
     let base = ctx.primary.assignments.peek_next_idx();
 
     for assign in comb_group.assignments.iter() {
-        let assign_new = translate_assignment(assign, &mut ctx.primary, map);
+        let assign_new =
+            translate_assignment(assign, &mut ctx.primary, map, hash_cons_map);
         ctx.primary.assignments.push(assign_new);
     }
 
@@ -112,11 +173,12 @@ fn translate_assignment(
     assign: &cir::Assignment<cir::Nothing>,
     interp_ctx: &mut InterpretationContext,
     map: &PortMapper,
+    hash_cons_map: &mut GuardHashConsMap,
 ) -> Assignment {
     Assignment {
         dst: map[&assign.dst.as_raw()],
         src: map[&assign.src.as_raw()],
-        guard: translate_guard(&assign.guard, interp_ctx, map),
+        guard: translate_guard(&assign.guard, interp_ctx, map, hash_cons_map),
     }
 }
 #[must_use]
@@ -124,8 +186,20 @@ fn translate_guard(
     guard: &cir::Guard<cir::Nothing>,
     interp_ctx: &mut InterpretationContext,
     map: &PortMapper,
+    hash_cons_map: &mut GuardHashConsMap,
 ) -> GuardIdx {
-    let idx = flatten_tree(guard, None, &mut interp_ctx.guards, map);
+    let guard = TranslationGuard::translate(guard, map);
+
+    if let Some(idx) = hash_cons_map.get(&guard) {
+        return *idx;
+    }
+
+    let idx =
+        flatten_tree(&guard, None, &mut interp_ctx.guards, &(), hash_cons_map);
+
+    // if we didn't exit early, the full guard needs to be added to hash-cons
+    // map. The sub-guards will have already been added during flattening
+    hash_cons_map.insert(guard, idx);
 
     // not worth trying to force this search traversal into the flatten trait so
     // I'm just gonna opt for this. It's a onetime cost, so I'm not particularly
@@ -170,6 +244,7 @@ fn translate_component(
     comp: &cir::Component,
     ctx: &mut Context,
     component_id_map: &mut ComponentMapper,
+    hash_cons_map: &mut GuardHashConsMap,
 ) -> ComponentIdx {
     let mut auxiliary_component_info = AuxiliaryComponentInfo::new_with_name(
         ctx.secondary.string_table.insert(comp.name),
@@ -185,8 +260,12 @@ fn translate_component(
     // Continuous Assignments
     let cont_assignment_base = ctx.primary.assignments.peek_next_idx();
     for assign in &comp.continuous_assignments {
-        let assign_new =
-            translate_assignment(assign, &mut ctx.primary, &layout.port_map);
+        let assign_new = translate_assignment(
+            assign,
+            &mut ctx.primary,
+            &layout.port_map,
+            hash_cons_map,
+        );
         ctx.primary.assignments.push(assign_new);
     }
 
@@ -202,7 +281,8 @@ fn translate_component(
 
     for group in comp.groups.iter() {
         let group_brw = group.borrow();
-        let group_idx = translate_group(&group_brw, ctx, &layout.port_map);
+        let group_idx =
+            translate_group(&group_brw, ctx, &layout.port_map, hash_cons_map);
         let k = ctx.primary.groups.push(group_idx);
         group_map.insert(group.as_raw(), k);
     }
@@ -215,8 +295,12 @@ fn translate_component(
 
     for comb_grp in comp.comb_groups.iter() {
         let comb_grp_brw = comb_grp.borrow();
-        let comb_grp_idx =
-            translate_comb_group(&comb_grp_brw, ctx, &layout.port_map);
+        let comb_grp_idx = translate_comb_group(
+            &comb_grp_brw,
+            ctx,
+            &layout.port_map,
+            hash_cons_map,
+        );
         let k = ctx.primary.comb_groups.push(comb_grp_idx);
         comb_group_map.insert(comb_grp.as_raw(), k);
     }
@@ -253,6 +337,7 @@ fn translate_component(
                 None,
                 &mut taken_control,
                 &argument_tuple,
+                &mut (),
             );
             Some(ctrl_node)
         };
@@ -582,47 +667,48 @@ fn is_primitive(cell_ref: &std::cell::Ref<cir::Cell>) -> bool {
         || matches!(&cell_ref.prototype, cir::CellType::Constant { .. })
 }
 
-impl FlattenTree for cir::Guard<cir::Nothing> {
+impl FlattenTree for TranslationGuard {
     type Output = Guard;
     type IdxType = GuardIdx;
-    type AuxiliaryData = PortMapper;
+    type AuxiliaryData = ();
+    type MutAuxiliaryData = GuardHashConsMap;
 
     fn process_element<'data>(
         &'data self,
         mut handle: SingleHandle<'_, 'data, Self, Self::IdxType, Self::Output>,
-        aux: &Self::AuxiliaryData,
+        _: &Self::AuxiliaryData,
+        cons_map: &mut Self::MutAuxiliaryData,
     ) -> Self::Output {
         match self {
-            cir::Guard::Or(a, b) => {
-                Guard::Or(handle.enqueue(a), handle.enqueue(b))
-            }
-            cir::Guard::And(a, b) => {
-                Guard::And(handle.enqueue(a), handle.enqueue(b))
-            }
-            cir::Guard::Not(n) => Guard::Not(handle.enqueue(n)),
-            cir::Guard::True => Guard::True,
-            cir::Guard::CompOp(op, a, b) => Guard::Comp(
-                op.clone(),
-                *aux.get(&a.as_raw()).unwrap(),
-                *aux.get(&b.as_raw()).unwrap(),
+            TranslationGuard::Or(a, b) => Guard::Or(
+                *cons_map.entry(*a.clone()).or_insert(handle.enqueue(a)),
+                *cons_map.entry(*b.clone()).or_insert(handle.enqueue(b)),
             ),
-            cir::Guard::Port(p) => Guard::Port(*aux.get(&p.as_raw()).unwrap()),
-            cir::Guard::Info(_) => panic!("Guard::Info(_) not handled yet"),
+            TranslationGuard::And(a, b) => Guard::And(
+                *cons_map.entry(*a.clone()).or_insert(handle.enqueue(a)),
+                *cons_map.entry(*b.clone()).or_insert(handle.enqueue(b)),
+            ),
+            TranslationGuard::Not(n) => Guard::Not(
+                *cons_map.entry(*n.clone()).or_insert(handle.enqueue(n)),
+            ),
+            TranslationGuard::True => Guard::True,
+            TranslationGuard::Comp(op, a, b) => Guard::Comp(*op, *a, *b),
+            TranslationGuard::Port(p) => Guard::Port(*p),
         }
     }
 }
 
 impl FlattenTree for cir::Control {
     type Output = ControlNode;
-
     type IdxType = ControlIdx;
-
     type AuxiliaryData = (GroupMapper, Layout, Context, AuxiliaryComponentInfo);
+    type MutAuxiliaryData = ();
 
     fn process_element<'data>(
         &'data self,
         mut handle: SingleHandle<'_, 'data, Self, Self::IdxType, Self::Output>,
         aux: &Self::AuxiliaryData,
+        _: &mut Self::MutAuxiliaryData,
     ) -> Self::Output {
         let (group_map, layout, ctx, comp_info) = aux;
         let ctrl = match self {

--- a/cider/src/flatten/flat_ir/flatten_trait.rs
+++ b/cider/src/flatten/flat_ir/flatten_trait.rs
@@ -85,29 +85,38 @@ pub trait FlattenTree: Sized {
     type Output;
     type IdxType: IndexRef;
     type AuxiliaryData;
+    type MutAuxiliaryData;
 
     fn process_element<'data>(
         &'data self,
         handle: SingleHandle<'_, 'data, Self, Self::IdxType, Self::Output>,
         aux: &Self::AuxiliaryData,
+        mut_aux: &mut Self::MutAuxiliaryData,
     ) -> Self::Output;
 }
 
-pub fn flatten_tree<In, Idx, Out, Aux>(
+pub fn flatten_tree<In, Idx, Out, Aux, MutAux>(
     root_node: &In,
     base: Option<Idx>,
     vec: &mut IndexedMap<Idx, Out>,
     aux: &Aux,
+    mut_aux: &mut MutAux,
 ) -> Idx
 where
     Idx: IndexRef,
-    In: FlattenTree<Output = Out, IdxType = Idx, AuxiliaryData = Aux>,
+    In: FlattenTree<
+            Output = Out,
+            IdxType = Idx,
+            AuxiliaryData = Aux,
+            MutAuxiliaryData = MutAux,
+        >,
 {
     let mut handle = VecHandle::new(vec, root_node, base);
     let mut root_node_idx: Option<Idx> = None;
 
     while let Some(node) = handle.next_element() {
-        let res = node.process_element(handle.produce_limited_handle(), aux);
+        let res =
+            node.process_element(handle.produce_limited_handle(), aux, mut_aux);
         root_node_idx.get_or_insert(handle.finish_processing(res));
     }
 

--- a/cider/src/flatten/flat_ir/wires/guards.rs
+++ b/cider/src/flatten/flat_ir/wires/guards.rs
@@ -1,10 +1,48 @@
-use calyx_ir::PortComp;
+use calyx_ir as cir;
 use cider_idx::maps::IndexedMap;
 
 use crate::flatten::flat_ir::prelude::{GuardIdx, PortRef};
 
 /// A map storing all the guards defined in the program
 pub type GuardMap = IndexedMap<GuardIdx, Guard>;
+
+/// The comparison operator between two ports. This re-implementation exists
+/// solely to derive Hash on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PortComp {
+    Eq,
+    Neq,
+    Gt,
+    Lt,
+    Geq,
+    Leq,
+}
+
+impl PortComp {
+    pub fn to_str(&self) -> &str {
+        match self {
+            PortComp::Eq => "==",
+            PortComp::Neq => "!=",
+            PortComp::Gt => ">",
+            PortComp::Lt => "<",
+            PortComp::Geq => ">=",
+            PortComp::Leq => "<=",
+        }
+    }
+}
+
+impl From<&cir::PortComp> for PortComp {
+    fn from(value: &cir::PortComp) -> Self {
+        match value {
+            calyx_ir::PortComp::Eq => Self::Eq,
+            calyx_ir::PortComp::Neq => Self::Neq,
+            calyx_ir::PortComp::Gt => Self::Gt,
+            calyx_ir::PortComp::Lt => Self::Lt,
+            calyx_ir::PortComp::Geq => Self::Geq,
+            calyx_ir::PortComp::Leq => Self::Leq,
+        }
+    }
+}
 
 /// A boolean expression that determines whether an assignment fires. Analogue
 /// of [calyx_ir::Guard]

--- a/cider/src/flatten/structures/environment/env.rs
+++ b/cider/src/flatten/structures/environment/env.rs
@@ -24,7 +24,7 @@ use crate::{
             },
             cell_prototype::{CellPrototype, SingleWidthType},
             prelude::*,
-            wires::guards::Guard,
+            wires::guards::{Guard, PortComp},
         },
         primitives::{
             self, Primitive,
@@ -2640,12 +2640,12 @@ impl<C: AsRef<Context> + Clone> BaseSimulator<C> {
                 let a_val = self.env.ports[a].val()?;
                 let b_val = self.env.ports[b].val()?;
                 match c {
-                    calyx_ir::PortComp::Eq => a_val == b_val,
-                    calyx_ir::PortComp::Neq => a_val != b_val,
-                    calyx_ir::PortComp::Gt => a_val.is_greater(b_val),
-                    calyx_ir::PortComp::Lt => a_val.is_less(b_val),
-                    calyx_ir::PortComp::Geq => a_val.is_greater_or_equal(b_val),
-                    calyx_ir::PortComp::Leq => a_val.is_less_or_equal(b_val),
+                    PortComp::Eq => a_val == b_val,
+                    PortComp::Neq => a_val != b_val,
+                    PortComp::Gt => a_val.is_greater(b_val),
+                    PortComp::Lt => a_val.is_less(b_val),
+                    PortComp::Geq => a_val.is_greater_or_equal(b_val),
+                    PortComp::Leq => a_val.is_less_or_equal(b_val),
                 }
                 .into()
             }

--- a/cider/src/flatten/structures/printer.rs
+++ b/cider/src/flatten/structures/printer.rs
@@ -1,5 +1,3 @@
-use calyx_ir::PortComp;
-
 use crate::flatten::flat_ir::{
     cell_prototype::{CellPrototype, ConstantType},
     identifier::{CanonicalIdentifier, IdMap},
@@ -385,17 +383,6 @@ impl<'a> Printer<'a> {
         parent: ComponentIdx,
         guard: GuardIdx,
     ) -> String {
-        fn op_to_str(op: &PortComp) -> String {
-            match op {
-                PortComp::Eq => String::from("=="),
-                PortComp::Neq => String::from("!="),
-                PortComp::Gt => String::from(">"),
-                PortComp::Lt => String::from("<"),
-                PortComp::Geq => String::from(">="),
-                PortComp::Leq => String::from("<="),
-            }
-        }
-
         match &self.ctx.primary.guards[guard] {
             Guard::True => String::new(),
             Guard::Or(l, r) => {

--- a/cider/src/flatten/structures/printer.rs
+++ b/cider/src/flatten/structures/printer.rs
@@ -418,7 +418,7 @@ impl<'a> Printer<'a> {
                 format!(
                     "{} {} {}",
                     l.format_name(&self.ctx.secondary.string_table),
-                    op_to_str(op),
+                    op.to_str(),
                     r.format_name(&self.ctx.secondary.string_table)
                 )
             }

--- a/cider/src/flatten/text_utils.rs
+++ b/cider/src/flatten/text_utils.rs
@@ -91,6 +91,16 @@ pub trait Color: OwoColorize + Display {
         let style = Style::new().red();
         Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
     }
+
+    fn stylize_value(&self) -> impl Display {
+        let style = Style::new().bold();
+        Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
+    }
+
+    fn stylize_port_name(&self) -> impl Display {
+        let style = Style::new().yellow();
+        Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
+    }
 }
 
 impl<T: OwoColorize + Display> Color for T {}


### PR DESCRIPTION
Small PR which reimplements the display command which was left behind during the overhaul. Rather than dump the ports for all cells in the main components, as was the previous behavior, I've opted to make it only dump the ports for cells which are in currently executing groups. A limitation of this behavior is that groups which are on their last cycle, i.e. their done ports are high, will not be counted as active.

Also, I decided to hash cons the guards finally, though I am not sure why I decided to do this now.