### PR TITLE
fud2: Suppress SIGINT during Ninja execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,7 @@ dependencies = [
  "env_logger",
  "figment",
  "itertools 0.11.0",
+ "libc",
  "log",
  "once_cell",
  "pathdiff",
@@ -1875,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libredox"

--- a/fud2/fud-core/Cargo.toml
+++ b/fud2/fud-core/Cargo.toml
@@ -27,6 +27,7 @@ itertools.workspace = true
 rand = "0.8.5"
 egg = { version = "0.9.5", optional = true }
 toml_edit = { version = "0.22.20", features = ["serde"] }
+libc = "0.2.174"
 
 [dev-dependencies]
 rand_chacha = "0.3.1"

--- a/fud2/fud-core/src/lib.rs
+++ b/fud2/fud-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod exec;
 pub mod run;
 pub mod script;
+mod uninterrupt;
 pub mod utils;
 
 pub use exec::{Driver, DriverBuilder};

--- a/fud2/fud-core/src/uninterrupt.rs
+++ b/fud2/fud-core/src/uninterrupt.rs
@@ -1,0 +1,39 @@
+/// Temporarily suppress SIGINT.
+///
+/// This is an RAII marker that temporarily suppresses the default behavior of
+/// the SIGINT signal, i.e., that ignores "control-C." It does not suppress the
+/// signal for the entire process group, however, so child processes still get
+/// interrupted as usual.
+///
+/// Use the lifetime of the `Uninterrupt` object to define a scope where this
+/// behavior is applied, like this:
+///
+///     let foo = {
+///         let _unint = Uninterrupt::suppress();
+///         do_stuff();
+///     };
+///
+/// Then SIGINT will be suppressed during the call to `do_stuff()`.
+pub struct Uninterrupt {}
+
+impl Uninterrupt {
+    pub fn suppress() -> Self {
+        // Register a no-op handler for SIGINT. This is different from ignoring
+        // SIGINT altogether because it still allows the signal to go to the
+        // children in the process group.
+        fn nop() {}
+        unsafe {
+            libc::signal(libc::SIGINT, nop as usize);
+        }
+        Self {}
+    }
+}
+
+impl Drop for Uninterrupt {
+    fn drop(&mut self) {
+        // Restore the default behavior of SIGINT.
+        unsafe {
+            libc::signal(libc::SIGINT, libc::SIG_DFL);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2154, which is about leaving the `.fud2` directory behind when you interrupt execution with ^C.

The idea is to suppress the default behavior of SIGINT *for the fud2 process only*. SIGINT still goes to the child process, i.e., to Ninja. This way, when you type ^C when running fud2, it kills the underlying Ninja process as you expect, but fud2 still gets a chance to clean up afterward---notably, by deleting the `.fud2` working directory.

Interestingly, the solution here is to register a no-op handler for SIGINT. This is distinct from using SIG_IGN, which ignores the signal for the entire process group (not what we want: it would make it impossible to stop Ninja too!).

This seems to work here; interrupting with ^C looks like this:

```
$ fud2 --from ntt tests/correctness/ntt-pipeline/ntt-16.txt --to dat -s sim.data=tests/correctness/ntt-pipeline/ntt-16.txt.data --through verilator
^Cninja: build stopped: interrupted by user.
Error: ninja exited with exit status: 2
```

And the `.fud2` directory is indeed deleted. (We could consider making the latter error message friendlier if we want.)

I would really appreciate it if someone else were to try this out locally! And to check my thinking on the weirdo RAII-only struct for managing the signal state.