### PR TITLE
[Fud2] Tweak error message to list states

### DIFF
--- a/fud2/fud-core/src/cli.rs
+++ b/fud2/fud-core/src/cli.rs
@@ -471,7 +471,19 @@ fn cli_ext<T: CliExt>(
     let workdir = req.workdir.clone();
     let csv_file = req.timing_csv.clone();
     let csv_path = csv_file.as_ref().map(Utf8PathBuf::as_path);
-    let plan = driver.plan(&req).ok_or(anyhow!("could not find path"))?;
+    let plan = driver.plan(&req).ok_or_else(|| {
+        let dest = req
+            .end_states
+            .iter()
+            .map(|state_ref| &driver.states[*state_ref].name)
+            .join(", ");
+        let src = req
+            .start_states
+            .iter()
+            .map(|state_ref| &driver.states[*state_ref].name)
+            .join(", ");
+        anyhow!("could not find path from {{{src}}} to {{{dest}}}")
+    })?;
 
     // Configure.
     let mut run = Run::new(driver, plan, config.clone());

--- a/fud2/fud-core/src/cli.rs
+++ b/fud2/fud-core/src/cli.rs
@@ -471,7 +471,7 @@ fn cli_ext<T: CliExt>(
     let workdir = req.workdir.clone();
     let csv_file = req.timing_csv.clone();
     let csv_path = csv_file.as_ref().map(Utf8PathBuf::as_path);
-    let plan = driver.plan(req).ok_or(anyhow!("could not find path"))?;
+    let plan = driver.plan(&req).ok_or(anyhow!("could not find path"))?;
 
     // Configure.
     let mut run = Run::new(driver, plan, config.clone());

--- a/fud2/fud-core/src/exec/data.rs
+++ b/fud2/fud-core/src/exec/data.rs
@@ -10,7 +10,7 @@ pub struct State {
     ///
     /// The first extension in the list is used when generating a new filename for the state. If
     /// the list is empty, this is a "pseudo-state" that doesn't correspond to an actual file.
-    /// Pseudo-states can only be final outputs; they are appropraite for representing actions that
+    /// Pseudo-states can only be final outputs; they are appropriate for representing actions that
     /// interact directly with the user, for example.
     pub extensions: Vec<String>,
 

--- a/fud2/fud-core/src/exec/driver.rs
+++ b/fud2/fud-core/src/exec/driver.rs
@@ -182,18 +182,18 @@ impl Driver {
             .into_iter()
             .map(|(op, used)| {
                 let input_filenames =
-                    self.gen_names(&self.ops[op].input, &req, true, &used);
+                    self.gen_names(&self.ops[op].input, req, true, &used);
                 let output_filenames =
-                    self.gen_names(&self.ops[op].output, &req, false, &used);
+                    self.gen_names(&self.ops[op].output, req, false, &used);
                 (op, input_filenames, output_filenames)
             })
             .collect::<Vec<_>>();
 
         // Collect filenames of inputs and outputs
         let results =
-            self.gen_names(&req.end_states, &req, false, &req.end_states);
+            self.gen_names(&req.end_states, req, false, &req.end_states);
         let inputs =
-            self.gen_names(&req.start_states, &req, true, &req.start_states);
+            self.gen_names(&req.start_states, req, true, &req.start_states);
 
         Some(Plan {
             steps,

--- a/fud2/fud-core/src/exec/driver.rs
+++ b/fud2/fud-core/src/exec/driver.rs
@@ -167,7 +167,7 @@ impl Driver {
     ///
     /// This works by searching for a path through the available operations from the input state
     /// to the output state. If no such path exists in the operation graph, we return None.
-    pub fn plan(&self, req: Request) -> Option<Plan> {
+    pub fn plan(&self, req: &Request) -> Option<Plan> {
         // Find a plan through the states.
         let path = req.planner.find_plan(
             &req.start_states,
@@ -199,7 +199,7 @@ impl Driver {
             steps,
             inputs,
             results,
-            workdir: req.workdir,
+            workdir: req.workdir.clone(),
         })
     }
 

--- a/fud2/tests/tests.rs
+++ b/fud2/tests/tests.rs
@@ -174,7 +174,7 @@ impl InstaTest for Request {
     }
 
     fn emit(self, driver: &Driver) -> String {
-        let plan = driver.plan(self).unwrap();
+        let plan = driver.plan(&self).unwrap();
         plan.emit(driver)
     }
 }
@@ -377,7 +377,7 @@ fn emit_bad_config() {
         .merge(("sim.data", "/test/data.json"));
 
     let req = request(&driver, &["dahlia"], &["verilog"], &[]);
-    let plan = driver.plan(req).unwrap();
+    let plan = driver.plan(&req).unwrap();
 
     let err = emit_with_config(plan, &driver, config).unwrap_err();
     if let RunError::RhaiError(err_str) = err {


### PR DESCRIPTION
Closes #2206 

A small change to the could not find path error message. It now lists the set of sources and the set of destinations that it failed to find a path for. Probably should do something better for the multi-input version but I don't know enough about that to properly speculate. Only other thing of note is that I changed the plan function to take a reference to the request rather than owning it which results in one clone of a pathbuf which I think is acceptable.

Now when running a nonsense command, such as going from dat to cider-debug we get the following error message:
```
Error: could not find path from {dat} to {cider-debug}
```