### PR TITLE
[cell-share] Option for emitting shared cells in JSON format

### DIFF
--- a/calyx/opt/src/passes/cell_share.rs
+++ b/calyx/opt/src/passes/cell_share.rs
@@ -510,6 +510,7 @@ impl Visitor for CellShare {
         Ok(Action::Stop)
     }
 
+    /// If requested, emit share map json after all components are processed
     fn finish_context(&mut self, _ctx: &mut calyx_ir::Context) -> VisResult {
         if let Some(json_out_file) = &mut self.emit_share_map {
             let _ = serde_json::to_writer_pretty(

--- a/calyx/opt/src/passes/cell_share.rs
+++ b/calyx/opt/src/passes/cell_share.rs
@@ -140,7 +140,7 @@ pub struct CellShare {
 
     /// whether or not to print the share mappings
     emit_share_map: Option<OutputFile>,
-    /// Bookkeeping for share mappings
+    /// Bookkeeping for share mappings, using a BTreeMap for output determinism.
     shared_cells: BTreeMap<String, Vec<ShareEntry>>,
 }
 

--- a/tests/passes/cell-share/emit-share-map.expect
+++ b/tests/passes/cell-share/emit-share-map.expect
@@ -1,0 +1,79 @@
+import "primitives/core.futil";
+import "primitives/memories/comb.futil";
+import "primitives/binary_operators.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    @external mem = comb_mem_d1(32, 1, 1);
+    r = std_reg(32);
+    ans = std_reg(32);
+    id_1 = identity();
+    id_2 = identity();
+    id_3 = identity();
+  }
+  wires {
+    group read {
+      mem.addr0 = 1'd0;
+      r.in = mem.read_data;
+      r.write_en = 1'd1;
+      read[done] = r.done;
+    }
+    group write {
+      mem.addr0 = 1'd0;
+      mem.write_en = 1'd1;
+      mem.write_data = r.out;
+      write[done] = mem.done;
+    }
+  }
+  control {
+    @NODE_ID(0) seq {
+      @NODE_ID read;
+      @NODE_ID(2) invoke id_1(
+        in_1 = r.out
+      )(
+        out = ans.in
+      );
+      @NODE_ID(3) invoke id_1(
+        in_1 = r.out
+      )(
+        out = ans.in
+      );
+      @NODE_ID(4) invoke id_1(
+        in_1 = r.out
+      )(
+        out = ans.in
+      );
+      @NODE_ID(5) write;
+    }
+  }
+}
+component identity<"state_share"=1>(in_1: 32, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 32, @done done: 1) {
+  cells {
+    r = std_reg(32);
+  }
+  wires {
+    group save {
+      r.in = in_1;
+      r.write_en = 1'd1;
+      save[done] = r.done;
+    }
+    out = r.out;
+  }
+  control {
+    @NODE_ID(0) save;
+  }
+}
+---STDERR---
+[
+  {
+    "original": "id_3",
+    "new": "id_1",
+    "component": "main",
+    "cell_type": "identity"
+  },
+  {
+    "original": "id_2",
+    "new": "id_1",
+    "component": "main",
+    "cell_type": "identity"
+  }
+]

--- a/tests/passes/cell-share/emit-share-map.expect
+++ b/tests/passes/cell-share/emit-share-map.expect
@@ -63,17 +63,18 @@ component identity<"state_share"=1>(in_1: 32, @go go: 1, @clk clk: 1, @reset res
   }
 }
 ---STDERR---
-[
-  {
-    "original": "id_3",
-    "new": "id_1",
-    "component": "main",
-    "cell_type": "identity"
-  },
-  {
-    "original": "id_2",
-    "new": "id_1",
-    "component": "main",
-    "cell_type": "identity"
-  }
-]
+{
+  "identity": [],
+  "main": [
+    {
+      "original": "id_3",
+      "new": "id_1",
+      "cell_type": "identity"
+    },
+    {
+      "original": "id_2",
+      "new": "id_1",
+      "cell_type": "identity"
+    }
+  ]
+}

--- a/tests/passes/cell-share/emit-share-map.futil
+++ b/tests/passes/cell-share/emit-share-map.futil
@@ -1,0 +1,54 @@
+// -p cell-share -x cell-share:emit-share-map=<err>
+
+import "primitives/core.futil";
+import "primitives/memories/comb.futil";
+import "primitives/binary_operators.futil";
+component main() -> () {
+  cells {
+    @external mem = comb_mem_d1(32, 1, 1);
+    r = std_reg(32);
+    ans = std_reg(32);
+    id_1 = identity();
+    id_2 = identity();
+    id_3 = identity();
+  }
+  wires {
+    group read {
+      mem.addr0 = 1'd0;
+      r.in = mem.read_data;
+      r.write_en = 1'd1;
+      read[done] = r.done;
+    }
+    group write {
+      mem.addr0 = 1'd0;
+      mem.write_en = 1'd1;
+      mem.write_data = r.out;
+      write[done] = mem.done;
+    }
+  }
+  control {
+    seq {
+      read;
+      invoke id_1(in_1=r.out)(out=ans.in);
+      invoke id_2(in_1=r.out)(out=ans.in);
+      invoke id_3(in_1=r.out)(out=ans.in);
+      write;
+    }
+  }
+}
+component identity<"state_share"=1>(in_1: 32) -> (out: 32) {
+  cells {
+    r = std_reg(32);
+  }
+  wires {
+    group save {
+      r.in = in_1;
+      r.write_en = 1'd1;
+      save[done] = r.done;
+    }
+    out = r.out;
+  }
+  control {
+    save;
+  }
+}


### PR DESCRIPTION
This PR adds the `emit-share-map` option to `cell-share` that emits the mapping between old and new cells in JSON format. The motivation for this is that I realized that the profiler sometimes needs to know when/how cells are shared. As always, please let me know if there's anything I should change here!

# Example

The test `tests/passes/cell-share/emit-share-map.futil` contains three cells (`id_1`, `id_2`, `id_3`) of component `identity` that can be shared. When running `cargo run -- tests/passes/cell-share/emit-share-map.futil -p cell-share -p cell-share:emit-share-map:map.json`, the following is written to `map.json`:

```
{
  "identity": [],
  "main": [
    {
      "original": "id_3",
      "new": "id_1",
      "cell_type": "identity"
    },
    {
      "original": "id_2",
      "new": "id_1",
      "cell_type": "identity"
    }
  ]
}
```
This indicates that `id_2` and `id_3` were both replaced by `id_1` by the `cell-share` pass.