### PR TITLE
[Fud2] Extract execution timing from Ninja

### DIFF
--- a/fud2/fud-core/src/cli.rs
+++ b/fud2/fud-core/src/cli.rs
@@ -186,7 +186,7 @@ pub struct FudArgs<T: CliExt> {
     #[argh(option)]
     through: Vec<String>,
 
-    /// verbose ouput
+    /// verbose output
     #[argh(switch, short = 'v')]
     verbose: Option<bool>,
 

--- a/fud2/fud-core/src/cli.rs
+++ b/fud2/fud-core/src/cli.rs
@@ -201,6 +201,10 @@ pub struct FudArgs<T: CliExt> {
     /// planner for the backend
     #[argh(option, default = "Planner::Legacy")]
     planner: Planner,
+
+    /// name of the file to output timing csv if in running mode
+    #[argh(option, long = "csv")]
+    timing_csv: Option<Utf8PathBuf>,
 }
 
 fn get_states_with_errors(
@@ -298,6 +302,7 @@ fn get_request<T: CliExt>(
             Planner::Egg => Box::new(plan::EggPlanner {}),
             Planner::Enumerate => Box::new(plan::EnumeratePlanner {}),
         },
+        timing_csv: args.timing_csv.clone(),
     })
 }
 
@@ -464,6 +469,8 @@ fn cli_ext<T: CliExt>(
     // Make a plan.
     let req = get_request(driver, &args)?;
     let workdir = req.workdir.clone();
+    let csv_file = req.timing_csv.clone();
+    let csv_path = csv_file.as_ref().map(Utf8PathBuf::as_path);
     let plan = driver.plan(req).ok_or(anyhow!("could not find path"))?;
 
     // Configure.
@@ -486,8 +493,8 @@ fn cli_ext<T: CliExt>(
         Mode::ShowDot => run.show_dot(),
         Mode::EmitNinja => run.emit_to_stdout()?,
         Mode::Generate => run.emit_to_dir(&workdir)?.keep(),
-        Mode::Run => run.emit_and_run(&workdir, false, args.quiet)?,
-        Mode::Cmds => run.emit_and_run(&workdir, true, false)?,
+        Mode::Run => run.emit_and_run(&workdir, false, args.quiet, csv_path)?,
+        Mode::Cmds => run.emit_and_run(&workdir, true, false, csv_path)?,
     }
 
     Ok(())

--- a/fud2/fud-core/src/exec/request.rs
+++ b/fud2/fud-core/src/exec/request.rs
@@ -24,6 +24,9 @@ pub struct Request {
     /// The working directory for the build.
     pub workdir: Utf8PathBuf,
 
+    /// The optional timing CSV to generate
+    pub timing_csv: Option<Utf8PathBuf>,
+
     /// The algorithm used to find a plan to turn start states into end states
     pub planner: Box<dyn FindPlan>,
 }

--- a/fud2/fud-core/src/lib.rs
+++ b/fud2/fud-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cli;
 mod cli_ext;
 pub mod config;
 pub mod exec;
+pub mod log_parser;
 pub mod run;
 pub mod script;
 mod uninterrupt;

--- a/fud2/fud-core/src/log_parser.rs
+++ b/fud2/fud-core/src/log_parser.rs
@@ -1,0 +1,117 @@
+use std::{error::Error, fmt::Display, fs::File, io::Read, num::ParseIntError};
+
+use camino::Utf8Path;
+use itertools::Itertools;
+
+#[derive(Debug)]
+pub enum LogParseError {
+    /// Doesn't match the expected ninja log format
+    UnexpectedFormat,
+    /// An IO error for reading the log and writing the CSV
+    Io(std::io::Error),
+}
+
+impl From<std::io::Error> for LogParseError {
+    fn from(v: std::io::Error) -> Self {
+        Self::Io(v)
+    }
+}
+
+impl Display for LogParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogParseError::UnexpectedFormat => {
+                write!(f, "ninja log file does not have the expected format")
+            }
+
+            LogParseError::Io(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl From<ParseIntError> for LogParseError {
+    fn from(_: ParseIntError) -> Self {
+        LogParseError::UnexpectedFormat
+    }
+}
+
+impl Error for LogParseError {}
+
+#[derive(Debug, Clone)]
+pub struct NinjaLogEntry {
+    start_time: u32,
+    end_time: u32,
+    file_produced: Box<str>,
+}
+
+impl NinjaLogEntry {
+    fn from_str(input: &str) -> Result<Self, LogParseError> {
+        let mut iter = input.split_whitespace();
+        let Some((start_time, end_time, _tstamp, filename, _hash)) =
+            iter.next_tuple()
+        else {
+            return Err(LogParseError::UnexpectedFormat);
+        };
+
+        let start_time: u32 = start_time.parse()?;
+        let end_time: u32 = end_time.parse()?;
+        let file_produced: Box<str> = filename.into();
+
+        Ok(NinjaLogEntry {
+            start_time,
+            end_time,
+            file_produced,
+        })
+    }
+
+    fn emit_csv<W: std::io::Write>(&self, mut writer: W) {
+        writeln!(
+            writer,
+            "{}, {}",
+            self.file_produced,
+            self.end_time - self.start_time,
+        )
+        .expect("writing failed");
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NinjaLog {
+    entries: Vec<NinjaLogEntry>,
+}
+
+impl NinjaLog {
+    fn from_str(input: &str) -> Result<Self, LogParseError> {
+        let mut out = vec![];
+
+        for line in input.lines() {
+            if !line.starts_with("#") {
+                out.push(NinjaLogEntry::from_str(line)?)
+            }
+        }
+
+        Ok(NinjaLog { entries: out })
+    }
+
+    fn emit_csv<W: std::io::Write>(&self, mut writer: W) {
+        writeln!(&mut writer, "filename, duration").expect("writing failed");
+        for entry in &self.entries {
+            entry.emit_csv(&mut writer);
+        }
+        writer.flush().expect("writing failed");
+    }
+}
+
+pub fn generate_timing_csv(
+    temp_dir: &Utf8Path,
+    csv_file: &Utf8Path,
+) -> Result<(), LogParseError> {
+    let log_file = temp_dir.join(".ninja_log");
+    let mut file = File::open(log_file)?;
+    let mut buffer = String::new();
+    file.read_to_string(&mut buffer)?;
+    let log = NinjaLog::from_str(&buffer)?;
+    let output = File::create(csv_file)?;
+    log.emit_csv(output);
+    Ok(())
+}

--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -1,7 +1,10 @@
-use crate::config;
-use crate::exec::{Driver, OpRef, Plan, SetupRef, StateRef};
 use crate::uninterrupt::Uninterrupt;
 use crate::utils::relative_path;
+use crate::{config, log_parser};
+use crate::{
+    exec::{Driver, OpRef, Plan, SetupRef, StateRef},
+    log_parser::LogParseError,
+};
 use camino::{Utf8Path, Utf8PathBuf};
 use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
@@ -30,6 +33,15 @@ pub enum RunError {
     /// The Rhai emitter ran into an error. Probably should just reconfigure so
     /// that the emitter just returns the actual error type
     RhaiError(String),
+
+    /// Errors from the timing extraction
+    TimingLog(LogParseError),
+}
+
+impl From<LogParseError> for RunError {
+    fn from(v: LogParseError) -> Self {
+        Self::TimingLog(v)
+    }
 }
 
 impl From<Box<rhai::EvalAltResult>> for RunError {
@@ -74,6 +86,9 @@ impl std::fmt::Display for RunError {
             }
             RunError::RhaiError(eval_alt_result) => {
                 write!(f, "{}", eval_alt_result)
+            }
+            RunError::TimingLog(log_parse_error) => {
+                write!(f, "{log_parse_error}")
             }
         }
     }
@@ -363,6 +378,7 @@ impl<'a> Run<'a> {
         dir: &Utf8Path,
         print_cmds: bool,
         quiet_mode: bool,
+        csv_file: Option<&Utf8Path>,
     ) -> EmitResult {
         // Emit the Ninja file.
         let dir = self.emit_to_dir(dir)?;
@@ -436,6 +452,11 @@ impl<'a> Run<'a> {
                     &mut std::io::stdout(),
                 )?;
             }
+
+            if let Some(csv_file) = csv_file {
+                log_parser::generate_timing_csv(&dir.path, csv_file)?;
+            }
+
             Ok(())
         } else {
             Err(RunError::NinjaFailed(status))


### PR DESCRIPTION
A quick extension to `fud2` which will output a csv of execution timing when the `--csv` argument is given with a filename. This is similar to functionality in the original `fud`.

This works by extracting the timing info placed in the `.ninja_log` which reports the timestamp in milliseconds (with zero being the start of the overall build) at the beginning and end of the build command for the given file. I'm not certain how precise this information is, but this should at least give a reasonable ballpark estimate for how long the individual parts of an execution are taking. Unfortunately, while the `.ninja_log` file seems stable in its construction, it is not formally documented anywhere and could potentially change down the line which would break this functionality.