### PR TITLE
Temporarily removing `group2seq` from profiler pipeline

### DIFF
--- a/calyx/opt/src/default_passes.rs
+++ b/calyx/opt/src/default_passes.rs
@@ -191,12 +191,27 @@ impl PassManager {
             ["validate", "pre-opt", "compile", "post-opt", "lower",]
         );
 
+        register_alias!(
+            pm,
+            "experimental",
+            [
+                "validate",
+                GroupToSeq,
+                CompileInvoke,
+                "pre-opt",
+                "compile",
+                "post-opt",
+                "lower"
+            ]
+        );
+
         // profiler flow for pass explorer access
         register_alias!(
             pm,
             "profiler",
             [
                 "validate",
+                GroupToSeq,
                 CompileInvoke,
                 ProfilerInstrumentation,
                 "pre-opt",

--- a/calyx/opt/src/default_passes.rs
+++ b/calyx/opt/src/default_passes.rs
@@ -97,7 +97,7 @@ impl PassManager {
                 DataPathInfer,
                 CollapseControl, // Run it twice: once at beginning of pre-opt, once at end.
                 CompileSyncWithoutSyncReg,
-                // GroupToSeq, // FIXME: makes programs *slower* in certain cases
+                GroupToSeq, // FIXME: may make programs *slower*
                 DeadAssignmentRemoval,
                 GroupToInvoke, // Creates Dead Groups potentially
                 InferShare,
@@ -123,7 +123,7 @@ impl PassManager {
                 DataPathInfer,
                 CollapseControl,
                 CompileSyncWithoutSyncReg,
-                // GroupToSeq, // FIXME: makes programs *slower* in certain cases
+                GroupToSeq, // FIXME: may make programs *slower*
                 DeadAssignmentRemoval,
                 GroupToInvoke,
                 ComponentInliner,
@@ -199,7 +199,25 @@ impl PassManager {
                 "validate",
                 CompileInvoke,
                 ProfilerInstrumentation,
-                "pre-opt",
+                // "pre-opt" without GroupToSeq
+                DataPathInfer,
+                CollapseControl, // Run it twice: once at beginning of pre-opt, once at end.
+                CompileSyncWithoutSyncReg,
+                DeadAssignmentRemoval,
+                GroupToInvoke, // Creates Dead Groups potentially
+                InferShare,
+                ComponentInliner,
+                CombProp,
+                ConstantPortProp,
+                DeadCellRemoval, // Clean up dead wires left by CombProp
+                CellShare,       // LiveRangeAnalaysis should handle comb groups
+                SimplifyWithControl, // Must run before compile-invoke
+                CompileInvoke,   // creates dead comb groups
+                StaticInference,
+                StaticPromotion,
+                CompileRepeat,
+                DeadGroupRemoval, // Since previous passes potentially create dead groups
+                CollapseControl,
                 "compile",
                 "post-opt",
                 "lower"

--- a/calyx/opt/src/default_passes.rs
+++ b/calyx/opt/src/default_passes.rs
@@ -97,7 +97,7 @@ impl PassManager {
                 DataPathInfer,
                 CollapseControl, // Run it twice: once at beginning of pre-opt, once at end.
                 CompileSyncWithoutSyncReg,
-                GroupToSeq,
+                // GroupToSeq, // FIXME: makes programs *slower* in certain cases
                 DeadAssignmentRemoval,
                 GroupToInvoke, // Creates Dead Groups potentially
                 InferShare,
@@ -123,7 +123,7 @@ impl PassManager {
                 DataPathInfer,
                 CollapseControl,
                 CompileSyncWithoutSyncReg,
-                GroupToSeq,
+                // GroupToSeq, // FIXME: makes programs *slower* in certain cases
                 DeadAssignmentRemoval,
                 GroupToInvoke,
                 ComponentInliner,
@@ -191,27 +191,12 @@ impl PassManager {
             ["validate", "pre-opt", "compile", "post-opt", "lower",]
         );
 
-        register_alias!(
-            pm,
-            "experimental",
-            [
-                "validate",
-                GroupToSeq,
-                CompileInvoke,
-                "pre-opt",
-                "compile",
-                "post-opt",
-                "lower"
-            ]
-        );
-
         // profiler flow for pass explorer access
         register_alias!(
             pm,
             "profiler",
             [
                 "validate",
-                GroupToSeq,
                 CompileInvoke,
                 ProfilerInstrumentation,
                 "pre-opt",

--- a/fud2/scripts/profiler.rhai
+++ b/fud2/scripts/profiler.rhai
@@ -57,7 +57,7 @@ fn edsl_to_flamegraph(e, input, output) {
     e.build_cmd(["$cells"], "component-cells", [calyx], []);
     e.build_cmd([instrumented_verilog], "calyx", [calyx], []);
     e.arg("backend", "verilog");
-    e.arg("args", "-p validate -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json");
+    e.arg("args", "-p validate -p group2seq -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json");
 
     let instrumented_sim = "instrumented.exe";
     // verilog --> sim; adapted from verilator::verilator_build()
@@ -96,7 +96,7 @@ fn calyx_to_flamegraph(e, input, output) {
     e.build_cmd(["$cells"], "component-cells", [input], []);
     e.build_cmd([instrumented_verilog], "calyx", [input], []);
     e.arg("backend", "verilog");
-    e.arg("args", "-p validate -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json");
+    e.arg("args", "-p validate -p group2seq -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json");
 
     let instrumented_sim = "instrumented.exe";
     // verilog --> sim; adapted from verilator::verilator_build()

--- a/fud2/scripts/profiler.rhai
+++ b/fud2/scripts/profiler.rhai
@@ -57,7 +57,7 @@ fn edsl_to_flamegraph(e, input, output) {
     e.build_cmd(["$cells"], "component-cells", [calyx], []);
     e.build_cmd([instrumented_verilog], "calyx", [calyx], []);
     e.arg("backend", "verilog");
-    e.arg("args", "-p validate -p group2seq -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json");
+    e.arg("args", "-p validate -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json");
 
     let instrumented_sim = "instrumented.exe";
     // verilog --> sim; adapted from verilator::verilator_build()
@@ -96,7 +96,7 @@ fn calyx_to_flamegraph(e, input, output) {
     e.build_cmd(["$cells"], "component-cells", [input], []);
     e.build_cmd([instrumented_verilog], "calyx", [input], []);
     e.arg("backend", "verilog");
-    e.arg("args", "-p validate -p group2seq -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json");
+    e.arg("args", "-p validate -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json");
 
     let instrumented_sim = "instrumented.exe";
     // verilog --> sim; adapted from verilator::verilator_build()

--- a/fud2/scripts/profiler.rhai
+++ b/fud2/scripts/profiler.rhai
@@ -57,7 +57,8 @@ fn edsl_to_flamegraph(e, input, output) {
     e.build_cmd(["$cells"], "component-cells", [calyx], []);
     e.build_cmd([instrumented_verilog], "calyx", [calyx], []);
     e.arg("backend", "verilog");
-    e.arg("args", "-p validate -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json");
+    // NOTE: disabling group2seq because it may cause cycle count differences btwn profiled vs non-profiled versions.
+    e.arg("args", "-d group2seq -p validate -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json");
 
     let instrumented_sim = "instrumented.exe";
     // verilog --> sim; adapted from verilator::verilator_build()
@@ -96,7 +97,8 @@ fn calyx_to_flamegraph(e, input, output) {
     e.build_cmd(["$cells"], "component-cells", [input], []);
     e.build_cmd([instrumented_verilog], "calyx", [input], []);
     e.arg("backend", "verilog");
-    e.arg("args", "-p validate -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json");
+    // NOTE: disabling group2seq because it may cause cycle count differences btwn profiled vs non-profiled versions.
+    e.arg("args", "-d group2seq -p validate -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json");
 
     let instrumented_sim = "instrumented.exe";
     // verilog --> sim; adapted from verilator::verilator_build()

--- a/fud2/tests/snapshots/tests__test@plan_calyx-py-profiler.snap
+++ b/fud2/tests/snapshots/tests__test@plan_calyx-py-profiler.snap
@@ -1,6 +1,7 @@
 ---
 source: fud2/tests/tests.rs
 description: "emit plan: calyx-py-profiler"
+snapshot_kind: text
 ---
 build-tool = fud2
 rule get-rsrc
@@ -70,7 +71,7 @@ build $metadata-mapping-json: parse-metadata calyx.futil
 build $cells: component-cells calyx.futil
 build instrumented.sv: calyx calyx.futil
   backend = verilog
-  args = -p validate -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json
+  args = -d group2seq -p validate -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json
 build verilator-out/Vtoplevel: verilator-compile-standalone-tb instrumented.sv | tb.sv
   out-dir = verilator-out
 build instrumented.exe: cp verilator-out/Vtoplevel

--- a/fud2/tests/snapshots/tests__test@plan_profiler.snap
+++ b/fud2/tests/snapshots/tests__test@plan_profiler.snap
@@ -1,6 +1,7 @@
 ---
 source: fud2/tests/tests.rs
 description: "emit plan: profiler"
+snapshot_kind: text
 ---
 build-tool = fud2
 rule get-rsrc
@@ -68,7 +69,7 @@ cycle-limit = 500000000
 build $cells: component-cells /input.ext
 build instrumented.sv: calyx /input.ext
   backend = verilog
-  args = -p validate -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json
+  args = -d group2seq -p validate -p compile-invoke -p profiler-instrumentation $passes -x tdcc:dump-fsm-json=fsm.json -x cell-share:emit-share-map=shared-cells.json
 build verilator-out/Vtoplevel: verilator-compile-standalone-tb instrumented.sv | tb.sv
   out-dir = verilator-out
 build instrumented.exe: cp verilator-out/Vtoplevel


### PR DESCRIPTION
I found differences in cycle counts when running @jiahanxie353 's ffnn program, for which the root cause was `group2seq` making programs _slower_. A more detailed explanation is in Issue #2470 !