### PR TITLE
Bug fix/comb prop 2437

### DIFF
--- a/calyx/opt/src/passes/comb_prop.rs
+++ b/calyx/opt/src/passes/comb_prop.rs
@@ -3,6 +3,7 @@ use crate::traversal::{
 };
 use calyx_ir::{self as ir, RRC};
 use itertools::Itertools;
+use std::collections::HashSet;
 use std::rc::Rc;
 
 /// A data structure to track rewrites of ports with added functionality to declare
@@ -10,6 +11,7 @@ use std::rc::Rc;
 #[derive(Default, Clone)]
 struct WireRewriter {
     rewrites: ir::rewriter::PortRewriteMap,
+    visited: HashSet<ir::Canonical>, // If there are two or more occurences then we cannot safely inline
 }
 
 impl WireRewriter {
@@ -49,11 +51,19 @@ impl WireRewriter {
         dst: RRC<ir::Port>,
     ) {
         let wire_in = wire.borrow().get("in");
+        let wire_in_key = wire_in.borrow().canonical();
         log::debug!(
             "dst rewrite: {} -> {}",
-            wire_in.borrow().canonical(),
+            wire_in_key,
             dst.borrow().canonical(),
         );
+
+        // Already visited the wire, cannot safely inline, see issue #2437 for more details
+        //   Once we have explored a wire twice we add it to this set to make sure we dont check any other ones
+        if self.visited.contains(&wire_in_key) {
+            return;
+        }
+
         let old_v = self.insert(Rc::clone(&wire_in), dst);
 
         // If the insertion process found an old key, we have something like:
@@ -65,6 +75,9 @@ impl WireRewriter {
         // simple inlining will not work.
         if old_v.is_some() {
             self.remove(wire_in);
+
+            // To make sure we dont check this wire again, add to visited set, see #2437 for more details
+            self.visited.insert(wire_in_key);
         }
 
         // No forwading generated because the wire is used in dst position
@@ -119,7 +132,10 @@ impl WireRewriter {
                 (from.clone(), Rc::clone(final_to.unwrap_or(to)))
             })
             .collect();
-        Self { rewrites }
+        Self {
+            rewrites,
+            visited: HashSet::new(),
+        }
     }
 }
 

--- a/tests/passes/comb-prop/wire_three_readers.expect
+++ b/tests/passes/comb-prop/wire_three_readers.expect
@@ -1,0 +1,24 @@
+import "primitives/core.futil";
+comb component alu_bitwise<"toplevel"=1>(op: 2, lhs: 32, rhs: 32, invert_rhs: 1) -> (out: 32) {
+  cells {
+    right = std_wire(32);
+    not_1 = std_not(32);
+    A = std_and(32);
+    B = std_or(32);
+    C = std_xor(32);
+  }
+  wires {
+    C.left = lhs;
+    B.left = lhs;
+    A.left = lhs;
+    right.in = !invert_rhs ? rhs;
+    not_1.in = rhs;
+    right.in = invert_rhs ? not_1.out;
+    C.right = right.out;
+    out = op == 2'd2 ? C.out;
+    B.right = right.out;
+    out = op == 2'd1 ? B.out;
+    A.right = right.out;
+    out = op == 2'd0 ? A.out;
+  }
+}

--- a/tests/passes/comb-prop/wire_three_readers.futil
+++ b/tests/passes/comb-prop/wire_three_readers.futil
@@ -1,0 +1,28 @@
+// -p validate -p comb-prop
+// -p no-opt -p comb-prop
+// comb-prop pass incorrectly inlines and elides assignment #2437
+// calyx -p no-opt -p comb-prop
+import "primitives/core.futil";
+comb component alu_bitwise<"toplevel"=1>(op: 2, lhs: 32, rhs: 32, invert_rhs: 1) -> (out: 32) {
+  cells {
+    right = std_wire(32);
+    not_1 = std_not(32);
+    A = std_and(32);
+    B = std_or(32);
+    C = std_xor(32);
+  }
+  wires {
+    not_1.in = rhs;
+    right.in = !invert_rhs ? rhs;
+    right.in = invert_rhs ? not_1.out;
+    A.left = lhs;
+    B.left = lhs;
+    C.left = lhs;
+    A.right = right.out;
+    B.right = right.out;
+    C.right = right.out;
+    out = (op == 2'd0) ? A.out;
+    out = (op == 2'd1) ? B.out;
+    out = (op == 2'd2) ? C.out;
+  }
+}

--- a/tests/passes/comb-prop/wire_three_readers.futil
+++ b/tests/passes/comb-prop/wire_three_readers.futil
@@ -1,5 +1,4 @@
 // -p validate -p comb-prop
-// -p no-opt -p comb-prop
 // comb-prop pass incorrectly inlines and elides assignment #2437
 // calyx -p no-opt -p comb-prop
 import "primitives/core.futil";


### PR DESCRIPTION
# Overview

Issue #2437 
My understanding of the issue is that there was toggling on the visited set. Essentially,

1 visit to inline (correct)
2 visits to not inline (correct)
3 visits to have a weird partial count of visited (incorrect)

___

# Bug Fix

Added a permanent visited set once we know we should not count something, and added a shortcircuit, which prevents the toggle logic from acting up.

___

# Testing

Ported over the specified test in the issue.