### PR TITLE
[Fud 2] Use `uv` for `fud2 env init` and to install the needed dependencies

### DIFF
--- a/frontends/ntt-pipeline/pyproject.toml
+++ b/frontends/ntt-pipeline/pyproject.toml
@@ -11,10 +11,3 @@ description = ""
 
 [tool.uv.sources]
 calyx-ast = { workspace = true }
-
-# [project.scripts]
-# ntt-pipeline = "./gen-ntt-pipeline:main"
-
-# [build-system]
-# requires = ["flit_core >=3.2,<4"]
-# build-backend = "flit_core.buildapi"

--- a/frontends/ntt-pipeline/pyproject.toml
+++ b/frontends/ntt-pipeline/pyproject.toml
@@ -1,0 +1,20 @@
+
+[project]
+name = "ntt-pipeline"
+requires-python = ">=3.13"
+dependencies = [
+    "numpy>=2.3.0",
+    "prettytable>=3.16.0",
+]
+version = "0.1.0"
+description = ""
+
+[tool.uv.sources]
+calyx-ast = { workspace = true }
+
+# [project.scripts]
+# ntt-pipeline = "./gen-ntt-pipeline:main"
+
+# [build-system]
+# requires = ["flit_core >=3.2,<4"]
+# build-backend = "flit_core.buildapi"

--- a/frontends/systolic-lang/pyproject.toml
+++ b/frontends/systolic-lang/pyproject.toml
@@ -1,0 +1,14 @@
+tool.uv.package = false
+
+[project]
+name = "systolic-lang"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = [
+    "calyx-ast",
+    "numpy>=2.3.0",
+]
+
+
+[tool.uv.sources]
+calyx-ast = { workspace = true }

--- a/fud2/src/cli_pyenv.rs
+++ b/fud2/src/cli_pyenv.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::Path, process::Command};
+use std::{fs, process::Command};
 
 use argh::{CommandInfo, FromArgs};
 use fud_core::{
@@ -33,49 +33,45 @@ pub struct ActivateCommand {}
 
 impl PyenvCommand {
     fn init(&self, driver: &fud_core::Driver) -> anyhow::Result<()> {
-        let data_dir = config::data_dir(&driver.name);
+        // This is a bit of a hack to detect whether or not uv is installed
+        if Command::new("uv").arg("--version").output().is_err() {
+            anyhow::bail!(
+                "fud2 env requires `uv` to be installed.\n       Installation instructions can be found at: https://docs.astral.sh/uv/getting-started/installation/"
+            )
+        }
 
+        let data_dir = config::data_dir(&driver.name);
         fs::create_dir_all(&data_dir)?;
 
         let pyenv = data_dir.join("venv");
 
         // create new venv
-        Command::new("python3")
-            .args(["-m", "venv"])
+        Command::new("uv")
+            .args(["venv"])
             .arg(&pyenv)
             .stdout(std::io::stdout())
-            .output()?;
-
-        // install vcdvcd (for Profiler)
-        Command::new(pyenv.join("bin").join("pip"))
-            .arg("install")
-            .arg("vcdvcd")
-            .stdout(std::io::stdout())
-            .output()?;
-
-        // install flit
-        Command::new(pyenv.join("bin").join("pip"))
-            .arg("install")
-            .arg("flit")
-            .stdout(std::io::stdout())
+            .stderr(std::io::stderr())
             .output()?;
 
         // grab the location of the calyx base install
         let config = config::load_config(&driver.name);
         let calyx_base: String = config.extract_inner("calyx.base")?;
 
-        // install fud python library
-        Command::new(pyenv.join("bin").join("python"))
-            .args(["-m", "flit", "install"])
-            .current_dir(Path::new(&calyx_base).join("fud"))
+        Command::new("uv")
+            .args([
+                "sync",
+                "--all-extras",
+                // needed to use the proper venv since uv REALLY wants to use a
+                // local `.venv` directory
+                "--active",
+            ])
             .stdout(std::io::stdout())
-            .output()?;
-
-        // install calyx-py library
-        Command::new(pyenv.join("bin").join("python"))
-            .args(["-m", "flit", "install"])
-            .current_dir(Path::new(&calyx_base).join("calyx-py"))
-            .stdout(std::io::stdout())
+            .stderr(std::io::stderr())
+            // ensure this executes in the appropriate venv
+            .env("VIRTUAL_ENV", &pyenv)
+            // ensure this executes from the calyx dir so that uv sync reads the
+            // right pyproject.toml when installing dependencies
+            .current_dir(calyx_base)
             .output()?;
 
         // add python location to fud2.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+tool.uv.package = false
+
+[project]
+name = "calyx-tools"
+authors = []
+requires-python = ">=3.13"
+dependencies = ["calyx-ast"]
+version = "0.1.0"
+
+[tool.uv.sources]
+calyx-ast = { workspace = true }
+ntt-pipeline = { workspace = true }
+systolic-lang = { workspace = true }
+mrxl = { workspace = true }
+queues = { workspace = true }
+
+[tool.uv.workspace]
+members = [
+    "frontends/ntt-pipeline",
+    "frontends/systolic-lang",
+    "calyx-py",
+    "frontends/mrxl",
+    "frontends/queues",
+]
+
+[project.optional-dependencies]
+ntt = ["ntt-pipeline"]
+systolic = ["systolic-lang"]
+mrxl = ["mrxl"]
+queues = ["queues"]
+profiler = [
+    # should probably add the profiler to the workplace but I don't want to deal
+    # with that right now
+    "vcdvcd"
+]
+fud2_scripts = [
+    # definitely incomplete list
+    "simplejson"
+]

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,196 @@
+version = 1
+revision = 2
+requires-python = ">=3.13"
+
+[manifest]
+members = [
+    "calyx-ast",
+    "calyx-tools",
+    "mrxl",
+    "ntt-pipeline",
+    "queues",
+    "systolic-lang",
+]
+
+[[package]]
+name = "calyx-ast"
+source = { editable = "calyx-py" }
+
+[[package]]
+name = "calyx-tools"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "calyx-ast" },
+]
+
+[package.optional-dependencies]
+fud2-scripts = [
+    { name = "simplejson" },
+]
+mrxl = [
+    { name = "mrxl" },
+]
+ntt = [
+    { name = "ntt-pipeline" },
+]
+profiler = [
+    { name = "vcdvcd" },
+]
+queues = [
+    { name = "queues" },
+]
+systolic = [
+    { name = "systolic-lang" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "calyx-ast", editable = "calyx-py" },
+    { name = "mrxl", marker = "extra == 'mrxl'", editable = "frontends/mrxl" },
+    { name = "ntt-pipeline", marker = "extra == 'ntt'", virtual = "frontends/ntt-pipeline" },
+    { name = "queues", marker = "extra == 'queues'", editable = "frontends/queues" },
+    { name = "simplejson", marker = "extra == 'fud2-scripts'" },
+    { name = "systolic-lang", marker = "extra == 'systolic'", virtual = "frontends/systolic-lang" },
+    { name = "vcdvcd", marker = "extra == 'profiler'" },
+]
+provides-extras = ["ntt", "systolic", "mrxl", "queues", "profiler", "fud2-scripts"]
+
+[[package]]
+name = "lark-parser"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/ee/fd1192d7724419ddfe15b6f17d1c8742800d4de917c0adac3b6aaf22e921/lark-parser-0.12.0.tar.gz", hash = "sha256:15967db1f1214013dca65b1180745047b9be457d73da224fcda3d9dd4e96a138", size = 235029, upload-time = "2021-08-30T09:14:44.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/00/90f05db333fe1aa6b6ffea83a35425b7d53ea95c8bba0b1597f226cf1d5f/lark_parser-0.12.0-py2.py3-none-any.whl", hash = "sha256:0eaf30cb5ba787fe404d73a7d6e61df97b21d5a63ac26c5008c78a494373c675", size = 103498, upload-time = "2021-08-30T13:01:01.603Z" },
+]
+
+[[package]]
+name = "mrxl"
+source = { editable = "frontends/mrxl" }
+dependencies = [
+    { name = "calyx-ast" },
+    { name = "lark-parser" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "calyx-ast", editable = "calyx-py" },
+    { name = "lark-parser" },
+]
+
+[[package]]
+name = "ntt-pipeline"
+version = "0.1.0"
+source = { virtual = "frontends/ntt-pipeline" }
+dependencies = [
+    { name = "numpy" },
+    { name = "prettytable" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "numpy", specifier = ">=2.3.0" },
+    { name = "prettytable", specifier = ">=3.16.0" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/db/8e12381333aea300890829a0a36bfa738cac95475d88982d538725143fd9/numpy-2.3.0.tar.gz", hash = "sha256:581f87f9e9e9db2cba2141400e160e9dd644ee248788d6f90636eeb8fd9260a6", size = 20382813, upload-time = "2025-06-07T14:54:32.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/fc/1d67f751fd4dbafc5780244fe699bc4084268bad44b7c5deb0492473127b/numpy-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5754ab5595bfa2c2387d241296e0381c21f44a4b90a776c3c1d39eede13a746a", size = 20889633, upload-time = "2025-06-07T14:44:06.839Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/73ffdb69e5c3f19ec4530f8924c4386e7ba097efc94b9c0aff607178ad94/numpy-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d11fa02f77752d8099573d64e5fe33de3229b6632036ec08f7080f46b6649959", size = 14151683, upload-time = "2025-06-07T14:44:28.847Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d5/06d4bb31bb65a1d9c419eb5676173a2f90fd8da3c59f816cc54c640ce265/numpy-2.3.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:aba48d17e87688a765ab1cd557882052f238e2f36545dfa8e29e6a91aef77afe", size = 5102683, upload-time = "2025-06-07T14:44:38.417Z" },
+    { url = "https://files.pythonhosted.org/packages/12/8b/6c2cef44f8ccdc231f6b56013dff1d71138c48124334aded36b1a1b30c5a/numpy-2.3.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4dc58865623023b63b10d52f18abaac3729346a7a46a778381e0e3af4b7f3beb", size = 6640253, upload-time = "2025-06-07T14:44:49.359Z" },
+    { url = "https://files.pythonhosted.org/packages/62/aa/fca4bf8de3396ddb59544df9b75ffe5b73096174de97a9492d426f5cd4aa/numpy-2.3.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:df470d376f54e052c76517393fa443758fefcdd634645bc9c1f84eafc67087f0", size = 14258658, upload-time = "2025-06-07T14:45:10.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/12/734dce1087eed1875f2297f687e671cfe53a091b6f2f55f0c7241aad041b/numpy-2.3.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:87717eb24d4a8a64683b7a4e91ace04e2f5c7c77872f823f02a94feee186168f", size = 16628765, upload-time = "2025-06-07T14:45:35.076Z" },
+    { url = "https://files.pythonhosted.org/packages/48/03/ffa41ade0e825cbcd5606a5669962419528212a16082763fc051a7247d76/numpy-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d8fa264d56882b59dcb5ea4d6ab6f31d0c58a57b41aec605848b6eb2ef4a43e8", size = 15564335, upload-time = "2025-06-07T14:45:58.797Z" },
+    { url = "https://files.pythonhosted.org/packages/07/58/869398a11863310aee0ff85a3e13b4c12f20d032b90c4b3ee93c3b728393/numpy-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e651756066a0eaf900916497e20e02fe1ae544187cb0fe88de981671ee7f6270", size = 18360608, upload-time = "2025-06-07T14:46:25.687Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/8a/5756935752ad278c17e8a061eb2127c9a3edf4ba2c31779548b336f23c8d/numpy-2.3.0-cp313-cp313-win32.whl", hash = "sha256:e43c3cce3b6ae5f94696669ff2a6eafd9a6b9332008bafa4117af70f4b88be6f", size = 6310005, upload-time = "2025-06-07T14:50:13.138Z" },
+    { url = "https://files.pythonhosted.org/packages/08/60/61d60cf0dfc0bf15381eaef46366ebc0c1a787856d1db0c80b006092af84/numpy-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:81ae0bf2564cf475f94be4a27ef7bcf8af0c3e28da46770fc904da9abd5279b5", size = 12729093, upload-time = "2025-06-07T14:50:31.82Z" },
+    { url = "https://files.pythonhosted.org/packages/66/31/2f2f2d2b3e3c32d5753d01437240feaa32220b73258c9eef2e42a0832866/numpy-2.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:c8738baa52505fa6e82778580b23f945e3578412554d937093eac9205e845e6e", size = 9885689, upload-time = "2025-06-07T14:50:47.888Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/89/c7828f23cc50f607ceb912774bb4cff225ccae7131c431398ad8400e2c98/numpy-2.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:39b27d8b38942a647f048b675f134dd5a567f95bfff481f9109ec308515c51d8", size = 20986612, upload-time = "2025-06-07T14:46:56.077Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/46/79ecf47da34c4c50eedec7511e53d57ffdfd31c742c00be7dc1d5ffdb917/numpy-2.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:0eba4a1ea88f9a6f30f56fdafdeb8da3774349eacddab9581a21234b8535d3d3", size = 14298953, upload-time = "2025-06-07T14:47:18.053Z" },
+    { url = "https://files.pythonhosted.org/packages/59/44/f6caf50713d6ff4480640bccb2a534ce1d8e6e0960c8f864947439f0ee95/numpy-2.3.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:b0f1f11d0a1da54927436505a5a7670b154eac27f5672afc389661013dfe3d4f", size = 5225806, upload-time = "2025-06-07T14:47:27.524Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/43/e1fd1aca7c97e234dd05e66de4ab7a5be54548257efcdd1bc33637e72102/numpy-2.3.0-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:690d0a5b60a47e1f9dcec7b77750a4854c0d690e9058b7bef3106e3ae9117808", size = 6735169, upload-time = "2025-06-07T14:47:38.057Z" },
+    { url = "https://files.pythonhosted.org/packages/84/89/f76f93b06a03177c0faa7ca94d0856c4e5c4bcaf3c5f77640c9ed0303e1c/numpy-2.3.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:8b51ead2b258284458e570942137155978583e407babc22e3d0ed7af33ce06f8", size = 14330701, upload-time = "2025-06-07T14:47:59.113Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/f5/4858c3e9ff7a7d64561b20580cf7cc5d085794bd465a19604945d6501f6c/numpy-2.3.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:aaf81c7b82c73bd9b45e79cfb9476cb9c29e937494bfe9092c26aece812818ad", size = 16692983, upload-time = "2025-06-07T14:48:24.196Z" },
+    { url = "https://files.pythonhosted.org/packages/08/17/0e3b4182e691a10e9483bcc62b4bb8693dbf9ea5dc9ba0b77a60435074bb/numpy-2.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f420033a20b4f6a2a11f585f93c843ac40686a7c3fa514060a97d9de93e5e72b", size = 15641435, upload-time = "2025-06-07T14:48:47.712Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/463279fda028d3c1efa74e7e8d507605ae87f33dbd0543cf4c4527c8b882/numpy-2.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d344ca32ab482bcf8735d8f95091ad081f97120546f3d250240868430ce52555", size = 18433798, upload-time = "2025-06-07T14:49:14.866Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1e/7a9d98c886d4c39a2b4d3a7c026bffcf8fbcaf518782132d12a301cfc47a/numpy-2.3.0-cp313-cp313t-win32.whl", hash = "sha256:48a2e8eaf76364c32a1feaa60d6925eaf32ed7a040183b807e02674305beef61", size = 6438632, upload-time = "2025-06-07T14:49:25.67Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ab/66fc909931d5eb230107d016861824f335ae2c0533f422e654e5ff556784/numpy-2.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ba17f93a94e503551f154de210e4d50c5e3ee20f7e7a1b5f6ce3f22d419b93bb", size = 12868491, upload-time = "2025-06-07T14:49:44.898Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e8/2c8a1c9e34d6f6d600c83d5ce5b71646c32a13f34ca5c518cc060639841c/numpy-2.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f14e016d9409680959691c109be98c436c6249eaf7f118b424679793607b5944", size = 9935345, upload-time = "2025-06-07T14:50:02.311Z" },
+]
+
+[[package]]
+name = "prettytable"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/b1/85e18ac92afd08c533603e3393977b6bc1443043115a47bb094f3b98f94f/prettytable-3.16.0.tar.gz", hash = "sha256:3c64b31719d961bf69c9a7e03d0c1e477320906a98da63952bc6698d6164ff57", size = 66276, upload-time = "2025-03-24T19:39:04.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c7/5613524e606ea1688b3bdbf48aa64bafb6d0a4ac3750274c43b6158a390f/prettytable-3.16.0-py3-none-any.whl", hash = "sha256:b5eccfabb82222f5aa46b798ff02a8452cf530a352c31bddfa29be41242863aa", size = 33863, upload-time = "2025-03-24T19:39:02.359Z" },
+]
+
+[[package]]
+name = "queues"
+source = { editable = "frontends/queues" }
+
+[[package]]
+name = "simplejson"
+version = "3.20.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/92/51b417685abd96b31308b61b9acce7ec50d8e1de8fbc39a7fd4962c60689/simplejson-3.20.1.tar.gz", hash = "sha256:e64139b4ec4f1f24c142ff7dcafe55a22b811a74d86d66560c8815687143037d", size = 85591, upload-time = "2025-02-15T05:18:53.15Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/03/0f453a27877cb5a5fff16a975925f4119102cc8552f52536b9a98ef0431e/simplejson-3.20.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:71e849e7ceb2178344998cbe5ade101f1b329460243c79c27fbfc51c0447a7c3", size = 93109, upload-time = "2025-02-15T05:17:00.377Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1f/a729f4026850cabeaff23e134646c3f455e86925d2533463420635ae54de/simplejson-3.20.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b63fdbab29dc3868d6f009a59797cefaba315fd43cd32ddd998ee1da28e50e29", size = 75475, upload-time = "2025-02-15T05:17:02.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/14/50a2713fee8ff1f8d655b1a14f4a0f1c0c7246768a1b3b3d12964a4ed5aa/simplejson-3.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1190f9a3ce644fd50ec277ac4a98c0517f532cfebdcc4bd975c0979a9f05e1fb", size = 75112, upload-time = "2025-02-15T05:17:03.875Z" },
+    { url = "https://files.pythonhosted.org/packages/45/86/ea9835abb646755140e2d482edc9bc1e91997ed19a59fd77ae4c6a0facea/simplejson-3.20.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1336ba7bcb722ad487cd265701ff0583c0bb6de638364ca947bb84ecc0015d1", size = 150245, upload-time = "2025-02-15T05:17:06.899Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b4/53084809faede45da829fe571c65fbda8479d2a5b9c633f46b74124d56f5/simplejson-3.20.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e975aac6a5acd8b510eba58d5591e10a03e3d16c1cf8a8624ca177491f7230f0", size = 158465, upload-time = "2025-02-15T05:17:08.707Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/7d/d56579468d1660b3841e1f21c14490d103e33cf911886b22652d6e9683ec/simplejson-3.20.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6a6dd11ee282937ad749da6f3b8d87952ad585b26e5edfa10da3ae2536c73078", size = 148514, upload-time = "2025-02-15T05:17:11.323Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e3/874b1cca3d3897b486d3afdccc475eb3a09815bf1015b01cf7fcb52a55f0/simplejson-3.20.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab980fcc446ab87ea0879edad41a5c28f2d86020014eb035cf5161e8de4474c6", size = 152262, upload-time = "2025-02-15T05:17:13.543Z" },
+    { url = "https://files.pythonhosted.org/packages/32/84/f0fdb3625292d945c2bd13a814584603aebdb38cfbe5fe9be6b46fe598c4/simplejson-3.20.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f5aee2a4cb6b146bd17333ac623610f069f34e8f31d2f4f0c1a2186e50c594f0", size = 150164, upload-time = "2025-02-15T05:17:15.021Z" },
+    { url = "https://files.pythonhosted.org/packages/95/51/6d625247224f01eaaeabace9aec75ac5603a42f8ebcce02c486fbda8b428/simplejson-3.20.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:652d8eecbb9a3b6461b21ec7cf11fd0acbab144e45e600c817ecf18e4580b99e", size = 151795, upload-time = "2025-02-15T05:17:16.542Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d9/bb921df6b35be8412f519e58e86d1060fddf3ad401b783e4862e0a74c4c1/simplejson-3.20.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8c09948f1a486a89251ee3a67c9f8c969b379f6ffff1a6064b41fea3bce0a112", size = 159027, upload-time = "2025-02-15T05:17:18.083Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c5/5950605e4ad023a6621cf4c931b29fd3d2a9c1f36be937230bfc83d7271d/simplejson-3.20.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cbbd7b215ad4fc6f058b5dd4c26ee5c59f72e031dfda3ac183d7968a99e4ca3a", size = 154380, upload-time = "2025-02-15T05:17:20.334Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ad/b74149557c5ec1e4e4d55758bda426f5d2ec0123cd01a53ae63b8de51fa3/simplejson-3.20.1-cp313-cp313-win32.whl", hash = "sha256:ae81e482476eaa088ef9d0120ae5345de924f23962c0c1e20abbdff597631f87", size = 74102, upload-time = "2025-02-15T05:17:22.475Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a9/25282fdd24493e1022f30b7f5cdf804255c007218b2bfaa655bd7ad34b2d/simplejson-3.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:1b9fd15853b90aec3b1739f4471efbf1ac05066a2c7041bf8db821bb73cd2ddc", size = 75736, upload-time = "2025-02-15T05:17:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/00f02a0a921556dd5a6db1ef2926a1bc7a8bbbfb1c49cfed68a275b8ab2b/simplejson-3.20.1-py3-none-any.whl", hash = "sha256:8a6c1bbac39fa4a79f83cbf1df6ccd8ff7069582a9fd8db1e52cea073bc2c697", size = 57121, upload-time = "2025-02-15T05:18:51.243Z" },
+]
+
+[[package]]
+name = "systolic-lang"
+version = "0.1.0"
+source = { virtual = "frontends/systolic-lang" }
+dependencies = [
+    { name = "calyx-ast" },
+    { name = "numpy" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "calyx-ast", editable = "calyx-py" },
+    { name = "numpy", specifier = ">=2.3.0" },
+]
+
+[[package]]
+name = "vcdvcd"
+version = "2.3.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/15/9c24d476935e26116ac0b12b2e282f17b28cd1bba842ae9e0733c8d712b5/vcdvcd-2.3.6.tar.gz", hash = "sha256:3a48654f63fe4c303456acd27b2ab8480c9d357097f34f7e1b9d84005408cd4e", size = 13434, upload-time = "2024-08-10T12:04:26.616Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/18/d8a0a4efab0dfc20af2f6043cfe1d77e689d12eef5e744de71831cd24860/vcdvcd-2.3.6-py3-none-any.whl", hash = "sha256:69607a4e9eac45dd868366327a157d152c49caf590dbd676a96e4baa62a2fe27", size = 11685, upload-time = "2024-08-10T12:04:24.665Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
+]


### PR DESCRIPTION
Reworks the `fud2 env init` flow to use the `uv` tool to create the environment and populate it with all the dependencies we've registered in the `pyproject.toml` at the root of the repo. The list of dependencies is likely currently incomplete but we can add the needed dependencies as the migration progresses