### PR TITLE
[docs] First cut at recommending fud2 throughout

### DIFF
--- a/docs/frontends/dahlia.md
+++ b/docs/frontends/dahlia.md
@@ -37,7 +37,7 @@ Dahlia programs can be compiled to Calyx using:
 fud2 --from dahlia <input file> --to calyx
 ```
 
-The Dahlia backed for Calyx is neither *complete* nor *stable*. If you find
+The Dahlia backend for Calyx is neither *complete* nor *stable*. If you find
 a confusing error or wrong program, please open an [issue][].
 
 [dahlia]: https://capra.cs.cornell.edu/dahlia

--- a/docs/frontends/dahlia.md
+++ b/docs/frontends/dahlia.md
@@ -21,16 +21,11 @@ The Dahlia compiler can be run using the `./fuse` binary:
 ./fuse --help
 ```
 
-Finally, configure `fud` to use the Dahlia compiler:
+Finally, configure `fud2` to use the Dahlia compiler.
+Type `fud2 edit-config` and add a line like this:
 ```
-fud c stages.dahlia.exec <path to Dahlia repository>/fuse
+dahlia = "<path to Dahlia repository>/fuse"
 ```
-Use `fud` to check if the compiler was installed correctly:
-```
-fud check
-```
-`fud` should report that the Dahlia compiler is available and has the right
-version.
 
 If something went wrong, try following the [instructions][] to build the Dahlia
 compiler from its repository.
@@ -39,7 +34,7 @@ compiler from its repository.
 
 Dahlia programs can be compiled to Calyx using:
 ```
-fud e --from dahlia <input file> --to calyx
+fud2 --from dahlia <input file> --to calyx
 ```
 
 The Dahlia backed for Calyx is neither *complete* nor *stable*. If you find

--- a/docs/frontends/mrxl.md
+++ b/docs/frontends/mrxl.md
@@ -16,25 +16,15 @@ The explanation on this page is relatively brief; see the [frontend tutorial][fr
 Install
 -------
 
-First, install the [calyx-py](../calyx-py.md) library.
+You can run the MrXL implementation using [uv][].
+Type this in the `mrxl` directory:
 
-The MrXL implementation is in Python and uses [Flit][].
-Install Flit (`pip install flit` or similar), and then type the
-following after changing your directory to `frontends/mrxl`:
+    uv run mrxl --help
 
-    flit install --symlink
+[fud2][] also comes with an op for compiling MrXL programs to Calyx.
 
-This creates a symbolic link to the present directory and installs the `mrxl` command line tool.
-
-By default, [fud](../running-calyx/fud) looks for the `mrxl` executable to enable
-the `mrxl` compilation stage.
-Type `fud check` to make sure `fud` reports that the `mrxl` compiler has been
-found. If it does not, run the following while still in `frontends/mrxl`.
-
-    fud register mrxl -p fud/mrxl.py
-
-Run `fud check` again to ensure that `fud` sees `mrxl`.
-
+[uv]: https://docs.astral.sh/uv/
+[fud2]: ../running-calyx/fud2
 
 Interpreting MrXL
 -----------------
@@ -64,16 +54,16 @@ To run the compiler and see the Calyx code your MrXL program generates, just dro
 
 In order to run the compiler through `fud`, pass the `--from mrxl` and `--to calyx` flags:
 
-    fud e --from mrxl <prog.mrxl> --to calyx
+    fud2 --from mrxl <prog.mrxl> --to calyx
 
 And finally, the real prize.
 In order to compile MrXL to Calyx and then simulate the Calyx code in Verilog, run:
 
-    fud e --from mrxl <prog>.mrxl --to dat --through verilog -s mrxl.data <prog>.mrxl.data
+    mrxl --convert --data <prog>.mrxl.data > something.dat
+    fud2 --from mrxl <prog>.mrxl --to dat --through verilator -s sim.data=something.dat
 
 An aside: MrXL permits a simplified data format, which is what we have been looking at in our `<prog>.mrxl.data` files.
 Files of this form need to be beefed up with additional information so that Verilog (and similar simulators) can work with them.
-We did this beefing up "on the fly" in the incantation above, but it is interesting to see the changes we made.
 
 See this with:
 

--- a/docs/frontends/ntt.md
+++ b/docs/frontends/ntt.md
@@ -29,17 +29,10 @@ during each stage of the pipeline. This requires installing PrettyTable:
 
     pip3 install prettytable numpy
 
-## Fud Stage
+## fud2 Op
 
-The NTT pipeline defines an [external fud stage](../running-calyx/fud/external.md) to
-transform configuration files into Calyx programs.
-To install, run:
-
-```
-fud register ntt -p frontends/ntt-pipeline/fud/ntt.py && fud check
-```
-
-This should report the newly installed `ntt` stage in the configuration.
+fud2 comes with an op for generating NTT implementations built-in.
+Use `--from ntt`.
 
 ## Configuration Files
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -105,41 +105,36 @@ tests.
 
 ## Installing the Command-Line Driver
 
-[The Calyx driver](./running-calyx/fud) wraps the various compiler frontends and
+[The Calyx driver](./running-calyx/fud2), called fud2, wraps the various compiler frontends and
 backends to simplify running Calyx programs.
 Start at the root of the repository.
 
-Install [Flit][]:
+Install fud2 using Cargo:
 
-```
-pip3 install flit
-```
+    cargo install --path fud2
 
-Install [`calyx-py`](builder/calyx-py.md):
+fud2 requires [Ninja][] and [uv][], so install those if you don't already have them.
+For example, use `brew install ninja uv` on macOS or `apt-get install ninja-build` followed by `curl -LsSf https://astral.sh/uv/install.sh | sh` on Debian/Ubuntu.
 
-```
-cd calyx-py && flit install -s && cd -
-```
+Configure fud2 by typing:
 
-Install `fud`:
+    fud2 edit-config
 
-```
-flit -f fud/pyproject.toml install -s --deps production
-```
+And put this in the resulting TOML file:
 
-Configure `fud`:
-
-```
-fud config --create global.root <full path to Calyx repository>
+```toml
+[calyx]
+base = "<path to Calyx repository>"
 ```
 
-Check the `fud` configuration:
+Finally, use this to set up fud2's Python environment:
 
-```
-fud check
-```
+    fud2 env init
 
-`fud` will report certain tools are not available. This is expected.
+You can read [more about setting up and using fud2][fud2] if you're curious.
+
+[ninja]: https://ninja-build.org/manual.html
+[uv]: https://docs.astral.sh/uv/
 
 ## Simulation
 
@@ -150,12 +145,6 @@ You'll want to set up at least one of these options so you can try out your code
 Icarus Verilog is an easy way to get started on most platforms.
 On a Mac, you can install it via [Homebrew][] by typing `brew install icarus-verilog`.
 On Ubuntu, [install from source][icarus-install-source].
-Then install the relevant [fud support][fud-icarus] by running:
-
-    fud register icarus-verilog -p fud/icarus/icarus.py
-
-Type `fud check` to make sure the new stage is working.
-Some missing tools are again expected; just pay attention to the report for `stages.icarus-verilog.exec`.
 
 It is worth saying a little about the alternatives.
 You could consider:
@@ -168,12 +157,12 @@ You could consider:
 You're all set to run a Calyx hardware design now. Run the following command:
 
 ```
-fud e examples/tutorial/language-tutorial-iterate.futil \
-  -s verilog.data examples/tutorial/data.json \
-  --to dat --through icarus-verilog -v
+fud2 examples/tutorial/language-tutorial-iterate.futil \
+  -s sim.data=examples/tutorial/data.json \
+  --to dat --through icarus
 ```
 
-(Change the last bit to `--through verilog` to use Verilator instead.)
+(Change the last bit to `--through verilator` to use Verilator instead.)
 
 This command will compile `examples/tutorial/language-tutorial-iterate.futil` to Verilog
 using the Calyx compiler, simulate the design using the data in `examples/tutorial/data.json`, and generate a JSON representation of the
@@ -185,8 +174,7 @@ Congratulations! You've simulated your first hardware design with Calyx.
 
 * [How can I setup syntax highlighting in my editor?](./tools/editor-highlighting.md)
 * [How does the language work?](./tutorial/language-tut.md)
-* [How do I install Calyx frontends?](./running-calyx/fud/index.html#dahlia-fronted)
-* [Where can I see further examples with `fud`?](./running-calyx/fud/examples.md)
+* [Where can I see further examples with `fud2`?](./running-calyx/fud2#general-use)
 * [How do I write a frontend for Calyx?](./tutorial/frontend-tut.md)
 
 [rust]: https://doc.rust-lang.org/cargo/getting-started/installation.html

--- a/docs/lang/data-format.md
+++ b/docs/lang/data-format.md
@@ -1,6 +1,6 @@
 # Data Format
 
-Calyx's [`fud`][fud]-based workflows specifies a JSON-based data format which can be used with software simulators.
+Calyx's [`fud2`][fud2]-based workflows specifies a JSON-based data format which can be used with software simulators.
 
 ## External memories
 
@@ -66,11 +66,11 @@ To pass a JSON file with initial values, use the `-s verilog.data` flag:
 
 ```bash
 # Use Icarus Verilog
-fud e --to dat --through icarus-verilog <CALYX FILE> -s verilog.data <JSON>
+fud2 --to dat --through icarus <CALYX FILE> -s sim.data=<JSON>
 # Use Verilator
-fud e --to dat --through verilog <CALYX FILE> -s verilog.data <JSON>
-# Use the Calyx Interpreter
-fud e --to interpreter-out <CALYX FILE> -s verilog.data <JSON>
+fud2 --to dat --through verilator <CALYX FILE> -s sim.data=<JSON>
+# Use Cider, the Calyx interpreter
+fud2 --to dat --through cider <CALYX FILE> -s sim.data=<JSON>
 ```
 
 ## Generating Random Values
@@ -82,6 +82,7 @@ Often times, it can be useful to automatically generate random values for a larg
 [toplevel-attr]: attributes.md#toplevel
 [ext-attr]: attributes.md#external
 [fud]: ../running-calyx/fud/index.md
+[fud2]: ../running-calyx/fud2
 [data-gen]: ../tools/data-gen.md
 [iv]: ../running-calyx/fud/index.md#icarus-verilog
 [verilator]: ../running-calyx/fud/index.md#verilator

--- a/docs/lang/memories-by-reference.md
+++ b/docs/lang/memories-by-reference.md
@@ -209,8 +209,8 @@ This gives us the `main` component:
 
 To see this example simulated, run the command:
 ```
-fud e examples/futil/memory-by-reference/memory-by-reference.futil --to dat \
--s verilog.data examples/futil/memory-by-reference/memory-by-reference.futil.data
+fud2 examples/futil/memory-by-reference/memory-by-reference.futil --to dat \
+-s sim.data=examples/futil/memory-by-reference/memory-by-reference.futil.data
 ```
 
 ### Multi-dimensional Memories

--- a/docs/lang/multi-component.md
+++ b/docs/lang/multi-component.md
@@ -41,5 +41,5 @@ The component executes the two groups in-order.
 
 To see the output from running this component, run the command:
 ```
-fud e examples/futil/multi-component.futil --to vcd
+fud2 examples/futil/multi-component.futil --to vcd
 ```

--- a/docs/tutorial/frontend-tut.md
+++ b/docs/tutorial/frontend-tut.md
@@ -43,11 +43,6 @@ Next, install the `mrxl` binary:
 ```
 cd frontends/mrxl && flit install -s && cd -
 ```
-Register the `mrxl` binary with `fud`:
-```
-fud register mrxl -p frontends/mrxl/fud/mrxl.py
-```
-Now, running `fud check` should report that the `mrxl` binary is correctly installed.
 
 ### Running MrXL
 
@@ -88,10 +83,11 @@ Finally, let us go the whole hog: we compile our MrXL program to Calyx, compile 
 
 Run:
 ```
-fud e --from mrxl frontends/mrxl/test/sos.mrxl --to dat --through verilog -s mrxl.data frontends/mrxl/test/sos.mrxl.data
+mrxl --convert --data frontends/mrxl/test/sos.mrxl.data frontends/mrxl/test/sos.mrxl > sos.data
+fud2 --from mrxl frontends/mrxl/test/sos.mrxl --to dat --through verilator -s sim.data=sos.data
 ```
 
-The above command takes a MrXL program, `sos.mrxl`, and generates results with Verilator using the MrXL data file `sos.mrxl.data`.
+The above commands take a MrXL program, `sos.mrxl`, and generates results with Verilator using the MrXL data file `sos.mrxl.data`.
 
 # Compiling MrXL into Calyx
 
@@ -213,7 +209,7 @@ At a high level, we want to generate the following pieces of hardware:
 3. An adder to increment the value of the index.
 4. Whatever hardware is needed to implement the loop body computation.
 
-We have implemented exactly this, and you have been using it thus far with the `fud` invocations that we have provided you.
+We have implemented exactly this, and you have been using it thus far with the `fud2` invocations that we have provided you.
 
 However, it is time to get your hands dirty.
 We provide a [stub implementation][mymap-stub] of `map` in `gen_calyx.py`:
@@ -225,10 +221,10 @@ You are invited to try implementing map yourself according to the outline given 
 
 To run `mrxl` with `my_map_impl` instead of our implementation, pass the `--my-map` flag:
 ```sh
-fud e --from mrxl test/sos.mrxl \
-        --to dat --through verilog \
-        -s mrxl.flags "--my-map "  \
-        -s mrxl.data test/sos.mrxl.data
+fud2 --from mrxl test/sos.mrxl \
+     --to dat --through verilator \
+     -s mrxl.flags="--my-map "  \
+     -s sim.data=sos.data
 ```
 
 If you are feeling good about your implementation, skip to [the next section](#adding-parallelization)!
@@ -311,7 +307,7 @@ Translating this into a hardware implementation has a couple of associated chall
 
 To produce the full Calyx program for the above example, run the following from the root of the Calyx repository:
 ```
-fud e --from mrxl --to calyx frontends/mrxl/test/squares.mrxl
+fud2 --from mrxl --to calyx frontends/mrxl/test/squares.mrxl
 ```
 
 
@@ -360,12 +356,12 @@ par {
 The [`par` operator][lf-par] executes all the loops in parallel which use distinct computational resources.
 As specified by the language specification, [conflicting resource usage is undefined behavior][par-undef].
 
-You can use `fud` to compile the MrXL program and run it with some data:
+You can use `fud2` to compile the MrXL program and run it with some data:
 ```
-fud e --from mrxl --to dat \
-      --through verilog \
-      -s mrxl.data frontends/mrxl/test/squares.mrxl.data \
-      frontends/mrxl/test/squares.mrxl
+fud2 --from mrxl --to dat \
+     --through verilator \
+     -s sim.data=squares.data \
+     frontends/mrxl/test/squares.mrxl
 ```
 
 > The [complete implementation][impl] shows the necessary code to create physical memory banks and create an outer loop to generate distinct hardware for each copy of the loop.
@@ -443,10 +439,10 @@ And we can generate this automatically. Try it yourself:
 mrxl frontends/mrxl/test/squares.mrxl --data frontends/mrxl/test/squares.mrxl.data --convert
 ```
 
-This transformation is achieved using a [`fud`][fud] pass that converts MrXL-native data files into Calyx-native data files.
+This transformation is achieved using a [`fud2`][fud2] pass that converts MrXL-native data files into Calyx-native data files.
 
 [mrxldocs-install]: https://docs.calyxir.org/frontends/mrxl.html#install
-[fud]: ../running-calyx/fud/index.md
+[fud2]: ../running-calyx/fud2
 [fud-data]: ../lang/data-format.md
 [json]: https://www.json.org/json-en.html
 [calyx-tut]: ./language-tut.md

--- a/docs/tutorial/language-tut.md
+++ b/docs/tutorial/language-tut.md
@@ -94,15 +94,15 @@ We have one (unsigned integer) data element, and we indicate the bit width (32 b
 
 If you want to see how this Calyx program compiles to Verilog, here's the [fud][] incantation you need:
 
-    fud exec language-tutorial-mem.futil --to verilog
+    fud2 language-tutorial-mem.futil --to verilog
 
 Not terribly interesting!
 However, one nice thing you can do with programs is execute them.
 
 To run our program using [Icarus Verilog][], do this:
 
-    fud exec language-tutorial-mem.futil --to dat --through icarus-verilog \
-        -s verilog.data data.json
+    fud2 language-tutorial-mem.futil --to dat --through icarus \
+        -s sim.data=data.json
 
 Using `--to dat` asks fud to run the program, and the extra `-s verilog.data <filename>` argument tells it where to find the input data.
 The `--through icarus-verilog` option tells fud which Verilog simulator to use (see [the chapter about fud][fud] for alternatives such as [Verilator][]).
@@ -142,7 +142,7 @@ But now we're controlling things with an execution schedule.
 
 If you're curious to see how the Calyx compiler lowers this program to a Verilog-like structural form of Calyx, you can do this:
 
-    fud exec language-tutorial-mem.futil --to calyx-lowered
+    calyx language-tutorial-mem.futil
 
 Notably, you'll see `control {}` in the output, meaning that the compiler has eliminated all the control statements and replaced them with continuous assignments in `wires`.
 


### PR DESCRIPTION
Here's a quick attempt to convert all the low-hanging fruit I could find in the docs to refer to fud2 instead of fud. I haven't done anything about the actual fud docs themselves, the "experimental" label, or anything like that.

Most of the changes are pretty mechanical. The only substantial bit of new writing is in the "getting started" guide, where I added a compressed overview of how to install fud2 (which is of course already explained in more detail on the main fud2 docs page).

I'm sure there's plenty more to do here, but I thought I'd just get the ball rolling!