### PR TITLE
[Profiler] Producing group statistics

### DIFF
--- a/calyx/opt/src/passes/top_down_compile_control.rs
+++ b/calyx/opt/src/passes/top_down_compile_control.rs
@@ -1574,7 +1574,7 @@ impl Visitor for TopDownCompileControl {
         let mut done_regs = Vec::with_capacity(s.stmts.len());
 
         // Profiling: record each par child (arm)'s group and done register
-        let child_infos = Vec::with_capacity(s.stmts.len());
+        let mut child_infos = Vec::with_capacity(s.stmts.len());
 
         // For each child, build the enabling logic.
         for con in &s.stmts {
@@ -1642,6 +1642,10 @@ impl Visitor for TopDownCompileControl {
                     pd["write_en"] = group_done ? signal_on["out"];
                 );
 
+                child_infos.push(ParChildInfo {
+                    group: group.borrow().name(),
+                    register: pd.borrow().name(),
+                });
                 par_group.borrow_mut().assignments.extend(assigns);
                 done_regs.push(pd)
             };

--- a/tools/profiler/profiler-process/classes.py
+++ b/tools/profiler/profiler-process/classes.py
@@ -517,7 +517,6 @@ class CycleTrace:
 class GroupSummary:
     """
     Summary for groups on the number of times they were active vs their active cycles
-    FIXME: Add min/max/avg and collect these for normal groups as well?
     """
 
     display_name: str

--- a/tools/profiler/profiler-process/classes.py
+++ b/tools/profiler/profiler-process/classes.py
@@ -115,7 +115,6 @@ class CellMetadata:
     @property
     def cells(self) -> list[str]:
         cells = []
-        print(self.component_to_cells)
         for component in self.component_to_cells:
             cells += self.component_to_cells[component]
         return cells
@@ -524,7 +523,7 @@ class GroupSummary:
     display_name: str
     num_times_active: int = 0
     active_cycles: set[int] = field(default_factory=set)
-    
+
     interval_lengths: list[int] = field(default_factory=list)
 
     def register_interval(self, interval: range):
@@ -533,8 +532,16 @@ class GroupSummary:
         self.interval_lengths.append(len(interval))
 
     def fieldnames():
-        return ["group-name", "num-times-active", "total-cycles", "min", "max", "avg", "can-static"]
-    
+        return [
+            "group-name",
+            "num-times-active",
+            "total-cycles",
+            "min",
+            "max",
+            "avg",
+            "can-static",
+        ]
+
     def stats(self):
         stats = {}
         stats["group-name"] = self.display_name
@@ -549,6 +556,7 @@ class GroupSummary:
         stats["can-static"] = "Y" if min_interval == max_interval else "N"
         return stats
 
+
 @dataclass
 class Summary:
     """
@@ -558,6 +566,7 @@ class Summary:
 
     num_times_active: int = 0
     active_cycles: set[int] = field(default_factory=set)
+
 
 class ControlRegUpdateType(Enum):
     FSM = 1

--- a/tools/profiler/profiler-process/classes.py
+++ b/tools/profiler/profiler-process/classes.py
@@ -4,6 +4,7 @@ import json
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from enum import Enum
+import statistics
 
 from errors import ProfilerException
 
@@ -514,6 +515,41 @@ class CycleTrace:
 
 
 @dataclass
+class GroupSummary:
+    """
+    Summary for groups on the number of times they were active vs their active cycles
+    FIXME: Add min/max/avg and collect these for normal groups as well?
+    """
+
+    display_name: str
+    num_times_active: int = 0
+    active_cycles: set[int] = field(default_factory=set)
+    
+    interval_lengths: list[int] = field(default_factory=list)
+
+    def register_interval(self, interval: range):
+        self.num_times_active += 1
+        self.active_cycles.update(set(interval))
+        self.interval_lengths.append(len(interval))
+
+    def fieldnames():
+        return ["group-name", "num-times-active", "total-cycles", "min", "max", "avg", "can-static"]
+    
+    def stats(self):
+        stats = {}
+        stats["group-name"] = self.display_name
+        stats["num-times-active"] = self.num_times_active
+        stats["total-cycles"] = len(self.active_cycles)
+        min_interval = min(self.interval_lengths)
+        max_interval = max(self.interval_lengths)
+        avg_interval = round(statistics.mean(self.interval_lengths), 1)
+        stats["min"] = min_interval
+        stats["max"] = max_interval
+        stats["avg"] = avg_interval
+        stats["can-static"] = "Y" if min_interval == max_interval else "N"
+        return stats
+
+@dataclass
 class Summary:
     """
     Summary for Cells/Control groups on the number of times they were active vs their active cycles
@@ -522,7 +558,6 @@ class Summary:
 
     num_times_active: int = 0
     active_cycles: set[int] = field(default_factory=set)
-
 
 class ControlRegUpdateType(Enum):
     FSM = 1

--- a/tools/profiler/profiler-process/main.py
+++ b/tools/profiler/profiler-process/main.py
@@ -77,6 +77,7 @@ def create_visuals(
     flame.create_simple_flame_graph(
         tracedata, control_reg_updates_per_cycle, args.out_dir
     )
+    stats.write_group_stats(cell_metadata, tracedata, args.out_dir)
     stats.write_cell_stats(
         cell_metadata,
         control_metadata,

--- a/tools/profiler/profiler-process/visuals/stats.py
+++ b/tools/profiler/profiler-process/visuals/stats.py
@@ -8,15 +8,15 @@ from classes import (
     CycleType,
     CycleTrace,
     StackElementType,
-    Summary,
-    GroupSummary
+    GroupSummary,
 )
 
 
 def create_group_summaries(cell_metadata: CellMetadata, tracedata: TraceData):
     """
+    Processes the trace to identify group activation blocks and collect group statistics.
     """
-    group_summaries: dict[str, GroupSummary] = {} # names would be component.group
+    group_summaries: dict[str, GroupSummary] = {}  # names would be component.group
     currently_active_to_start: dict[str, int] = {}
     for i in tracedata.trace:
         active_this_cycle: set[str] = set()
@@ -26,35 +26,39 @@ def create_group_summaries(cell_metadata: CellMetadata, tracedata: TraceData):
             for stack_elem in stack:
                 match stack_elem.element_type:
                     case StackElementType.CELL:
-                       if not stack_elem.is_main:
+                        if not stack_elem.is_main:
                             stack_acc = f"{stack_acc}.{stack_elem.name}"
-                            current_component = cell_metadata.get_component_of_cell(stack_acc)
+                            current_component = cell_metadata.get_component_of_cell(
+                                stack_acc
+                            )
                     case StackElementType.GROUP:
                         group_id = f"{current_component}.{stack_elem.name}"
                         if group_id not in group_summaries:
                             group_summaries[group_id] = GroupSummary(group_id)
                         active_this_cycle.add(group_id)
 
-        # print(f"CURRENTLY ACTIVE: {currently_active_to_start.keys()}")
-        # print(f"ACTIVE THIS CYCLE: {active_this_cycle}")
-            
         # groups that ended this cycle
-        for done_group in set(currently_active_to_start.keys()).difference(active_this_cycle):
-            # print(f"cycle {i} - end group: {done_group}")
+        for done_group in set(currently_active_to_start.keys()).difference(
+            active_this_cycle
+        ):
             start_cycle = currently_active_to_start[done_group]
             group_summaries[done_group].register_interval(range(start_cycle, i))
             del currently_active_to_start[done_group]
         # groups that started this cycle
-        for new_group in active_this_cycle.difference(set(currently_active_to_start.keys())):
-            # print(f"cycle {i} - new group: {new_group}")
+        for new_group in active_this_cycle.difference(
+            set(currently_active_to_start.keys())
+        ):
             currently_active_to_start[new_group] = i
 
     # groups that are active until the end
     for still_active_group in currently_active_to_start:
         start_cycle = currently_active_to_start[still_active_group]
-        group_summaries[group_id].register_interval(range(start_cycle, len(tracedata.trace)))
+        group_summaries[group_id].register_interval(
+            range(start_cycle, len(tracedata.trace))
+        )
 
     return group_summaries
+
 
 def write_group_stats(cell_metadata: CellMetadata, tracedata: TraceData, out_dir: str):
     group_summaries = create_group_summaries(cell_metadata, tracedata)
@@ -70,6 +74,7 @@ def write_group_stats(cell_metadata: CellMetadata, tracedata: TraceData, out_dir
         )
         writer.writeheader()
         writer.writerows(stats_list)
+
 
 def write_cell_stats(
     cell_metadata: CellMetadata,

--- a/tools/profiler/profiler-process/visuals/stats.py
+++ b/tools/profiler/profiler-process/visuals/stats.py
@@ -61,6 +61,9 @@ def create_group_summaries(cell_metadata: CellMetadata, tracedata: TraceData):
 
 
 def write_group_stats(cell_metadata: CellMetadata, tracedata: TraceData, out_dir: str):
+    """
+    Collects and writes statistics information about groups to group-stats.csv.
+    """
     group_summaries = create_group_summaries(cell_metadata, tracedata)
     fieldnames = GroupSummary.fieldnames()
     stats_list = []

--- a/tools/profiler/profiler-process/visuals/stats.py
+++ b/tools/profiler/profiler-process/visuals/stats.py
@@ -8,8 +8,68 @@ from classes import (
     CycleType,
     CycleTrace,
     StackElementType,
+    Summary,
+    GroupSummary
 )
 
+
+def create_group_summaries(cell_metadata: CellMetadata, tracedata: TraceData):
+    """
+    """
+    group_summaries: dict[str, GroupSummary] = {} # names would be component.group
+    currently_active_to_start: dict[str, int] = {}
+    for i in tracedata.trace:
+        active_this_cycle: set[str] = set()
+        for stack in tracedata.trace[i].stacks:
+            stack_acc = cell_metadata.main_component
+            current_component = cell_metadata.main_component
+            for stack_elem in stack:
+                match stack_elem.element_type:
+                    case StackElementType.CELL:
+                       if not stack_elem.is_main:
+                            stack_acc = f"{stack_acc}.{stack_elem.name}"
+                            current_component = cell_metadata.get_component_of_cell(stack_acc)
+                    case StackElementType.GROUP:
+                        group_id = f"{current_component}.{stack_elem.name}"
+                        if group_id not in group_summaries:
+                            group_summaries[group_id] = GroupSummary(group_id)
+                        active_this_cycle.add(group_id)
+
+        # print(f"CURRENTLY ACTIVE: {currently_active_to_start.keys()}")
+        # print(f"ACTIVE THIS CYCLE: {active_this_cycle}")
+            
+        # groups that ended this cycle
+        for done_group in set(currently_active_to_start.keys()).difference(active_this_cycle):
+            # print(f"cycle {i} - end group: {done_group}")
+            start_cycle = currently_active_to_start[done_group]
+            group_summaries[done_group].register_interval(range(start_cycle, i))
+            del currently_active_to_start[done_group]
+        # groups that started this cycle
+        for new_group in active_this_cycle.difference(set(currently_active_to_start.keys())):
+            # print(f"cycle {i} - new group: {new_group}")
+            currently_active_to_start[new_group] = i
+
+    # groups that are active until the end
+    for still_active_group in currently_active_to_start:
+        start_cycle = currently_active_to_start[still_active_group]
+        group_summaries[group_id].register_interval(range(start_cycle, len(tracedata.trace)))
+
+    return group_summaries
+
+def write_group_stats(cell_metadata: CellMetadata, tracedata: TraceData, out_dir: str):
+    group_summaries = create_group_summaries(cell_metadata, tracedata)
+    fieldnames = GroupSummary.fieldnames()
+    stats_list = []
+    for group in sorted(group_summaries.keys()):
+        stats_list.append(group_summaries[group].stats())
+    with open(
+        os.path.join(out_dir, "group-stats.csv"), "w", encoding="utf-8"
+    ) as csvFile:
+        writer = csv.DictWriter(
+            csvFile, fieldnames=fieldnames, lineterminator=os.linesep
+        )
+        writer.writeheader()
+        writer.writerows(stats_list)
 
 def write_cell_stats(
     cell_metadata: CellMetadata,

--- a/tools/profiler/profiler-process/visuals/timeline.py
+++ b/tools/profiler/profiler-process/visuals/timeline.py
@@ -183,7 +183,7 @@ def compute_timeline(tracedata: TraceData, cell_metadata: CellMetadata, out_dir)
                 "E",
                 cell_to_info,
                 group_to_parent_cell,
-                cell_display_name=nonactive_element_display,
+                display_name=nonactive_element_display,
             )
             write_timeline_event(end_event, out_file)
         for newly_active_element, newly_active_display in active_this_cycle.difference(
@@ -195,7 +195,7 @@ def compute_timeline(tracedata: TraceData, cell_metadata: CellMetadata, out_dir)
                 "B",
                 cell_to_info,
                 group_to_parent_cell,
-                cell_display_name=newly_active_display,
+                display_name=newly_active_display,
             )
             write_timeline_event(begin_event, out_file)
         currently_active = active_this_cycle
@@ -213,7 +213,7 @@ def compute_timeline(tracedata: TraceData, cell_metadata: CellMetadata, out_dir)
             "E",
             cell_to_info,
             group_to_parent_cell,
-            cell_display_name=still_active_display,
+            display_name=still_active_display,
         )
         write_timeline_event(end_event, out_file)
 
@@ -228,7 +228,7 @@ def create_timeline_event(
     event_type,
     cell_to_info,
     group_to_parent_cell,
-    cell_display_name=None,
+    display_name=None,
 ):
     """
     Creates a JSON entry for traceEvents.
@@ -239,7 +239,7 @@ def create_timeline_event(
     """
     if element_name in cell_to_info:  # cell
         event = {
-            "name": element_name if cell_display_name is None else cell_display_name,
+            "name": element_name if display_name is None else display_name,
             "cat": "cell",
             "ph": event_type,
             "pid": cell_to_info[element_name].pid,


### PR DESCRIPTION
The VCD-processing scripts now produce statistics about groups, including the min/max/average number of cycles the group was active for on each enable. If `min` == `max`, then the group is a candidate to be converted to `static`.

I also brought back changes to TDCC that output par parent-child info that was removed.