### PR TITLE
[fud 2] tweak `fud2 env activate`

### DIFF
--- a/fud2/src/cli_pyenv.rs
+++ b/fud2/src/cli_pyenv.rs
@@ -89,7 +89,10 @@ impl PyenvCommand {
 
         fs::write(&config_path, toml_doc.to_string())?;
 
-        println!("run 'eval $(fud2 env activate)' to activate the virtualenv");
+        println!(
+            "Fud2 has been configured to automatically use the virtual environment's python interpreter.
+  To use the virtual environment outside of fud2 run 'eval $(fud2 env activate)' to activate it"
+        );
 
         Ok(())
     }

--- a/fud2/src/cli_pyenv.rs
+++ b/fud2/src/cli_pyenv.rs
@@ -89,6 +89,8 @@ impl PyenvCommand {
 
         fs::write(&config_path, toml_doc.to_string())?;
 
+        println!("run 'eval $(fud2 env activate)' to activate the virtualenv");
+
         Ok(())
     }
 
@@ -102,7 +104,10 @@ impl PyenvCommand {
             )
         }
 
-        println!("{}", pyenv.join("bin").join("activate").to_str().unwrap());
+        println!(
+            "source {}",
+            pyenv.join("bin").join("activate").to_str().unwrap()
+        );
 
         Ok(())
     }


### PR DESCRIPTION
make `fud2 env activate` print out a command which can be `eval`ed to activate the venv, or just copied and run separately and reference this in the `init` printout