### PR TITLE
Dockerfile: Switch from flit to uv

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -182,7 +182,7 @@ jobs:
     - name: Install calyx-py, MrXL, and queues
       working-directory: /home/calyx
       run: |
-        uv pip install ./frontends/mrxl ./frontends/queues
+        uv pip install -e ./frontends/mrxl ./frontends/queues
         uv pip install ./calyx-py
 
     - name: Generate queue .data and .expect files

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -182,7 +182,8 @@ jobs:
     - name: Install calyx-py, MrXL, and queues
       working-directory: /home/calyx
       run: |
-        uv pip install -e ./frontends/mrxl ./frontends/queues
+        uv pip install -e ./frontends/mrxl
+        uv pip install -e ./frontends/queues
         uv pip install ./calyx-py
 
     - name: Generate queue .data and .expect files

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -182,7 +182,8 @@ jobs:
     - name: Install calyx-py, MrXL, and queues
       working-directory: /home/calyx
       run: |
-        uv pip install ./calyx-py ./frontends/mrxl ./frontends/queues
+        uv pip install ./frontends/mrxl ./frontends/queues
+        uv pip install ./calyx-py
 
     - name: Generate queue .data and .expect files
       working-directory: /home/calyx

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -182,14 +182,7 @@ jobs:
     - name: Install calyx-py, MrXL, and queues
       working-directory: /home/calyx
       run: |
-        cd calyx-py
-        FLIT_ROOT_INSTALL=1 flit install --symlink
-        cd -
-        cd frontends/mrxl
-        FLIT_ROOT_INSTALL=1 flit install --symlink
-        cd -
-        cd frontends/queues
-        FLIT_ROOT_INSTALL=1 flit install --symlink
+        uv pip install ./calyx-py ./frontends/mrxl ./frontends/queues
 
     - name: Generate queue .data and .expect files
       working-directory: /home/calyx

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,12 +72,12 @@ RUN cargo build --workspace && \
     cargo install vcdump && \
     cargo install runt --version 0.4.1
 
-# Install fud
-WORKDIR /home/calyx/fud
-RUN FLIT_ROOT_INSTALL=1 flit install --symlink --deps production
+# Install uv and then fud
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+WORKDIR /home/calyx
+RUN uv tool install ./fud
 RUN mkdir -p /root/.config
 ENV PATH=$PATH:/root/.local/bin
-ENV PYTHONPATH=/root/.local/lib/python3.9/site-packages:$PYTHONPATH
 
 # Link fud2
 WORKDIR /home/calyx
@@ -85,10 +85,6 @@ run mkdir -p ~/.local/bin
 RUN ln -s /home/calyx/target/debug/fud2 ~/.local/bin/
 RUN printf "dahlia = \"/home/dahlia/fuse\"\n" >> ~/.config/fud2.toml
 RUN printf "[calyx]\nbase = \"/home/calyx\"\n" >> ~/.config/fud2.toml
-
-# Install calyx-py
-WORKDIR /home/calyx/calyx-py
-RUN FLIT_ROOT_INSTALL=1 flit install --symlink
 
 # Setup fud
 RUN fud config --create global.root /home/calyx && \
@@ -100,8 +96,8 @@ RUN fud config --create global.root /home/calyx && \
     fud register icarus-verilog -p '/home/calyx/fud/icarus/icarus.py'
 
 # Install MrXL
-WORKDIR /home/calyx/frontends/mrxl
-RUN FLIT_ROOT_INSTALL=1 flit install --symlink
+WORKDIR /home/calyx
+RUN uv tool install ./frontends/mrxl
 
 WORKDIR /home/calyx
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN cargo build --workspace && \
 # Install fud
 WORKDIR /home/calyx
 RUN uv pip install ./fud
+RUN uv pip install ./calyx-py  # Install separately for source-position stuff.
 RUN mkdir -p /root/.config
 
 # Link fud2

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,6 @@ RUN cargo build --workspace && \
 # Install fud
 WORKDIR /home/calyx
 RUN uv pip install ./fud
-RUN uv pip install ./calyx-py  # Install separately for source-position stuff.
 RUN mkdir -p /root/.config
 
 # Link fud2
@@ -100,7 +99,10 @@ RUN fud config --create global.root /home/calyx && \
 WORKDIR /home/calyx
 RUN uv pip install ./frontends/mrxl
 
-WORKDIR /home/calyx
+# Install calyx-py. We do this separately from the other `uv pip install`s to
+# ensure that it gets installed in non-editable mode, which can affect its
+# stacktrace-walking magic that dictates source position generation.
+RUN uv pip install ./calyx-py
 
 # Used to make runt cocotb tests happy
 ENV LANG=C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ ENV PATH=$PATH:/root/.local/bin
 
 # Link fud2
 WORKDIR /home/calyx
-run mkdir -p ~/.local/bin
+RUN mkdir -p ~/.local/bin
 RUN ln -s /home/calyx/target/debug/fud2 ~/.local/bin/
 RUN printf "dahlia = \"/home/dahlia/fuse\"\n" >> ~/.config/fud2.toml
 RUN printf "[calyx]\nbase = \"/home/calyx\"\n" >> ~/.config/fud2.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,10 @@ RUN ln -s /home/calyx/target/debug/fud2 ~/.local/bin/
 RUN printf "dahlia = \"/home/dahlia/fuse\"\n" >> ~/.config/fud2.toml
 RUN printf "[calyx]\nbase = \"/home/calyx\"\n" >> ~/.config/fud2.toml
 
+# Install calyx-py (for use by ad hoc generator scripts in tests)
+WORKDIR /home/calyx
+RUN uv pip install --system --break-system-packages ./calyx-py
+
 # Setup fud
 RUN fud config --create global.root /home/calyx && \
     fud config stages.dahlia.exec '/home/dahlia/fuse' && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,9 @@ RUN git checkout v0.10.dev0 && \
 RUN mkdir build
 WORKDIR /home/tvm/build
 RUN cp ../cmake/config.cmake . && \
-    cmake -G Ninja .. && ninja && \
-    python3 -m pip install -Iv antlr4-python3-runtime==4.7.2
+    cmake -G Ninja .. && ninja
 WORKDIR /home/tvm/python
-RUN python3 setup.py bdist_wheel && python3 -m pip install dist/tvm-*.whl
+RUN uv pip install antlr4-python3-runtime==4.7.2 .
 
 # Install Dahlia
 WORKDIR /home

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,9 +83,7 @@ RUN mkdir -p /root/.config
 
 # Link fud2
 WORKDIR /home/calyx
-RUN mkdir -p ~/.local/bin
-ENV PATH=$PATH:$HOME/.local/bin
-RUN ln -s /home/calyx/target/debug/fud2 ~/.local/bin/
+RUN ln -s /home/calyx/target/debug/fud2 /bin/
 RUN printf "dahlia = \"/home/dahlia/fuse\"\n" >> ~/.config/fud2.toml
 RUN printf "[calyx]\nbase = \"/home/calyx\"\n" >> ~/.config/fud2.toml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,11 +75,10 @@ RUN cargo build --workspace && \
     cargo install vcdump && \
     cargo install runt --version 0.4.1
 
-# Install uv fud
+# Install fud
 WORKDIR /home/calyx
 RUN uv pip install ./fud
 RUN mkdir -p /root/.config
-ENV PATH=$PATH:/root/.local/bin
 
 # Link fud2
 WORKDIR /home/calyx

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ RUN mkdir -p /root/.config
 # Link fud2
 WORKDIR /home/calyx
 RUN mkdir -p ~/.local/bin
+ENV PATH=$PATH:$HOME/.local/bin
 RUN ln -s /home/calyx/target/debug/fud2 ~/.local/bin/
 RUN printf "dahlia = \"/home/dahlia/fuse\"\n" >> ~/.config/fud2.toml
 RUN printf "[calyx]\nbase = \"/home/calyx\"\n" >> ~/.config/fud2.toml

--- a/calyx-py/calyx/py_ast.py
+++ b/calyx-py/calyx/py_ast.py
@@ -69,6 +69,13 @@ class PosTable:
             # skip frames that do not have a real filename
             if frame.filename == "<string>":
                 continue
+            # Special-case the `gen_*.py` modules, which are clients themselves
+            # despite being part of the library.
+            # TODO(adrian): Move these out of the library and remove this hack.
+            if frame.filename.startswith(os.path.join(library_path, "gen_")):
+                user = frame
+                break
+            # Exclude everything else in the library.
             if not frame.filename.startswith(library_path):
                 user = frame
                 break

--- a/calyx-py/calyx/py_ast.py
+++ b/calyx-py/calyx/py_ast.py
@@ -69,13 +69,6 @@ class PosTable:
             # skip frames that do not have a real filename
             if frame.filename == "<string>":
                 continue
-            # Special-case the `gen_*.py` modules, which are clients themselves
-            # despite being part of the library.
-            # TODO(adrian): Move these out of the library and remove this hack.
-            if frame.filename.startswith(os.path.join(library_path, "gen_")):
-                user = frame
-                break
-            # Exclude everything else in the library.
             if not frame.filename.startswith(library_path):
                 user = frame
                 break


### PR DESCRIPTION
Following up on #2534, we apparently now _need_ to use uv to do this install to take advantage of the workspace (i.e., fud's dependency on calyx-py). So I have switched the Dockerfile to use uv instead of flit everywhere!

I am hoping this resolves the CI failure showing up in #2530.