### PR TITLE
Resolve logger warnings

### DIFF
--- a/fud/fud/config.py
+++ b/fud/fud/config.py
@@ -152,7 +152,7 @@ class DynamicDict:
         if lastkey in data:
             del data[lastkey]
         else:
-            log.warn(f"`{'.'.join(keys)}' not found. Ignoring delete command.")
+            log.warning(f"`{'.'.join(keys)}' not found. Ignoring delete command.")
 
     def __contains__(self, keys):
         data = self.data
@@ -208,7 +208,7 @@ class Configuration:
         """Find the configuration file."""
         self.path = Path(appdirs.user_config_dir("fud"))
         if not self.path.parent.exists():
-            log.warn(f"{self.path.parent} doesn't exist. Creating it.")
+            log.warning(f"{self.path.parent} doesn't exist. Creating it.")
         self.path.mkdir(parents=True, exist_ok=True)
 
         self.config_file = self.path / "config.toml"
@@ -222,7 +222,7 @@ class Configuration:
         self.wizard_data = DynamicDict(WIZARD_DATA)
         self.fill_missing(DEFAULT_CONFIGURATION, self.config.data)
         if ("global", ROOT) not in self.config:
-            log.warn(f"global.{ROOT} is not set in the configuration")
+            log.warning(f"global.{ROOT} is not set in the configuration")
 
     def commit(self):
         """
@@ -327,7 +327,7 @@ class Configuration:
                 # Only delete the stage if it's marked as an external
                 del self[["externals", args.name]]
             else:
-                log.warn(
+                log.warning(
                     f"Ignoring delete command, no external script named `{args.name}'."
                 )
 

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -304,7 +304,7 @@ def main():
             override = toml.load(args.config_file)
             for key, value in override.items():
                 if key != "stages":
-                    log.warn(
+                    log.warning(
                         f"Ignoring key `{key}' in config file."
                         + " Only 'stages' is allowed as a top-level key."
                     )

--- a/fud/fud/stages/__init__.py
+++ b/fud/fud/stages/__init__.py
@@ -224,7 +224,7 @@ class Stage:
             opts = config["stages", self.name]
             for opt in opts.keys():
                 if opt not in known:
-                    log.warn(
+                    log.warning(
                         f"Unknown option `{self.name}.{opt}' for stage `{self.name}'"
                     )
 
@@ -323,7 +323,7 @@ class ComputationGraph:
 
     def and_then_path(self, path: List[Stage], config: Configuration):
         """
-        Convienience method to stage all the computations in a path.
+        Convenience method to stage all the computations in a path.
         """
         for stage in path:
             stage.setup(config, self)
@@ -414,7 +414,7 @@ class ComputationGraph:
                 if len(args) != len(input_types):
                     raise Exception(
                         f"Expected {len(input_types)} input arguments,"
-                        f" but recieved {len(args)}"
+                        f" but received {len(args)}"
                     )
 
                 # make sure that the args are convertible to expected input
@@ -435,7 +435,7 @@ class ComputationGraph:
                 future_output = Source(None, output_types)
 
                 # convert the args to the right types and unwrap them
-                # NOTE(rachit): This is a *LAZY* computaion and only occurs when
+                # NOTE(rachit): This is a *LAZY* computation and only occurs when
                 # the step's data has been filled.
                 unwrapped_args = map(
                     lambda a: a[0].convert_to(a[1]).data, zip(args, input_types)

--- a/fud/fud/stages/remote_context.py
+++ b/fud/fud/stages/remote_context.py
@@ -56,7 +56,7 @@ class RemoteExecution:
         """
 
         if self.ssh_host == "" or self.ssh_user == "":
-            log.warn(
+            log.warning(
                 "Attempting to use remote execution but SSH host or user look invalid."
                 f" Host: `{self.ssh_host}`, user: `{self.ssh_user}`"
             )
@@ -133,7 +133,7 @@ class RemoteExecution:
                 log.debug(chunk.strip())
 
             for chunk in iter(lambda: stderr.readline(2048), ""):
-                log.warn(chunk.strip())
+                log.warning(chunk.strip())
 
             exit_code = stdout.channel.recv_exit_status()
             if exit_code != 0:

--- a/fud/fud/stages/vivado/extract.py
+++ b/fud/fud/stages/vivado/extract.py
@@ -52,7 +52,7 @@ def rpt_extract(file: PurePath):
     logic_type = "CLB"
 
     if not all([slice_logic, bram_table, dsp_table]):
-        log.warn("Failed to find CLB logic tables, defaulting to older RPT format")
+        log.warning("Failed to find CLB logic tables, defaulting to older RPT format")
         slice_logic = parser.get_table(re.compile(r"^\d+\. Slice Logic\*?$"), 2)
         bram_table = parser.get_table(re.compile(r"^\d+\. Memory$"), 2)
         dsp_table = parser.get_table(re.compile(r"^\d+\. DSP$"), 2)

--- a/fud/fud/stages/xilinx/execution.py
+++ b/fud/fud/stages/xilinx/execution.py
@@ -28,7 +28,7 @@ class HwExecutionStage(Stage):
         save_temps = bool(config["stages", self.name, "save_temps"])
         waveform = bool(config["stages", self.name, "waveform"])
         if waveform and not save_temps:
-            log.warn(
+            log.warning(
                 f"{self.name}.waveform is enabled, but {self.name}.save_temps "
                 f"is not. This will generate a WDB file but then immediately "
                 f"delete it. Consider adding `-s {self.name}.save_temps true`."

--- a/fud/icarus/icarus.py
+++ b/fud/icarus/icarus.py
@@ -159,7 +159,7 @@ class IcarusBaseStage(Stage):
             r = re.search(r"Simulated\s+((-)?\d+) cycles", simulated_output)
             cycle_count = int(r.group(1)) if r is not None else 0
             if cycle_count < 0:
-                log.warn("Cycle count is less than 0")
+                log.warning("Cycle count is less than 0")
             data = {
                 "cycles": cycle_count,
                 "memories": convert2json(tmpdir.name, "out"),


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
