### PR TITLE
add assert primitive and basic test

### DIFF
--- a/cider/tests/primitives/assert.futil
+++ b/cider/tests/primitives/assert.futil
@@ -1,0 +1,42 @@
+import "primitives/core.futil";
+import "primitives/binary_operators.futil";
+import "primitives/assert.futil";
+
+component main() -> () {
+  cells {
+    a = std_const(32, 42);
+    b = std_const(32, 41);
+    eq = std_eq(32);
+    tmp_reg = std_reg(1);
+    my_assert = assert_prim();
+  }
+
+  wires {
+    eq.left = a.out;
+    eq.right = b.out;
+
+
+    my_assert.in = eq.out;
+    group check_assert {
+      tmp_reg.in = 1'b1;
+      tmp_reg.write_en = 1'b1;
+      my_assert.en = 1'b1;
+      check_assert[done] = my_assert.out;
+
+    }
+    
+    group check_assert2 {
+      tmp_reg.in = eq.out;
+      tmp_reg.write_en = 1'b1;
+      check_assert2[done] = tmp_reg.done;
+
+      }
+  }
+
+  control {
+      check_assert;
+      check_assert2;
+
+
+  }
+}

--- a/primitives/assert.futil
+++ b/primitives/assert.futil
@@ -1,0 +1,8 @@
+
+extern "assert.sv" {
+   primitive assert_prim(@data in: 1, en: 1, @clk clk:1, @reset reset: 1) -> (out: 1);
+  // WARNING: `done` must be referenced, or this will be optimized out
+  // TODO (elam) how do we `dont_touch` this?
+
+
+}

--- a/primitives/assert.sv
+++ b/primitives/assert.sv
@@ -1,0 +1,14 @@
+module assert_prim #() (
+   input wire logic clk,
+   input wire logic reset,                        
+   input logic in,
+   input logic en,
+                        output logic out
+);
+    always_ff @(posedge clk) begin
+       out <= in;
+       if (in == '0 & en) begin
+            $fatal(1, "Assertion failed in assert primitive: input was 0");
+        end
+    end
+endmodule


### PR DESCRIPTION
TODO: get it working with runt. When I invoke the test with `fud` it (correctly) fails, but runt seems to complain that the primitive doesn't exist (perhaps for fud2 they have to be registered)?