### PR TITLE
[BitNum] Correct the upper bound when converting two's complement to decimal negative values

### DIFF
--- a/calyx-py/calyx/numeric_types.py
+++ b/calyx-py/calyx/numeric_types.py
@@ -120,7 +120,7 @@ class Bitnum(NumericType):
             self.uint_repr = int(self.bit_string_repr, 2)
             self.hex_string_repr = np.base_repr(self.uint_repr, 16)
 
-        if is_signed and self.uint_repr > (2 ** (width - 1)):
+        if is_signed and self.uint_repr > (2 ** (width - 1)) - 1:
             negated_value = -1 * ((2**width) - self.uint_repr)
             self.string_repr = str(negated_value)
 

--- a/tests/correctness/hardfloat/compareFN.futil.data
+++ b/tests/correctness/hardfloat/compareFN.futil.data
@@ -3,7 +3,7 @@
     "data": [0],
     "format": {
       "numeric_type": "bitnum",
-      "is_signed": true,
+      "is_signed": false,
       "width": 1
     }
   },
@@ -11,7 +11,7 @@
     "data": [0],
     "format": {
       "numeric_type": "bitnum",
-      "is_signed": true,
+      "is_signed": false,
       "width": 1
     }
   }


### PR DESCRIPTION
Two's complement to positive decimal representation should fall into [0, (2^(width-1)) - 1], instead of [0, (2^(width-1))].