### PR TITLE
[metadata-table-gen] Add sourceloc info for components

### DIFF
--- a/calyx/opt/src/passes_experimental/metadata_table_gen.rs
+++ b/calyx/opt/src/passes_experimental/metadata_table_gen.rs
@@ -77,13 +77,22 @@ impl Visitor for Metadata {
         // components have attributes !!
         // check if file exists for component definition
         let binding = comp.attributes.copy_span();
-        let (file, _bs) = binding.get_line_num();
+        let (file, (line, _)) = binding.get_line_num();
 
         // add file to source table (if not already in)
         if !self.file_ids.contains_key(file) {
             let id = self.src_table.push_file(PathBuf::from(file));
             self.file_ids.insert(String::from(file), id);
         }
+
+        // add source position of the component itself
+        let component_file_id = self.file_ids.get(file).unwrap();
+        let component_pos = self
+            .src_table
+            .push_position(*component_file_id, LineNum::new(line as u32));
+        comp.attributes
+            .insert_set(calyx_frontend::SetAttr::Pos, component_pos.value());
+
         // visit all groups in component
         for rrcgrp in comp.groups.iter() {
             let mut grp = rrcgrp.borrow_mut();

--- a/tests/passes/metadata-table-gen-non-empty.expect
+++ b/tests/passes/metadata-table-gen-non-empty.expect
@@ -1,5 +1,5 @@
 import "primitives/core.futil";
-component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+component main<"pos"={4}>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
     reg1 = std_reg(32);
     reg2 = std_reg(32);
@@ -7,22 +7,22 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     lt = std_lt(32);
   }
   wires {
-    group g1<"pos"={4}> {
+    group g1<"pos"={5}> {
       reg1.in = 32'd1;
       reg1.write_en = 1'd1;
       done = reg1.done;
     }
-    group g2<"pos"={5}> {
+    group g2<"pos"={6}> {
       reg2.in = 32'd2;
       reg2.write_en = 1'd1;
       done = reg2.done;
     }
-    group g3<"pos"={6}> {
+    group g3<"pos"={7}> {
       reg3.in = 32'd3;
       reg3.write_en = 1'd1;
       done = reg3.done;
     }
-    group g4<"pos"={7}> {
+    group g4<"pos"={8}> {
       reg3.in = 32'd0;
       reg3.write_en = 1'd1;
       done = reg3.done;
@@ -33,15 +33,15 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     }
   }
   control {
-    @pos{8} par {
-      @pos{9} seq {
-        @pos{10} g1;
-        @pos{11} g2;
+    @pos{9} par {
+      @pos{10} seq {
+        @pos{11} g1;
+        @pos{12} g2;
       }
-      @pos{12} if lt.out with cond {
-        @pos{13} g3;
+      @pos{13} if lt.out with cond {
+        @pos{14} g3;
       } else {
-        @pos{14} g4;
+        @pos{15} g4;
       }
     }
   }
@@ -54,15 +54,16 @@ POSITIONS
 1: 1 5
 2: 1 6
 3: 1 7
-4: 2 14
-5: 2 19
-6: 2 24
-7: 2 29
-8: 2 40
-9: 2 41
-10: 2 42
-11: 2 43
-12: 2 45
-13: 2 46
-14: 2 48
+4: 2 5
+5: 2 14
+6: 2 19
+7: 2 24
+8: 2 29
+9: 2 40
+10: 2 41
+11: 2 42
+12: 2 43
+13: 2 45
+14: 2 46
+15: 2 48
 }#

--- a/tests/passes/metadata-table-gen.expect
+++ b/tests/passes/metadata-table-gen.expect
@@ -1,5 +1,5 @@
 import "primitives/core.futil";
-component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+component main<"pos"={1}>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
     reg1 = std_reg(32);
     reg2 = std_reg(32);
@@ -7,22 +7,22 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     lt = std_lt(32);
   }
   wires {
-    group g1<"pos"={1}> {
+    group g1<"pos"={2}> {
       reg1.in = 32'd1;
       reg1.write_en = 1'd1;
       done = reg1.done;
     }
-    group g2<"pos"={2}> {
+    group g2<"pos"={3}> {
       reg2.in = 32'd2;
       reg2.write_en = 1'd1;
       done = reg2.done;
     }
-    group g3<"pos"={3}> {
+    group g3<"pos"={4}> {
       reg3.in = 32'd3;
       reg3.write_en = 1'd1;
       done = reg3.done;
     }
-    group g4<"pos"={4}> {
+    group g4<"pos"={5}> {
       reg3.in = 32'd0;
       reg3.write_en = 1'd1;
       done = reg3.done;
@@ -33,15 +33,15 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     }
   }
   control {
-    @pos{5} par {
-      @pos{6} seq {
-        @pos{7} g1;
-        @pos{8} g2;
+    @pos{6} par {
+      @pos{7} seq {
+        @pos{8} g1;
+        @pos{9} g2;
       }
-      @pos{9} if lt.out with cond {
-        @pos{10} g3;
+      @pos{10} if lt.out with cond {
+        @pos{11} g3;
       } else {
-        @pos{11} g4;
+        @pos{12} g4;
       }
     }
   }
@@ -50,15 +50,16 @@ sourceinfo #{
 FILES
 1: tests/passes/metadata-table-gen.futil
 POSITIONS
-1: 1 14
-2: 1 19
-3: 1 24
-4: 1 29
-5: 1 40
-6: 1 41
-7: 1 42
-8: 1 43
-9: 1 45
-10: 1 46
-11: 1 48
+1: 1 5
+2: 1 14
+3: 1 19
+4: 1 24
+5: 1 29
+6: 1 40
+7: 1 41
+8: 1 42
+9: 1 43
+10: 1 45
+11: 1 46
+12: 1 48
 }#


### PR DESCRIPTION
The `metadata-table-gen` pass previously didn't create position attributes for components, but this PR adds those in!