### PR TITLE
[misc] bump wasm bindgen version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "calyx-utils",
  "console_error_panic_hook",
  "serde",
+ "serde-wasm-bindgen",
  "serde_derive",
  "serde_json",
  "wasm-bindgen",
@@ -2954,6 +2955,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_cbor"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3955,8 +3967,6 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3948,11 +3948,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -3960,24 +3962,23 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3985,22 +3986,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"

--- a/web/rust/Cargo.toml
+++ b/web/rust/Cargo.toml
@@ -8,8 +8,9 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
+wasm-bindgen = { version = "=0.2.100" }
 serde.workspace = true
-wasm-bindgen = { version = "=0.2.100", features = ["serde-serialize"] }
+serde-wasm-bindgen = "0.4"
 serde_json = "1.0.59"
 serde_derive = "1.0"
 console_error_panic_hook = "0.1.7"

--- a/web/rust/Cargo.toml
+++ b/web/rust/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 serde.workspace = true
-wasm-bindgen = { version = "=0.2.80", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.100", features = ["serde-serialize"] }
 serde_json = "1.0.59"
 serde_derive = "1.0"
 console_error_panic_hook = "0.1.7"

--- a/web/rust/src/lib.rs
+++ b/web/rust/src/lib.rs
@@ -46,7 +46,8 @@ fn compile(
 #[wasm_bindgen]
 pub fn run(passes: &JsValue, library: &str, namespace: &str) -> String {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
-    let test: Vec<String> = passes.into_serde().unwrap();
+    let test: Vec<String> =
+        serde_wasm_bindgen::from_value(passes.clone()).unwrap();
     match compile(&test, library, namespace) {
         Ok(s) => s,
         Err(e) => format!("Error:\n{:?}", e),


### PR DESCRIPTION
We've been getting a "future incompatibility" warning from this package for a while but it turns out this would be a blocker if we ever wanted to switch to rust 1.88 (the one with let chains). I opted to bump it to the most recent version, which it turns out requests the use of `serde_wasm_bindgen` as the `to_serde` method is now deprecated. The path to resolution seems to be using `serde_wasm_bindgen::from_value` in place of `to_serde`. I had to throw in a clone but given that the jsvalues are basically just a newtype this should be a trivial cost.

Hopefully this just works? I don't actually know how to test the playground, so I'm hoping one of y'all has insight.