### PR TITLE
fud2: Depend on fud by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ profiler = [
     "vcdvcd",
 ]
 fud2_scripts = [
-    # definitely incomplete list
-    "simplejson",
+    # Some fud2 components import pieces of OG fud's Python implementation. It
+    # is a medium-term goal to split out this functionality to make it
+    # independent of the `fud` package, so we can eventually remove the latter.
+    "fud",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -104,7 +104,7 @@ dependencies = [
 
 [package.optional-dependencies]
 fud2-scripts = [
-    { name = "simplejson" },
+    { name = "fud" },
 ]
 mrxl = [
     { name = "mrxl" },
@@ -125,10 +125,10 @@ systolic = [
 [package.metadata]
 requires-dist = [
     { name = "calyx-ast", editable = "calyx-py" },
+    { name = "fud", marker = "extra == 'fud2-scripts'", editable = "fud" },
     { name = "mrxl", marker = "extra == 'mrxl'", editable = "frontends/mrxl" },
     { name = "ntt-pipeline", marker = "extra == 'ntt'", virtual = "frontends/ntt-pipeline" },
     { name = "queues", marker = "extra == 'queues'", editable = "frontends/queues" },
-    { name = "simplejson", marker = "extra == 'fud2-scripts'" },
     { name = "systolic-lang", marker = "extra == 'systolic'", virtual = "frontends/systolic-lang" },
     { name = "vcdvcd", marker = "extra == 'profiler'" },
 ]


### PR DESCRIPTION
It turns out that `fud2 env init` wasn't quite installing the `fud` package by default; we also needed to include a dependency on it. I hope this makes things work out of the box...

This is a follow-up to #2480.