### PR TITLE
[Docs] clean up spelling, grammar, and links

### DIFF
--- a/docs/compiler-as-library.md
+++ b/docs/compiler-as-library.md
@@ -1,10 +1,10 @@
 # Calyx Compiler as a Library
 
 The Calyx compiler is separated into [multiple crates][crates] that can be used independently.
-If you're interested in adding a new pass to the Calyx compiler or build a tool using it, your best bet is to [take a look at the example in the `calyx-opt`][opt-ex] library.
+If you're interested in adding a new pass to the Calyx compiler or building a tool using it, your best bet is to [take a look at the example in the `calyx-opt`][opt-ex] library.
 
 The `calyx` implements the compiler driver and plumbs together all the other crates.
-You mostly likely want to include the `calyx-opt` crate if you're working passes or just the `calyx-ir` crate if you're working with the IR.
+You most likely want to include the `calyx-opt` crate if you're working on passes or just the `calyx-ir` crate if you're working with the IR.
 You'll also need `calyx-frontend` and `calyx-utils` if you're parsing frontend code.
 
 ## Building the `calyx` Binary
@@ -14,10 +14,10 @@ The [`calyx` binary][calyx-crate] is published using Rust's crates.io repository
 1. The [`calyx-stdlib`][calyx-stdlib] package pulls in the sources of all the primitives using the Rust `include_str!` macro.
 2. The `calyx` binary defines a build script that depends on `calyx-stdlib` as a build dependency.
 3. During build time, the script loads the string representation of all the primitives files and writes them to `$CALYX_PRIMITIVE_DIR/primitives`. If the variable is not set, the location defaults to `$HOME/.calyx`.
-4. If (3) succeeds, the build scripts defines the `CALYX_PRIMITIVES_LIB` environment variable which is used when compiling the `calyx` crate.
+4. If (3) succeeds, the build script defines the `CALYX_PRIMITIVES_LIB` environment variable, which is used when compiling the `calyx` crate.
 5. During compilation, `calyx` embeds the value of this environment variable as the default argument to the `-l` flag. If the variable is not defined, the default value of the `-l` flag is `.`.
 
-Users of the `calyx` binary can still specify a value for `-l` to override the default primitives file. For example, the `fud` configuration for the `calyx` stage override the value of `-l` to the location of the Calyx repo.
+Users of the `calyx` binary can still specify a value for `-l` to override the default primitives file. For example, the `fud` configuration for the `calyx` stage overrides the value of `-l` with the location of the Calyx repo.
 
 
 [crates]: https://docs.rs/releases/search?query=calyx

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -187,6 +187,7 @@ Congratulations! You've simulated your first hardware design with Calyx.
 [homebrew]: https://brew.sh
 [fud-icarus]: ./running-calyx/fud/index.md#icarus-verilog
 [fud-verilator]: ./running-calyx/fud/index.md#verilator
+[fud2]: ./running-calyx/fud2/index.md
 [icarus-install-source]: https://iverilog.fandom.com/wiki/Installation_Guide#Installation_From_Source
 [calyx-crate]: https://crates.io/crates/calyx
 [core-lib]: https://github.com/calyxir/calyx/blob/master/primitives/core.futil

--- a/docs/libraries/core.md
+++ b/docs/libraries/core.md
@@ -44,7 +44,7 @@ during handshakes.
 - `i_valid: 1` - The one bit input valid signal. Indicates that the data
   provided on the `in` wire is valid.
 - `i_ready: 1` - The one bit input ready signal. Indicates that the follower is
-  ready to recieve data from the `out` wire.
+  ready to receive data from the `out` wire.
 
 **Outputs:**
 
@@ -52,7 +52,7 @@ during handshakes.
 - `o_valid: 1` - The one bit output valid signal. Indicates that the data
   provided on the `out` wire is valid.
 - `o_ready: 1` - The one bit output ready signal. Indicates that the skid buffer
-  is ready to recieve data on the `in` wire.
+  is ready to receive data on the `in` wire.
 
 ---
 

--- a/docs/tools/editor-highlighting.md
+++ b/docs/tools/editor-highlighting.md
@@ -2,7 +2,7 @@
 
 ## Language Server
 
-There is a Calyx language server that provides jump-to-definition and completion support. Instructions for intsalling it are [here](./language-server.md).
+There is a Calyx language server that provides jump-to-definition and completion support. Instructions for installing it are [here](./language-server.md).
 
 If you are using any of the `unsyn-*` primitives, you will need to tell the language server to use the Calyx repo as the library location instead of the default `~/.calyx`. Below, there are instructions on how to do this for each editor.
 


### PR DESCRIPTION
Fixes some spelling/grammar errors I encountered while going through the docs, as well as the broken fud2 docs link on [this](https://docs.calyxir.org/intro.html#installing-the-command-line-driver) page