### PR TITLE
[Cider] Proper source printing

### DIFF
--- a/cider/src/flatten/text_utils.rs
+++ b/cider/src/flatten/text_utils.rs
@@ -37,6 +37,8 @@ pub fn indent<S: AsRef<str>>(target: S, indent_count: usize) -> String {
 
 pub const ASSIGN_STYLE: Style = Style::new().yellow();
 
+/// A trait to standardize the coloring throughout Cider while still respecting the
+/// color setting. It is automatically implemented for most relevant types.
 pub trait Color: OwoColorize + Display {
     fn stylize_assignment(&self) -> impl Display {
         self.if_supports_color(Stdout, |text| text.style(ASSIGN_STYLE))
@@ -106,6 +108,16 @@ pub trait Color: OwoColorize + Display {
         let style = Style::new().yellow();
         Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
     }
+
+    fn stylize_underline(&self) -> impl Display {
+        let style = Style::new().underline();
+        Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
+    }
+
+    fn stylize_bold(&self) -> impl Display {
+        let style = Style::new().bold();
+        Box::new(self.if_supports_color(Stdout, move |text| text.style(style)))
+    }
 }
 
 impl<T: OwoColorize + Display> Color for T {}
@@ -113,11 +125,11 @@ impl<T: OwoColorize + Display> Color for T {}
 pub fn print_debugger_welcome() {
     println!(
         "==== {}: The {}alyx {}nterpreter and {}bugge{} ====",
-        "Cider".bold(),
-        "C".underline(),
-        "I".underline(),
-        "De".underline(),
-        "r".underline()
+        "Cider".stylize_bold(),
+        "C".stylize_underline(),
+        "I".stylize_underline(),
+        "De".stylize_underline(),
+        "r".stylize_underline()
     );
 }
 

--- a/cider/src/flatten/text_utils.rs
+++ b/cider/src/flatten/text_utils.rs
@@ -1,4 +1,7 @@
-use std::fmt::{Display, Write};
+use std::{
+    fmt::{Display, Write},
+    path::Path,
+};
 
 use owo_colors::{OwoColorize, Stream::Stdout, Style};
 
@@ -124,4 +127,15 @@ pub(crate) fn force_color(force_color: ColorConfig) {
         ColorConfig::Off => owo_colors::set_override(false),
         ColorConfig::Auto => owo_colors::unset_override(),
     }
+}
+
+pub fn format_file_line(
+    line_num: usize,
+    line_content: String,
+    file_path: &Path,
+) -> String {
+    format!(
+        "({}: {line_num}) {line_content}",
+        file_path.to_string_lossy()
+    )
 }

--- a/cider/tests/debugger/file1
+++ b/cider/tests/debugger/file1
@@ -1,0 +1,11 @@
+this file exists to help test source line printing in cider
+
+
+
+why are you looking down here
+
+
+
+
+
+no really there's nothing of interest here

--- a/cider/tests/debugger/file2
+++ b/cider/tests/debugger/file2
@@ -1,0 +1,5 @@
+this file also exists to help test source line printing in cider
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Ut dictum, purus id lobortis consequat, nunc nulla sagittis libero,
+ac aliquet leo diam sit amet dui.

--- a/cider/tests/debugger/if.expect
+++ b/cider/tests/debugger/if.expect
@@ -1,6 +1,6 @@
 
 ---STDERR---
-==== [1mCider[0m: The [4mC[0malyx [4mI[0mnterpreter and [4mDe[0mbugge[4mr[0m ====
+==== Cider: The Calyx Interpreter and Debugger ====
 Hit breakpoint: main::true
 Main component has finished executing. Debugger is now in inspection mode.
 Exiting.

--- a/cider/tests/debugger/infinite_group.expect
+++ b/cider/tests/debugger/infinite_group.expect
@@ -1,6 +1,6 @@
 
 ---STDERR---
-==== [1mCider[0m: The [4mC[0malyx [4mI[0mnterpreter and [4mDe[0mbugge[4mr[0m ====
+==== Cider: The Calyx Interpreter and Debugger ====
 main::write_reg1
 
 main::write_reg1

--- a/cider/tests/debugger/interactions.expect
+++ b/cider/tests/debugger/interactions.expect
@@ -1,6 +1,6 @@
 
 ---STDERR---
-==== [1mCider[0m: The [4mC[0malyx [4mI[0mnterpreter and [4mDe[0mbugge[4mr[0m ====
+==== Cider: The Calyx Interpreter and Debugger ====
 Warning: the control main: main. is already running. This breakpoint will not trigger until the next time the control runs.
     Current breakpoints:
     (0) main.   enabled

--- a/cider/tests/debugger/pow.expect
+++ b/cider/tests/debugger/pow.expect
@@ -1,6 +1,6 @@
 
 ---STDERR---
-==== [1mCider[0m: The [4mC[0malyx [4mI[0mnterpreter and [4mDe[0mbugge[4mr[0m ====
+==== Cider: The Calyx Interpreter and Debugger ====
 Hit breakpoint: main::init
 Hit breakpoint: main::fill_memory
 Main component has finished executing. Debugger is now in inspection mode.

--- a/cider/tests/debugger/source_info.expect
+++ b/cider/tests/debugger/source_info.expect
@@ -1,6 +1,6 @@
 
 ---STDERR---
-==== [1mCider[0m: The [4mC[0malyx [4mI[0mnterpreter and [4mDe[0mbugge[4mr[0m ====
+==== Cider: The Calyx Interpreter and Debugger ====
 (../debugger/file1: 1) this file exists to help test source line printing in cider
 (../debugger/file2: 3) Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 Error: file ../debugger/file2 does not have a line 17

--- a/cider/tests/debugger/source_info.expect
+++ b/cider/tests/debugger/source_info.expect
@@ -1,12 +1,12 @@
 
 ---STDERR---
 ==== [1mCider[0m: The [4mC[0malyx [4mI[0mnterpreter and [4mDe[0mbugge[4mr[0m ====
-test.futil:14
-my_super_cool_file.txt:15
-my_super_cool_file.txt:45
-test.futil:14
-test.futil:6578
-test.futil:14
-test.futil:6578
+(../debugger/file1: 1) this file exists to help test source line printing in cider
+(../debugger/file2: 3) Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Error: file ../debugger/file2 does not have a line 17
+(../debugger/file1: 1) this file exists to help test source line printing in cider
+(../debugger/file1: 5) why are you looking down here
+(../debugger/file1: 1) this file exists to help test source line printing in cider
+(../debugger/file1: 5) why are you looking down here
 Main component has finished executing. Debugger is now in inspection mode.
 Exiting.

--- a/cider/tests/debugger/source_info.futil
+++ b/cider/tests/debugger/source_info.futil
@@ -40,12 +40,12 @@ component main() -> () {
 
 sourceinfo #{
     FILES
-        0: test.futil
-        1: my_super_cool_file.txt
+        0: ../debugger/file1
+        1: ../debugger/file2
 
     POSITIONS
-        0: 0 14
-        1: 1 15
-        2: 0 6578
-        3: 1 45
+        0: 0 1
+        1: 1 3
+        2: 0 5
+        3: 1 17
 }#


### PR DESCRIPTION
Small set of changes to allow cider to print the source lines indicated by the sourcemap when they are available during execution. If unable to find the file it will print an error message and then continue execution. Currently this error message is not suppressed by the quiet setting. The correct thing to do would probably be to display it through logging as a warning to allow it to be suppressed, but I leave that for another time