### PR TITLE
[Fud2] Add the `vcd_json` op for `fud2`

### DIFF
--- a/fud2/scripts/vcd_json.rhai
+++ b/fud2/scripts/vcd_json.rhai
@@ -1,0 +1,7 @@
+import "rtl_sim" as sim;
+
+defop vcd_json(vcd: sim::vcd) >> out: sim::dat {
+    let vcdump = config_or("vcdump.exe", "vcdump");
+
+    shell(`${vcdump} ${vcd} > ${out}`)
+}

--- a/fud2/tests/snapshots/tests__list_ops.snap
+++ b/fud2/tests/snapshots/tests__list_ops.snap
@@ -1,6 +1,5 @@
 ---
 source: fud2/tests/tests.rs
-snapshot_kind: text
 ---
 [
     (
@@ -127,6 +126,11 @@ snapshot_kind: text
         "trace",
         "sim",
         "vcd",
+    ),
+    (
+        "vcd_json",
+        "vcd",
+        "dat",
     ),
     (
         "verilator",

--- a/fud2/tests/snapshots/tests__test@plan_vcd_json.snap
+++ b/fud2/tests/snapshots/tests__test@plan_vcd_json.snap
@@ -1,0 +1,17 @@
+---
+source: fud2/tests/tests.rs
+description: "emit plan: vcd_json"
+---
+build-tool = fud2
+rule get-rsrc
+  command = $build-tool get-rsrc $out
+
+vcdump.exe = vcdump
+rule vcd_json_rule_1
+  command = ${vcdump.exe} $i0 > $o0
+build _vcd_json_rule_1.fake $o0: vcd_json_rule_1 $i0
+  i0 = /input.ext
+  o0 = /output.ext
+
+
+default /output.ext


### PR DESCRIPTION
Turned out to be a pretty simple tool invocation. You can now use `--through vcd_json` as in original `fud`