### PR TITLE
[Fud2] comment out the license file so the command doesn't break

### DIFF
--- a/tools/report-parsing/pyproject.toml
+++ b/tools/report-parsing/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "synthrep"
 authors = [{ name = "The Calyx Authors" }]
-license = { file = "MIT" }
+# license = { file = "MIT" }
 classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
 dependencies = ["pandas", "plotly"]


### PR DESCRIPTION
Tiny fix to prevent `fud2 env init` from exploding because it can't find the license file