### PR TITLE
[Floating Point] Add `write_together` and `interval` attribute to the floating point library ops

### DIFF
--- a/primitives/float/addFN.futil
+++ b/primitives/float/addFN.futil
@@ -6,7 +6,7 @@ extern "addFN.sv" {
   ](
     @clk clk: 1,
     @reset reset: 1,
-    @go go: 1,
+    @write_together @interval(4) @go go: 1,
     control: 1,
     @write_together(1) subOp: 1,
     @write_together(1) left: numWidth,

--- a/primitives/float/addFN.futil
+++ b/primitives/float/addFN.futil
@@ -6,7 +6,7 @@ extern "addFN.sv" {
   ](
     @clk clk: 1,
     @reset reset: 1,
-    @write_together @interval(4) @go go: 1,
+    @write_together @interval(2) @go go: 1,
     control: 1,
     @write_together(1) subOp: 1,
     @write_together(1) left: numWidth,

--- a/primitives/float/compareFN.futil
+++ b/primitives/float/compareFN.futil
@@ -6,7 +6,7 @@ extern "compareFN.sv" {
   ](
     @clk clk: 1,
     @reset reset: 1,
-    @go go: 1,
+    @write_together @interval(4) @go go: 1,
     @write_together(1) left: numWidth,
     @write_together(1) right: numWidth,
     signaling: 1

--- a/primitives/float/compareFN.futil
+++ b/primitives/float/compareFN.futil
@@ -6,7 +6,7 @@ extern "compareFN.sv" {
   ](
     @clk clk: 1,
     @reset reset: 1,
-    @write_together @interval(4) @go go: 1,
+    @write_together @interval(2) @go go: 1,
     @write_together(1) left: numWidth,
     @write_together(1) right: numWidth,
     signaling: 1

--- a/primitives/float/divSqrtFN.futil
+++ b/primitives/float/divSqrtFN.futil
@@ -6,7 +6,7 @@ extern "divSqrtFN.sv" {
   ](
     @clk clk: 1,
     @reset reset: 1,
-    @go go: 1,
+    @write_together @interval(4) @go go: 1,
     control: 1,
     sqrtOp: 1,
     @write_together(1) left: numWidth,

--- a/primitives/float/divSqrtFN.futil
+++ b/primitives/float/divSqrtFN.futil
@@ -6,7 +6,7 @@ extern "divSqrtFN.sv" {
   ](
     @clk clk: 1,
     @reset reset: 1,
-    @write_together @interval(4) @go go: 1,
+    @write_together @interval(32) @go go: 1,
     control: 1,
     sqrtOp: 1,
     @write_together(1) left: numWidth,

--- a/primitives/float/mulFN.futil
+++ b/primitives/float/mulFN.futil
@@ -6,7 +6,7 @@ extern "mulFN.sv" {
   ](
     @clk clk: 1,
     @reset reset: 1,
-    @go go: 1,
+    @write_together @interval(4) @go go: 1,
     control: 1,
     @write_together(1) left: numWidth,
     @write_together(1) right: numWidth,

--- a/primitives/float/mulFN.futil
+++ b/primitives/float/mulFN.futil
@@ -6,7 +6,7 @@ extern "mulFN.sv" {
   ](
     @clk clk: 1,
     @reset reset: 1,
-    @write_together @interval(4) @go go: 1,
+    @write_together @interval(2) @go go: 1,
     control: 1,
     @write_together(1) left: numWidth,
     @write_together(1) right: numWidth,


### PR DESCRIPTION
This patch adds the `interval` attribute to all the pseudo-pipelined floating point library operations with value equals to 4. We also add `write_together` to the `go` signal.