### PR TITLE
[`fud2`] Removed unnecessary dependency on Flamegraph config var

### DIFF
--- a/fud2/scripts/synth-verilog-to-report.rhai
+++ b/fud2/scripts/synth-verilog-to-report.rhai
@@ -37,7 +37,9 @@ fn synth_setup(e) {
     e.rule("parse-rpt", "synthrep viz -t flamegraph -f $in > $out");
     e.rule("extract-util-json", "synthrep summary -m utilization > $out");
     e.rule("extract-hierarchy-json", "synthrep summary -m hierarchy > $out");
+}
 
+fn flamegraph_setup(e) {
     // Bash script to create a FlameGraph
     e.config_var("flamegraph-script", "flamegraph.script");
     e.var_("create-visuals-script", "$calyx-base/tools/profiler/create-visuals.sh");
@@ -124,7 +126,7 @@ op(
 // Op to get FlameGraph from area report
 op(
     "area-report-to-flamegraph",
-    [synth_setup],
+    [synth_setup, flamegraph_setup],
     area_report_state,
     p::flamegraph,
     |e, input, output| {

--- a/fud2/tests/snapshots/tests__test@plan_area-report-to-flamegraph.snap
+++ b/fud2/tests/snapshots/tests__test@plan_area-report-to-flamegraph.snap
@@ -30,6 +30,7 @@ rule extract-util-json
   command = synthrep summary -m utilization > $out
 rule extract-hierarchy-json
   command = synthrep summary -m hierarchy > $out
+
 flamegraph-script = /test/calyx/non-existent.script
 create-visuals-script = $calyx-base/tools/profiler/create-visuals.sh
 rule create-visuals

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-area-report.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-area-report.snap
@@ -30,10 +30,6 @@ rule extract-util-json
   command = synthrep summary -m utilization > $out
 rule extract-hierarchy-json
   command = synthrep summary -m hierarchy > $out
-flamegraph-script = /test/calyx/non-existent.script
-create-visuals-script = $calyx-base/tools/profiler/create-visuals.sh
-rule create-visuals
-  command = bash $create-visuals-script $flamegraph-script . $in $out
 
 build device.xdc: copy $device_xdc
 build IGNOREME: vivado | main.sv synth.tcl device.xdc

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-hierarchy-json.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-hierarchy-json.snap
@@ -30,10 +30,6 @@ rule extract-util-json
   command = synthrep summary -m utilization > $out
 rule extract-hierarchy-json
   command = synthrep summary -m hierarchy > $out
-flamegraph-script = /test/calyx/non-existent.script
-create-visuals-script = $calyx-base/tools/profiler/create-visuals.sh
-rule create-visuals
-  command = bash $create-visuals-script $flamegraph-script . $in $out
 
 build device.xdc: copy $device_xdc
 build IGNOREME: vivado | main.sv synth.tcl device.xdc

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-timing-report.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-timing-report.snap
@@ -30,10 +30,6 @@ rule extract-util-json
   command = synthrep summary -m utilization > $out
 rule extract-hierarchy-json
   command = synthrep summary -m hierarchy > $out
-flamegraph-script = /test/calyx/non-existent.script
-create-visuals-script = $calyx-base/tools/profiler/create-visuals.sh
-rule create-visuals
-  command = bash $create-visuals-script $flamegraph-script . $in $out
 
 build device.xdc: copy $device_xdc
 build IGNOREME: vivado | main.sv synth.tcl device.xdc

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-util-json.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-util-json.snap
@@ -30,10 +30,6 @@ rule extract-util-json
   command = synthrep summary -m utilization > $out
 rule extract-hierarchy-json
   command = synthrep summary -m hierarchy > $out
-flamegraph-script = /test/calyx/non-existent.script
-create-visuals-script = $calyx-base/tools/profiler/create-visuals.sh
-rule create-visuals
-  command = bash $create-visuals-script $flamegraph-script . $in $out
 
 build device.xdc: copy $device_xdc
 build IGNOREME: vivado | main.sv synth.tcl device.xdc

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-util-report.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-util-report.snap
@@ -30,10 +30,6 @@ rule extract-util-json
   command = synthrep summary -m utilization > $out
 rule extract-hierarchy-json
   command = synthrep summary -m hierarchy > $out
-flamegraph-script = /test/calyx/non-existent.script
-create-visuals-script = $calyx-base/tools/profiler/create-visuals.sh
-rule create-visuals
-  command = bash $create-visuals-script $flamegraph-script . $in $out
 
 build device.xdc: copy $device_xdc
 build IGNOREME: vivado | main.sv synth.tcl device.xdc


### PR DESCRIPTION
Split setup functions to remove unnecessary dependency on Flamegraph config var for several fud2 synthesis ops.