### PR TITLE
[Docs] Documentation about Source Location Metadata

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -64,6 +64,7 @@
 - [Editor Highlighting](./tools/editor-highlighting.md)
 - [Language Server](./tools/language-server.md)
 - [Visualizing Compiler Passes](./dev/calyx-pass-explorer.md)
+- [Source Location Metadata](./tools/source-locations.md)
 
 ----
 [Contributors](./contributors.md)

--- a/docs/lang/attributes.md
+++ b/docs/lang/attributes.md
@@ -254,4 +254,4 @@ Marks that the cell should not be removed or shared during optimization.
 
 ### `@pos`
 
-Contains the position IDs for source location(s) of the marked component/cell/group/control statement.
+Contains the position IDs for [source location(s)](../tools/source-locations.md) of the marked component/cell/group/control statement.

--- a/docs/lang/attributes.md
+++ b/docs/lang/attributes.md
@@ -251,3 +251,7 @@ as before.
 ### `@protected`
 
 Marks that the cell should not be removed or shared during optimization.
+
+### `@pos`
+
+Contains the position IDs for source location(s) of the marked component/cell/group/control statement.

--- a/docs/lang/attributes.md
+++ b/docs/lang/attributes.md
@@ -254,4 +254,4 @@ Marks that the cell should not be removed or shared during optimization.
 
 ### `@pos`
 
-Contains the position IDs for [source location(s)](../tools/source-locations.md) of the marked component/cell/group/control statement.
+Contains the position IDs for [source location(s)](../tools/source-locations.md) of the marked component/cell/group/control statement. Note that `@pos` is a set attribute (uses curly brace syntax) and can contain multiple values.

--- a/docs/tools/source-locations.md
+++ b/docs/tools/source-locations.md
@@ -1,0 +1,6 @@
+# Source Location Metadata
+
+
+- Motivation
+- Format
+- The `metadata-table-generation` pass

--- a/docs/tools/source-locations.md
+++ b/docs/tools/source-locations.md
@@ -1,6 +1,46 @@
 # Source Location Metadata
 
+Calyx is an intermediate language (IL) for Accelerator Design
+Languages (ADLs), higher-level languages that target hardware. It is
+helpful to be able to map Calyx code to the original ADL code. The
+Source Location Metadata format is used by the Calyx compiler and
+tools to map back Calyx to ADL.
 
-- Motivation
-- Format
-- The `metadata-table-generation` pass
+The source location comes in three parts:
+1. Components, cells, groups, and control blocks/statements contain the `pos` attribute that tracks a unique **position ID**.
+
+2. A `FILES` table that maps unique **file IDs** to corresponding files.
+
+3. A `POSITIONS` table that maps position IDs to file IDs and the line numbers.
+
+The `FILES` and `POSITIONS` tables are in the `sourceinfo` metadata block at the end of the Calyx file.
+
+For example, here is a shortened Calyx program with source location metadata:
+```
+component main<"pos"={0}>() -> () {
+  cells { ... }
+  wires {
+    group write<"pos"={1}> { ... }
+    ...
+  }
+  control {
+    @pos{2} write;
+  }
+}
+
+sourceinfo #{
+FILES
+  0: source.py
+POSITIONS
+  0: 0 6
+  1: 0 15
+  2: 0 25
+  ...
+}
+```
+
+Here, the component `main` has a position ID 0, the group `write` has a position ID 1, and the control statement enabling `write` has a position ID 2. The `FILES` map maps the file ID 0 to `source.py`. From this information, we can use the `POSITIONS` map to find that `main` was defined in `source.py` line 6, the group `write` was defined in `source.py` line 15, and the enable for `write` was defined in `source.py` line 25.
+
+### Calyx positions
+
+In order to track source locations of a Calyx program, use the `metadata-table-generation` pass.


### PR DESCRIPTION
Some documentation about the `@pos` set attribute and the `sourceinfo` metadata table (from #2396 )! Please let me know of any thoughts or changes.