### PR TITLE
[fud2] add a --force-rebuild flag

### DIFF
--- a/fud2/fud-core/src/cli.rs
+++ b/fud2/fud-core/src/cli.rs
@@ -194,6 +194,10 @@ pub struct FudArgs<T: CliExt> {
     #[argh(switch, short = 'q')]
     quiet: bool,
 
+    /// force rebuild
+    #[argh(switch, long = "force-rebuild")]
+    force_rebuild: bool,
+
     /// log level for debugging fud internal
     #[argh(option, long = "log", default = "log::LevelFilter::Warn")]
     pub log_level: log::LevelFilter,
@@ -493,8 +497,20 @@ fn cli_ext<T: CliExt>(
         Mode::ShowDot => run.show_dot(),
         Mode::EmitNinja => run.emit_to_stdout()?,
         Mode::Generate => run.emit_to_dir(&workdir)?.keep(),
-        Mode::Run => run.emit_and_run(&workdir, false, args.quiet, csv_path)?,
-        Mode::Cmds => run.emit_and_run(&workdir, true, false, csv_path)?,
+        Mode::Run => run.emit_and_run(
+            &workdir,
+            false,
+            args.quiet,
+            args.force_rebuild,
+            csv_path,
+        )?,
+        Mode::Cmds => run.emit_and_run(
+            &workdir,
+            true,
+            false,
+            args.force_rebuild,
+            csv_path,
+        )?,
     }
 
     Ok(())

--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -378,8 +378,17 @@ impl<'a> Run<'a> {
         dir: &Utf8Path,
         print_cmds: bool,
         quiet_mode: bool,
+        force_rebuild: bool,
         csv_file: Option<&Utf8Path>,
     ) -> EmitResult {
+        if force_rebuild && dir.join("build.ninja").exists() {
+            let mut cmd = Command::new(&self.global_config.ninja);
+            cmd.current_dir(dir);
+            cmd.args(["-t", "clean"]);
+            cmd.stdout(std::process::Stdio::null());
+            cmd.status()?;
+        }
+
         // Emit the Ninja file.
         let dir = self.emit_to_dir(dir)?;
 

--- a/fud2/fud-core/src/run.rs
+++ b/fud2/fud-core/src/run.rs
@@ -385,7 +385,11 @@ impl<'a> Run<'a> {
             let mut cmd = Command::new(&self.global_config.ninja);
             cmd.current_dir(dir);
             cmd.args(["-t", "clean"]);
-            cmd.stdout(std::process::Stdio::null());
+            if !quiet_mode {
+                cmd.stdout(std::io::stderr());
+            } else {
+                cmd.stdout(std::process::Stdio::null());
+            }
             cmd.status()?;
         }
 


### PR DESCRIPTION
Closes #2526 

Adds a flag that if the directory used by fud2 already exists (either `--keep` or `--dir`) and the `build.ninja` file exists then it will force ninja to cleanup all the build artifacts before running again. This makes it as though the prior build did not happen.