### PR TITLE
[fud2] Decouple synthesis ops

### DIFF
--- a/fud2/scripts/calyx-to-synth-verilog.rhai
+++ b/fud2/scripts/calyx-to-synth-verilog.rhai
@@ -5,7 +5,7 @@ export const synth_verilog_state = state("synth-verilog", ["sv"]);
 // Helper to compile Calyx to synth-ready SV
 fn calyx_to_synth_verilog(e, input, output) {
     // Compile Calyx to synth-ready SV
-    e.build_cmd(["main.sv"], "calyx", [input], []);
+    e.build_cmd([output], "calyx", [input], []);
     e.arg("backend", "verilog");
     e.arg("args", "--synthesis -p external --disable-verify");
 }

--- a/fud2/scripts/synth-verilog-to-report.rhai
+++ b/fud2/scripts/synth-verilog-to-report.rhai
@@ -48,6 +48,7 @@ fn flamegraph_setup(e) {
 
 // Helper to compile Calyx to SV and run Vivado on it
 fn synth_verilog_through_vivado(e, input, output) {
+    e.build_cmd(["main.sv"], "copy", [input], []);
     // Copy over XDC file
     e.build_cmd(["device.xdc"], "copy", ["$device_xdc"], []);
     // IGNOREME is needed by Ninja to consider this command as a build target

--- a/fud2/tests/snapshots/tests__test@plan_calyx-to-synth-verilog.snap
+++ b/fud2/tests/snapshots/tests__test@plan_calyx-to-synth-verilog.snap
@@ -18,7 +18,7 @@ cider-calyx-passes = -p none
 rule calyx-cider
   command = $calyx-exe -l $calyx-lib-path $cider-calyx-passes $args $in > $out
 
-build main.sv: calyx /input.ext
+build /output.ext: calyx /input.ext
   backend = verilog
   args = --synthesis -p external --disable-verify
 

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-area-report.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-area-report.snap
@@ -31,6 +31,7 @@ rule extract-util-json
 rule extract-hierarchy-json
   command = synthrep summary -m hierarchy > $out
 
+build main.sv: copy /input.ext
 build device.xdc: copy $device_xdc
 build IGNOREME: vivado | main.sv synth.tcl device.xdc
 build /output.ext: copy-area IGNOREME

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-hierarchy-json.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-hierarchy-json.snap
@@ -31,6 +31,7 @@ rule extract-util-json
 rule extract-hierarchy-json
   command = synthrep summary -m hierarchy > $out
 
+build main.sv: copy /input.ext
 build device.xdc: copy $device_xdc
 build IGNOREME: vivado | main.sv synth.tcl device.xdc
 build /output.ext: extract-hierarchy-json IGNOREME

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-timing-report.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-timing-report.snap
@@ -31,6 +31,7 @@ rule extract-util-json
 rule extract-hierarchy-json
   command = synthrep summary -m hierarchy > $out
 
+build main.sv: copy /input.ext
 build device.xdc: copy $device_xdc
 build IGNOREME: vivado | main.sv synth.tcl device.xdc
 build /output.ext: copy-timing IGNOREME

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-util-json.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-util-json.snap
@@ -31,6 +31,7 @@ rule extract-util-json
 rule extract-hierarchy-json
   command = synthrep summary -m hierarchy > $out
 
+build main.sv: copy /input.ext
 build device.xdc: copy $device_xdc
 build IGNOREME: vivado | main.sv synth.tcl device.xdc
 build /output.ext: extract-util-json IGNOREME

--- a/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-util-report.snap
+++ b/fud2/tests/snapshots/tests__test@plan_synth-verilog-to-util-report.snap
@@ -31,6 +31,7 @@ rule extract-util-json
 rule extract-hierarchy-json
   command = synthrep summary -m hierarchy > $out
 
+build main.sv: copy /input.ext
 build device.xdc: copy $device_xdc
 build IGNOREME: vivado | main.sv synth.tcl device.xdc
 build /output.ext: copy-utilization IGNOREME


### PR DESCRIPTION
The `calyx-to-synth-verilog` and `synth-verilog-to-*` ops could previously only be run together in a single `fud2` invocation due to the hardcoded filename `main.sv`. Now they can be run separately.