### PR TITLE
Allow multiple library paths

### DIFF
--- a/benches/component-sharing.rs
+++ b/benches/component-sharing.rs
@@ -19,11 +19,11 @@ fn cell_share_bench(c: &mut Criterion) {
                         let name =
                             format!("benches/component-sharing/{}.futil", name);
                         let bench = Path::new(&name);
-                        let lib = Path::new(".");
+                        let lib = [Path::new(".").to_path_buf()];
 
                         let ws = frontend::Workspace::construct(
                             &Some(bench.into()),
-                            lib,
+                            &lib,
                         )
                         .unwrap();
 

--- a/calyx-lsp/src/diagnostic.rs
+++ b/calyx-lsp/src/diagnostic.rs
@@ -1,11 +1,10 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tower_lsp::lsp_types::{self as lspt};
 
 use calyx_opt::{
     passes::{Papercut, SynthesisPapercut, WellFormed},
     traversal::{ConstructVisitor, DiagnosticPass, Visitor},
 };
-use resolve_path::PathResolveExt;
 
 use crate::document::Document;
 
@@ -24,11 +23,11 @@ pub struct CalyxError {
 }
 
 impl Diagnostic {
-    /// Run the `calyx` compiler on `path` with libraries at `lib_path`
-    pub fn did_save(path: &Path, lib_path: &Path) -> Vec<CalyxError> {
+    /// Run the `calyx` compiler on `path` with libraries at `lib_paths`
+    pub fn did_save(path: &Path, lib_paths: &[PathBuf]) -> Vec<CalyxError> {
         calyx_frontend::Workspace::construct_shallow(
             &Some(path.to_path_buf()),
-            lib_path.resolve().as_ref(),
+            lib_paths,
         )
         .and_then(calyx_ir::from_ast::ast_to_ir)
         .and_then(|mut ctx| {

--- a/calyx/frontend/src/workspace.rs
+++ b/calyx/frontend/src/workspace.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use crate::{LibrarySignatures, source_info::SourceInfoTable};
 use calyx_utils::{CalyxResult, Error, WithPos};
+use itertools::Itertools;
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
@@ -60,11 +61,11 @@ impl Workspace {
     /// An import path is first resolved as an absolute or
     /// relative(-to-`parent`) path, and if no file exists at either such
     /// extended path exists, it assumed to be under the library path
-    /// `lib_path`.
+    /// `lib_paths`.
     fn canonicalize_import<S>(
         import: S,
         parent: &Path,
-        lib_path: &Path,
+        lib_paths: &[PathBuf],
     ) -> CalyxResult<PathBuf>
     where
         S: AsRef<Path> + Clone + WithPos,
@@ -79,16 +80,19 @@ impl Workspace {
             return Ok(relative_import);
         }
 
-        let library_import = lib_path.join(import.clone());
-        if library_import.exists() {
+        let library_import = lib_paths.iter().find_map(|lib_path| {
+            let library_import = lib_path.join(import.clone());
+            library_import.exists().then_some(library_import)
+        });
+        if let Some(library_import) = library_import {
             return Ok(library_import);
-        }
+        };
 
         Err(Error::invalid_file(
             format!("Import path `{}` found neither as an absolute path, nor in the parent ({}), nor in library path ({})",
             import.as_ref().to_string_lossy(),
             parent.to_string_lossy(),
-            lib_path.to_string_lossy()
+            lib_paths.iter().map(|p| p.to_string_lossy()).format(", ")
         )).with_pos(&import))
     }
 
@@ -151,11 +155,11 @@ impl Workspace {
     /// program.
     pub fn construct(
         file: &Option<PathBuf>,
-        lib_path: &Path,
+        lib_paths: &[PathBuf],
     ) -> CalyxResult<Self> {
         Self::construct_with_all_deps::<false>(
             file.iter().cloned().collect(),
-            lib_path,
+            lib_paths,
         )
     }
 
@@ -163,11 +167,11 @@ impl Workspace {
     /// imported dependencies.
     pub fn construct_shallow(
         file: &Option<PathBuf>,
-        lib_path: &Path,
+        lib_paths: &[PathBuf],
     ) -> CalyxResult<Self> {
         Self::construct_with_all_deps::<true>(
             file.iter().cloned().collect(),
-            lib_path,
+            lib_paths,
         )
     }
 
@@ -194,7 +198,7 @@ impl Workspace {
         is_source: bool,
         parent: &Path,
         shallow: bool,
-        lib_path: &Path,
+        lib_paths: &[PathBuf],
     ) -> CalyxResult<Vec<(PathBuf, bool)>> {
         // Canonicalize the extern paths and add them
         for (path, exts) in ns.externs {
@@ -238,7 +242,7 @@ impl Workspace {
             .imports
             .into_iter()
             .map(|p| {
-                Self::canonicalize_import(p, parent, lib_path)
+                Self::canonicalize_import(p, parent, lib_paths)
                     .map(|s| (s, false))
             })
             .collect::<CalyxResult<_>>()?;
@@ -251,7 +255,7 @@ impl Workspace {
     /// If in doubt, set SHALLOW to false.
     pub fn construct_with_all_deps<const SHALLOW: bool>(
         mut files: Vec<PathBuf>,
-        lib_path: &Path,
+        lib_paths: &[PathBuf],
     ) -> CalyxResult<Self> {
         // Construct initial namespace. If `files` is empty, then we're reading from the standard input.
         let first = files.pop();
@@ -268,13 +272,19 @@ impl Workspace {
         let mut already_imported: HashSet<PathBuf> = HashSet::new();
 
         let mut ws = Workspace::default();
-        let abs_lib_path = lib_path.canonicalize().map_err(|err| {
-            Error::invalid_file(format!(
-                "Failed to canonicalize library path `{}`: {}",
-                lib_path.to_string_lossy(),
-                err
-            ))
-        })?;
+
+        let abs_lib_paths: Vec<_> = lib_paths
+            .iter()
+            .map(|lib_path| {
+                lib_path.canonicalize().map_err(|err| {
+                    Error::invalid_file(format!(
+                        "Failed to canonicalize library path `{}`: {}",
+                        lib_path.to_string_lossy(),
+                        err
+                    ))
+                })
+            })
+            .collect::<CalyxResult<_>>()?;
 
         // Add original imports to workspace
         ws.original_imports =
@@ -298,7 +308,7 @@ impl Workspace {
             true,
             &parent_canonical,
             false,
-            &abs_lib_path,
+            &abs_lib_paths,
         )?;
         dependencies.append(&mut deps);
 
@@ -314,7 +324,7 @@ impl Workspace {
                 source,
                 &parent,
                 SHALLOW,
-                &abs_lib_path,
+                &abs_lib_paths,
             )?;
             dependencies.append(&mut deps);
 

--- a/cider/src/flatten/setup.rs
+++ b/cider/src/flatten/setup.rs
@@ -15,7 +15,7 @@ fn do_setup(
     gen_metadata: bool,
 ) -> CiderResult<(Context, CiderResult<NewSourceMap>)> {
     // Construct IR
-    let ws = frontend::Workspace::construct(file, lib_path)?;
+    let ws = frontend::Workspace::construct(file, &[lib_path.to_path_buf()])?;
     let mut ctx = ir::from_ast::ast_to_ir(ws)?;
     let pm = PassManager::default_passes()?;
 

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -45,12 +45,8 @@ pub struct Opts {
     pub output: OutputFile,
 
     /// path to the primitives library
-    #[argh(
-        option,
-        short = 'l',
-        default = "Path::new(option_env!(\"CALYX_PRIMITIVES_DIR\").unwrap_or(\".\")).into()"
-    )]
-    pub lib_path: PathBuf,
+    #[argh(option, short = 'l')]
+    pub lib_path: Vec<PathBuf>,
 
     /// compilation mode
     #[argh(option, short = 'm', default = "CompileMode::default()")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,9 @@ fn main() -> PassResult<()> {
         }
     }
 
+    opts.lib_path
+        .push(option_env!("CALYX_PRIMITIVES_DIR").unwrap_or(".").into());
+
     // Construct the namespace.
     let mut ws = frontend::Workspace::construct(&opts.file, &opts.lib_path)?;
 

--- a/tools/component_cells/src/main.rs
+++ b/tools/component_cells/src/main.rs
@@ -31,7 +31,7 @@ fn read_path(path: &str) -> Result<PathBuf, String> {
 fn main() -> CalyxResult<()> {
     let p: Args = argh::from_env();
 
-    let ws = frontend::Workspace::construct(&p.file_path, &p.lib_path)?;
+    let ws = frontend::Workspace::construct(&p.file_path, &[p.lib_path])?;
 
     let ctx: ir::Context = ir::from_ast::ast_to_ir(ws)?;
 

--- a/tools/data_gen/src/main.rs
+++ b/tools/data_gen/src/main.rs
@@ -66,7 +66,7 @@ fn main() -> CalyxResult<()> {
     let fp_data = p.fp_data;
     let rand_data = p.random_data;
 
-    let ws = frontend::Workspace::construct(&p.file_path, &p.lib_path)?;
+    let ws = frontend::Workspace::construct(&p.file_path, &[p.lib_path])?;
     let ctx: ir::Context = ir::from_ast::ast_to_ir(ws)?;
     let top = ctx.entrypoint();
     let data_vec = top.get_mem_info();

--- a/tools/fileinfo_emitter/src/main.rs
+++ b/tools/fileinfo_emitter/src/main.rs
@@ -275,7 +275,7 @@ fn create_file_map(
 fn main() -> CalyxResult<()> {
     let p: Args = argh::from_env();
 
-    let ws = frontend::Workspace::construct(&p.file_path, &p.lib_path)?;
+    let ws = frontend::Workspace::construct(&p.file_path, &[p.lib_path])?;
 
     let ctx: ir::Context = ir::from_ast::ast_to_ir(ws)?;
 

--- a/tools/yxi/src/main.rs
+++ b/tools/yxi/src/main.rs
@@ -48,7 +48,7 @@ struct Memory<'a> {
 fn main() -> CalyxResult<()> {
     let p: Args = argh::from_env();
 
-    let ws = frontend::Workspace::construct(&p.file_path, &p.lib_path)?;
+    let ws = frontend::Workspace::construct(&p.file_path, &[p.lib_path])?;
     let ctx: ir::Context = ir::from_ast::ast_to_ir(ws)?;
 
     let toplevel = ctx.entrypoint();

--- a/web/rust/src/lib.rs
+++ b/web/rust/src/lib.rs
@@ -15,13 +15,7 @@ fn ws_from_ns(ns: frontend::NamespaceDef) -> CalyxResult<frontend::Workspace> {
         ));
     }
     let mut ws = frontend::Workspace::default();
-    ws.merge_namespace(
-        ns,
-        true,
-        &PathBuf::default(),
-        true,
-        &PathBuf::default(),
-    )?;
+    ws.merge_namespace(ns, true, &PathBuf::default(), true, &[])?;
     Ok(ws)
 }
 


### PR DESCRIPTION
This makes it possible to specify multiple library paths, which is useful for frontends that wish to provide their own primitive libraries in addition to Calyx's standard library.