### PR TITLE
[Cider] Structural enable fixes

### DIFF
--- a/cider/src/flatten/flat_ir/component.rs
+++ b/cider/src/flatten/flat_ir/component.rs
@@ -129,13 +129,14 @@ impl PrimaryComponentInfo {
         &self,
         ctx: &Context,
         assign: AssignmentIdx,
+        comp: ComponentIdx,
     ) -> Option<AssignmentDefinitionLocation> {
         match self {
             PrimaryComponentInfo::Comb(info) => {
                 info.contains_assignment(assign)
             }
             PrimaryComponentInfo::Standard(info) => {
-                info.contains_assignment(ctx, assign)
+                info.contains_assignment(ctx, assign, comp)
             }
         }
     }
@@ -220,6 +221,7 @@ impl ComponentCore {
         &self,
         ctx: &Context,
         assign: AssignmentIdx,
+        comp: ComponentIdx,
     ) -> Option<AssignmentDefinitionLocation> {
         if self.continuous_assignments.contains(assign) {
             return Some(AssignmentDefinitionLocation::ContinuousAssignment);
@@ -291,6 +293,15 @@ impl ComponentCore {
                             ));
                         }
                     }
+                }
+            }
+
+            // if we get to this point then it isn't in the control tree, but
+            // may be structurally invoked
+            for group in ctx.secondary.comp_aux_info[comp].definitions.groups()
+            {
+                if ctx.primary[group].assignments.contains(assign) {
+                    return Some(AssignmentDefinitionLocation::Group(group));
                 }
             }
         }

--- a/cider/src/flatten/structures/context.rs
+++ b/cider/src/flatten/structures/context.rs
@@ -469,12 +469,15 @@ impl Context {
         target: AssignmentIdx,
     ) -> (ComponentIdx, AssignmentDefinitionLocation) {
         for (idx, comp) in self.primary.components.iter() {
-            let found = comp.contains_assignment(self, target);
+            let found = comp.contains_assignment(self, target, idx);
             if let Some(found) = found {
                 return (idx, found);
             }
         }
-        unreachable!("Assignment does not belong to any component");
+        unreachable!(
+            "Assignment '{:?}' does not belong to any component",
+            target
+        );
     }
 
     /// Returns the assignment definition information, if it exists. This
@@ -486,7 +489,7 @@ impl Context {
         target: AssignmentIdx,
         comp: ComponentIdx,
     ) -> Option<AssignmentDefinitionLocation> {
-        self.primary.components[comp].contains_assignment(self, target)
+        self.primary.components[comp].contains_assignment(self, target, comp)
     }
 }
 


### PR DESCRIPTION
Minor set of changes to fix some code that was broken by #2456, namely the ability to search for assignments in groups that do not appear in the control tree.