### PR TITLE
[Floating Point] Hardfloat path should not be relative to the current working directory

### DIFF
--- a/calyx/backend/src/verilog.rs
+++ b/calyx/backend/src/verilog.rs
@@ -244,7 +244,7 @@ fn check_library_needed(ctx: &ir::Context) -> bool {
     ctx.lib
         .extern_paths()
         .iter()
-        .any(|path| path.to_string_lossy().contains("float"))
+        .any(|path| path.to_string_lossy().contains("float/"))
 }
 
 /// Collect all included files specified by the Calyx source file

--- a/calyx/backend/src/verilog.rs
+++ b/calyx/backend/src/verilog.rs
@@ -12,10 +12,13 @@ use morty::{FileBundle, LibraryBundle};
 use std::env;
 use std::io;
 use std::io::{Read, Seek, SeekFrom, Write};
+use std::path;
 use std::{collections::HashMap, collections::HashSet, path::PathBuf, rc::Rc};
 use std::{fs::File, time::Instant};
 use tempfile::NamedTempFile;
 use vast::v17::ast as v;
+
+const PRIM_DIR: &str = "CALYX_PRIMITIVES_DIR";
 
 /// Implements a simple Verilog backend. The backend only accepts Calyx programs with no control
 /// and no groups.
@@ -153,12 +156,18 @@ trait LibraryHandlerTrait {
 struct HardFloatHandler;
 impl LibraryHandlerTrait for HardFloatHandler {
     fn add_incs(&self) -> CalyxResult<Vec<PathBuf>> {
-        let current_dir = env::current_dir()
-            .map_err(|e| Error::invalid_file(e.to_string()))?;
+        let base: path::PathBuf = match env::var_os(PRIM_DIR) {
+            Some(v) => path::PathBuf::from(v),
+            None => {
+                let mut path: path::PathBuf =
+                    env::var_os("HOME").unwrap().into();
+                path.push(".calyx");
+                path
+            }
+        };
 
         // To include `HardFloat_consts.vi` file
-        let source_path =
-            current_dir.join("primitives/float/HardFloat-1/source/");
+        let source_path = base.join("primitives/float/HardFloat-1/source/");
         // Randomly pick the RISCV directory as the specialization subdirectory to include `HardFloat_specialize.vi`
         let riscv_path = source_path.join("RISCV/");
 
@@ -191,11 +200,17 @@ impl LibraryHandlerTrait for HardFloatHandler {
         Ok(inc_paths)
     }
     fn add_library_dirs(&self) -> CalyxResult<Vec<PathBuf>> {
-        let current_dir = env::current_dir()
-            .map_err(|e| Error::invalid_file(e.to_string()))?;
+        let base: path::PathBuf = match env::var_os(PRIM_DIR) {
+            Some(v) => path::PathBuf::from(v),
+            None => {
+                let mut path: path::PathBuf =
+                    env::var_os("HOME").unwrap().into();
+                path.push(".calyx");
+                path
+            }
+        };
 
-        let source_path =
-            current_dir.join("primitives/float/HardFloat-1/source/");
+        let source_path = base.join("primitives/float/HardFloat-1/source/");
 
         let mut inc_paths = Vec::new();
 

--- a/calyx/stdlib/src/primitives.rs
+++ b/calyx/stdlib/src/primitives.rs
@@ -31,6 +31,10 @@ load_prims! { DYN_MEMORIES, "memories/dyn.futil", "memories/dyn.sv" }
 load_prims! { PIPELINED, "pipelined.futil", "pipelined.sv" }
 load_prims! { STALLABLE, "stallable.futil", "stallable.sv" }
 load_prims! { SYNC, "sync.futil", "sync.sv" }
+load_prims! { ADD_FN, "float/addFN.futil", "float/addFN.sv"}
+load_prims! { CMP_FN, "float/compareFN.futil", "float/compareFN.sv"}
+load_prims! { DIVSQRT_FN, "float/divSqrtFN.futil", "float/divSqrtFN.sv"}
+load_prims! { MUL_FN, "float/mulFN.futil", "float/mulFN.sv"}
 
 /// The core primitive in the compiler
 pub const COMPILE_LIB: (&str, &str) = (
@@ -38,7 +42,7 @@ pub const COMPILE_LIB: (&str, &str) = (
     include_str!("../../../primitives/compile.futil"),
 );
 
-pub const KNOWN_LIBS: [(&str, [(&str, &str); 2]); 9] = [
+pub const KNOWN_LIBS: [(&str, [(&str, &str); 2]); 13] = [
     ("core", CORE),
     ("binary_operators", BINARY_OPERATORS),
     ("math", MATH),
@@ -48,4 +52,8 @@ pub const KNOWN_LIBS: [(&str, [(&str, &str); 2]); 9] = [
     ("pipelined", PIPELINED),
     ("stallable", STALLABLE),
     ("sync", SYNC),
+    ("addFN", ADD_FN),
+    ("compareFN", CMP_FN),
+    ("divSqrtFN", DIVSQRT_FN),
+    ("mulFN", MUL_FN),
 ];

--- a/primitives/float/get_hardfloat.sh
+++ b/primitives/float/get_hardfloat.sh
@@ -13,6 +13,12 @@ curl -LO "${HARDFLOAT_URL}"
 if [ -f "$ZIP_FILE" ]; then
     unzip -o "$ZIP_FILE"
     echo "HardFloat library fetched and extracted to ${HARDFLOAT_DIR}"
+    DEST_DIR="${CALYX_PRIMITIVES_DIR:-$HOME/.calyx}"
+
+    echo "Copying HardFloat to destination directory: $DEST_DIR"
+    mkdir -p "$DEST_DIR/primitives/float/HardFloat-1"
+    cp -r HardFloat-1/* "$DEST_DIR/primitives/float/HardFloat-1/"
+    echo "HardFloat copied successfully to $DEST_DIR/primitives/float/HardFloat-1"
 else
     echo "Failed to download HardFloat library from ${HARDFLOAT_URL}"
     exit 1


### PR DESCRIPTION
We should not set the directory of the Berkeley Hardfloat library to be relative to the current working directory because it will result in path error when using `fud2`, which creates a fresh directory for `ninja`.